### PR TITLE
Add native Pushover support as a webhook format

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -886,7 +886,7 @@ WEBHOOK_ENABLED=false              # true | false
 WEBHOOK_ENDPOINTS=                 # e.g., "discord_alerts,teams_ops"
 
 # Default payload format
-WEBHOOK_FORMAT=generic             # discord | slack | teams | generic
+WEBHOOK_FORMAT=generic             # discord | slack | teams | generic | pushover
 
 # Request timeout (seconds)
 WEBHOOK_TIMEOUT=30
@@ -903,7 +903,7 @@ WEBHOOK_RETRY_DELAY=2              # Seconds between retries
 WEBHOOK_DISCORD_ALERTS_URL=https://discord.com/api/webhooks/XXXX/YYY
 
 # Payload format
-WEBHOOK_DISCORD_ALERTS_FORMAT=discord  # discord | slack | teams | generic
+WEBHOOK_DISCORD_ALERTS_FORMAT=discord  # discord | slack | teams | generic | pushover
 
 # HTTP method
 WEBHOOK_DISCORD_ALERTS_METHOD=POST     # POST | GET | HEAD
@@ -915,10 +915,13 @@ WEBHOOK_DISCORD_ALERTS_HEADERS="X-Custom-Token:abc123,X-Another:value"
 WEBHOOK_DISCORD_ALERTS_AUTH_TYPE=none  # none | bearer | basic | hmac
 
 # Authentication credentials
-WEBHOOK_DISCORD_ALERTS_AUTH_TOKEN=     # Bearer token
-WEBHOOK_DISCORD_ALERTS_AUTH_USER=      # Basic auth username
+WEBHOOK_DISCORD_ALERTS_AUTH_TOKEN=     # Bearer token (or Pushover application token)
+WEBHOOK_DISCORD_ALERTS_AUTH_USER=      # Basic auth username (or Pushover user/group key)
 WEBHOOK_DISCORD_ALERTS_AUTH_PASS=      # Basic auth password
 WEBHOOK_DISCORD_ALERTS_AUTH_SECRET=    # HMAC secret key
+
+# Pushover-specific (only honored when FORMAT=pushover; default 0, range -2..1)
+WEBHOOK_DISCORD_ALERTS_PRIORITY=0
 ```
 
 **Supported formats**:
@@ -926,6 +929,7 @@ WEBHOOK_DISCORD_ALERTS_AUTH_SECRET=    # HMAC secret key
 - **slack**: Slack incoming webhook format
 - **teams**: Microsoft Teams connector format
 - **generic**: Simple JSON `{"status": "...", "message": "..."}`
+- **pushover**: [Pushover](https://pushover.net) push notifications. Reuses `AUTH_TOKEN` (application token) and `AUTH_USER` (user/group key); `AUTH_TYPE` stays `none` because Pushover takes credentials in the JSON body. Title is truncated to 250 characters and message to 1024 characters per Pushover's API limits. `PRIORITY` accepts -2..1 (default 0); emergency priority (2) is not supported.
 
 ---
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -528,16 +528,26 @@ EMAIL_DELIVERY_METHOD=relay
 EMAIL_RECIPIENT=admin@example.com
 EMAIL_FROM=noreply@proxmox.example.com
 
-# Webhook (Discord)
+# Webhook (Discord + Pushover)
 WEBHOOK_ENABLED=true
-WEBHOOK_ENDPOINTS=discord_alerts
+WEBHOOK_ENDPOINTS=discord_alerts,pushover
 WEBHOOK_DISCORD_ALERTS_URL=https://discord.com/api/webhooks/XXXX/YYYY
 WEBHOOK_DISCORD_ALERTS_FORMAT=discord
 WEBHOOK_DISCORD_ALERTS_METHOD=POST
 
+# Pushover (push notifications to phone/desktop). Token + user key go in the
+# JSON body, so AUTH_TYPE stays "none". PRIORITY accepts -2..1 (default 0).
+WEBHOOK_PUSHOVER_URL=https://api.pushover.net/1/messages.json
+WEBHOOK_PUSHOVER_FORMAT=pushover
+WEBHOOK_PUSHOVER_METHOD=POST
+WEBHOOK_PUSHOVER_AUTH_TYPE=none
+WEBHOOK_PUSHOVER_AUTH_TOKEN=azGDORePK8gMaC0QOYAMyEEuzJnyUi
+WEBHOOK_PUSHOVER_AUTH_USER=uQiRzpo4DXghDmr9QzzfQu27cmVRsG
+WEBHOOK_PUSHOVER_PRIORITY=0
+
 # Run backup
 ./build/proxsave
-# Result: Notifications sent to Telegram, Email, and Discord
+# Result: Notifications sent to Telegram, Email, Discord, and Pushover
 ```
 
 ### Setup Steps

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -503,7 +503,7 @@ crontab -e
 
 ## Example 7: Multi-Notification Setup
 
-**Scenario**: Telegram + Email + Webhook (Discord) notifications.
+**Scenario**: Telegram + Email + Webhook (Discord + Pushover) notifications.
 
 **Use case**:
 - Multiple notification channels
@@ -541,8 +541,8 @@ WEBHOOK_PUSHOVER_URL=https://api.pushover.net/1/messages.json
 WEBHOOK_PUSHOVER_FORMAT=pushover
 WEBHOOK_PUSHOVER_METHOD=POST
 WEBHOOK_PUSHOVER_AUTH_TYPE=none
-WEBHOOK_PUSHOVER_AUTH_TOKEN=azGDORePK8gMaC0QOYAMyEEuzJnyUi
-WEBHOOK_PUSHOVER_AUTH_USER=uQiRzpo4DXghDmr9QzzfQu27cmVRsG
+WEBHOOK_PUSHOVER_AUTH_TOKEN=<pushover-application-token>
+WEBHOOK_PUSHOVER_AUTH_USER=<pushover-user-or-group-key>
 WEBHOOK_PUSHOVER_PRIORITY=0
 
 # Run backup
@@ -601,11 +601,13 @@ printf "To: root\nSubject: proxsave test\n\nHello from proxsave\n" | sudo /usr/l
 - ✅ Telegram message with summary
 - ✅ Email with detailed report
 - ✅ Discord embed with stats
+- ✅ Pushover push notification
 
 **On failure**:
 - ❌ Telegram alert with error
 - ❌ Email with failure details
 - ❌ Discord mention with logs
+- ❌ Pushover push notification
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1427,13 +1427,16 @@ func (c *Config) BuildWebhookConfig() *WebhookConfig {
 			}
 		}
 
+		priority := c.getInt(prefix+"PRIORITY", 0)
+
 		endpoints = append(endpoints, WebhookEndpoint{
-			Name:    name,
-			URL:     url,
-			Format:  format,
-			Method:  method,
-			Headers: headers,
-			Auth:    auth,
+			Name:     name,
+			URL:      url,
+			Format:   format,
+			Method:   method,
+			Headers:  headers,
+			Auth:     auth,
+			Priority: priority,
 		})
 	}
 
@@ -1528,6 +1531,7 @@ type WebhookEndpoint struct {
 	Method       string
 	Headers      map[string]string
 	Auth         WebhookAuth
+	Priority     int
 	CustomFields map[string]interface{}
 }
 

--- a/internal/config/templates/backup.env
+++ b/internal/config/templates/backup.env
@@ -236,7 +236,7 @@ GOTIFY_PRIORITY_WARNING=5
 GOTIFY_PRIORITY_FAILURE=8
 
 # ----------------------------------------------------------------------
-# Webhook notifications (Phase 5.2 – Discord/Slack/Teams/Generic)
+# Webhook notifications (Phase 5.2 – Discord/Slack/Teams/Generic/Pushover)
 # ----------------------------------------------------------------------
 WEBHOOK_ENABLED=false
 WEBHOOK_ENDPOINTS=                     # Comma-separated names e.g. discord_alerts,teams_ops
@@ -247,7 +247,7 @@ WEBHOOK_RETRY_DELAY=2                  # seconds
 
 # For each endpoint use the uppercase name as prefix, e.g. "discord_alerts":
 # WEBHOOK_DISCORD_ALERTS_URL=https://discord.com/api/webhooks/XXXX/YYY
-# WEBHOOK_DISCORD_ALERTS_FORMAT=discord   # discord | slack | teams | generic
+# WEBHOOK_DISCORD_ALERTS_FORMAT=discord   # discord | slack | teams | generic | pushover
 # WEBHOOK_DISCORD_ALERTS_METHOD=POST      # POST recommended; GET/HEAD do not send a payload
 # WEBHOOK_DISCORD_ALERTS_HEADERS="X-Custom-Token:abc123"
 # WEBHOOK_DISCORD_ALERTS_AUTH_TYPE=none   # none | bearer | basic | hmac
@@ -255,6 +255,19 @@ WEBHOOK_RETRY_DELAY=2                  # seconds
 # WEBHOOK_DISCORD_ALERTS_AUTH_USER=
 # WEBHOOK_DISCORD_ALERTS_AUTH_PASS=
 # WEBHOOK_DISCORD_ALERTS_AUTH_SECRET=
+
+# Pushover example (https://pushover.net). Token + user are sent in the JSON
+# body, so AUTH_TYPE stays "none". Title/message are truncated to Pushover's
+# 250/1024 character limits. PRIORITY accepts -2..1 (default 0); emergency
+# priority (2) is not supported.
+# WEBHOOK_ENDPOINTS=pushover
+# WEBHOOK_PUSHOVER_URL=https://api.pushover.net/1/messages.json
+# WEBHOOK_PUSHOVER_FORMAT=pushover
+# WEBHOOK_PUSHOVER_METHOD=POST
+# WEBHOOK_PUSHOVER_AUTH_TYPE=none
+# WEBHOOK_PUSHOVER_AUTH_TOKEN=<pushover-application-token>
+# WEBHOOK_PUSHOVER_AUTH_USER=<pushover-user-or-group-key>
+# WEBHOOK_PUSHOVER_PRIORITY=0
 
 # ----------------------------------------------------------------------
 # Metriche / Prometheus

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -24,6 +24,25 @@ type WebhookNotifier struct {
 	client *http.Client
 }
 
+func resolveWebhookFormat(format, defaultFormat string) string {
+	format = strings.TrimSpace(format)
+	if format == "" {
+		format = strings.TrimSpace(defaultFormat)
+	}
+	if format == "" {
+		return "generic"
+	}
+	return format
+}
+
+func resolveWebhookMethod(method string) string {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "" {
+		return http.MethodPost
+	}
+	return method
+}
+
 // NewWebhookNotifier creates a new webhook notifier
 func NewWebhookNotifier(webhookConfig *config.WebhookConfig, logger *logging.Logger) (*WebhookNotifier, error) {
 	logger.Debug("WebhookNotifier initialization starting...")
@@ -59,9 +78,14 @@ func NewWebhookNotifier(webhookConfig *config.WebhookConfig, logger *logging.Log
 			}
 		}
 
-		if strings.EqualFold(ep.Format, "pushover") {
+		format := resolveWebhookFormat(ep.Format, webhookConfig.DefaultFormat)
+		method := resolveWebhookMethod(ep.Method)
+		if strings.EqualFold(format, "pushover") {
 			if ep.Priority < -2 || ep.Priority > 1 {
 				return nil, fmt.Errorf("webhook endpoint %q: PRIORITY must be in range -2..1 (got %d); priority 2 (emergency) is not supported", ep.Name, ep.Priority)
+			}
+			if method != http.MethodPost {
+				return nil, fmt.Errorf("webhook endpoint %q: METHOD must be POST for pushover (got %s)", ep.Name, method)
 			}
 		}
 	}
@@ -170,14 +194,21 @@ func (w *WebhookNotifier) sendToEndpoint(ctx context.Context, endpoint config.We
 	w.logger.Debug("Endpoint format: %s, URL: %s", endpoint.Format, maskURL(endpoint.URL))
 
 	// Determine format to use
-	format := endpoint.Format
-	if format == "" {
-		format = w.config.DefaultFormat
-		w.logger.Debug("Using default format: %s", format)
+	format := resolveWebhookFormat(endpoint.Format, w.config.DefaultFormat)
+	if strings.TrimSpace(endpoint.Format) == "" {
+		if strings.TrimSpace(w.config.DefaultFormat) != "" {
+			w.logger.Debug("Using default format: %s", format)
+		} else {
+			w.logger.Debug("No format specified, using generic")
+		}
 	}
-	if format == "" {
-		format = "generic"
-		w.logger.Debug("No format specified, using generic")
+
+	method := resolveWebhookMethod(endpoint.Method)
+	if strings.TrimSpace(endpoint.Method) == "" {
+		w.logger.Debug("No method specified, using POST")
+	}
+	if strings.EqualFold(format, "pushover") && method != http.MethodPost {
+		return fmt.Errorf("webhook endpoint %q: METHOD must be POST for pushover (got %s)", endpoint.Name, method)
 	}
 
 	// Build payload based on format
@@ -236,12 +267,6 @@ func (w *WebhookNotifier) sendToEndpoint(ctx context.Context, endpoint config.We
 			if err := sleepWithContext(ctx, time.Duration(retryDelay)*time.Second); err != nil {
 				return err
 			}
-		}
-
-		// Determine HTTP method
-		method := strings.ToUpper(strings.TrimSpace(endpoint.Method))
-		if method == "" {
-			method = "POST"
 		}
 
 		parsedURL, parseErr := url.Parse(endpoint.URL)

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -204,7 +204,9 @@ func (w *WebhookNotifier) sendToEndpoint(ctx context.Context, endpoint config.We
 
 	w.logger.Debug("Payload marshaled: %d bytes", len(payloadBytes))
 	if w.logger.GetLevel() <= types.LogLevelDebug {
-		if len(payloadBytes) > 200 {
+		if strings.EqualFold(format, "pushover") {
+			w.logger.Debug("Payload preview omitted: pushover payload contains credentials")
+		} else if len(payloadBytes) > 200 {
 			w.logger.Debug("Payload preview (first 200 chars): %s...", string(payloadBytes[:200]))
 		} else {
 			w.logger.Debug("Payload content: %s", string(payloadBytes))

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -58,6 +58,12 @@ func NewWebhookNotifier(webhookConfig *config.WebhookConfig, logger *logging.Log
 				logger.Debug("    Header: %s (value masked)", k)
 			}
 		}
+
+		if strings.EqualFold(ep.Format, "pushover") {
+			if ep.Priority < -2 || ep.Priority > 1 {
+				return nil, fmt.Errorf("webhook endpoint %q: PRIORITY must be in range -2..1 (got %d); priority 2 (emergency) is not supported", ep.Name, ep.Priority)
+			}
+		}
 	}
 
 	// Create HTTP client with timeout
@@ -178,7 +184,8 @@ func (w *WebhookNotifier) sendToEndpoint(ctx context.Context, endpoint config.We
 	w.logger.Debug("Building %s payload...", format)
 	payloadStart := time.Now()
 
-	payload, err := w.buildPayload(format, data)
+	endpoint.Format = format
+	payload, err := w.buildPayload(endpoint, data)
 	if err != nil {
 		w.logger.Error("Failed to build %s payload: %v", format, err)
 		return fmt.Errorf("failed to build payload: %w", err)
@@ -415,16 +422,19 @@ func (w *WebhookNotifier) sendToEndpoint(ctx context.Context, endpoint config.We
 }
 
 // buildPayload builds the webhook payload based on format
-func (w *WebhookNotifier) buildPayload(format string, data *NotificationData) (interface{}, error) {
+func (w *WebhookNotifier) buildPayload(endpoint config.WebhookEndpoint, data *NotificationData) (interface{}, error) {
+	format := strings.ToLower(endpoint.Format)
 	w.logger.Debug("buildPayload() called with format=%s", format)
 
-	switch strings.ToLower(format) {
+	switch format {
 	case "discord":
 		return buildDiscordPayload(data, w.logger)
 	case "slack":
 		return buildSlackPayload(data, w.logger)
 	case "teams":
 		return buildTeamsPayload(data, w.logger)
+	case "pushover":
+		return buildPushoverPayload(endpoint, data, w.logger)
 	case "generic":
 		return buildGenericPayload(data, w.logger)
 	default:

--- a/internal/notify/webhook_payloads.go
+++ b/internal/notify/webhook_payloads.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/logging"
 )
 
@@ -574,4 +575,54 @@ func buildGenericPayload(data *NotificationData, logger *logging.Logger) (map[st
 
 	logger.Debug("Generic payload built successfully with %d top-level keys", len(payload))
 	return payload, nil
+}
+
+// buildPushoverPayload builds a Pushover-formatted webhook payload.
+// Pushover requires the application token and user/group key in the JSON body
+// (not in headers); this builder reads them from endpoint.Auth.Token and
+// endpoint.Auth.User and rejects requests where either is missing.
+func buildPushoverPayload(endpoint config.WebhookEndpoint, data *NotificationData, logger *logging.Logger) (map[string]interface{}, error) {
+	logger.Debug("buildPushoverPayload() starting...")
+
+	if endpoint.Auth.Token == "" {
+		return nil, fmt.Errorf("pushover: AUTH_TOKEN (Pushover application token) is required")
+	}
+	if endpoint.Auth.User == "" {
+		return nil, fmt.Errorf("pushover: AUTH_USER (Pushover user/group key) is required")
+	}
+
+	title := truncateRunes(fmt.Sprintf("%s Proxmox Backup — %s", GetStatusEmoji(data.Status), data.Hostname), 250)
+
+	message := truncateRunes(fmt.Sprintf(
+		"Status: %s\nDuration: %s\nSize: %s\nErrors: %d | Warnings: %d",
+		data.StatusMessage,
+		FormatDuration(data.BackupDuration),
+		data.BackupSizeHR,
+		data.ErrorCount,
+		data.WarningCount,
+	), 1024)
+
+	payload := map[string]interface{}{
+		"token":    endpoint.Auth.Token,
+		"user":     endpoint.Auth.User,
+		"title":    title,
+		"message":  message,
+		"priority": endpoint.Priority,
+	}
+
+	logger.Debug("Pushover payload built (priority=%d, title_len=%d, message_len=%d)", endpoint.Priority, len([]rune(title)), len([]rune(message)))
+	return payload, nil
+}
+
+// truncateRunes shortens s to at most max runes, suffixing with "…" when cut.
+// Operates on runes (not bytes) so multibyte characters like emoji are not split.
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max-1]) + "…"
 }

--- a/internal/notify/webhook_test.go
+++ b/internal/notify/webhook_test.go
@@ -1247,3 +1247,74 @@ func TestNewWebhookNotifier_PushoverPriority(t *testing.T) {
 		})
 	}
 }
+
+func TestNewWebhookNotifier_PushoverPriority_UsesDefaultFormat(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+
+	ep := pushoverTestEndpoint(2)
+	ep.Format = ""
+
+	cfg := &config.WebhookConfig{
+		Enabled:       true,
+		DefaultFormat: "pushover",
+		Timeout:       30,
+		Endpoints:     []config.WebhookEndpoint{ep},
+	}
+
+	_, err := NewWebhookNotifier(cfg, logger)
+	if err == nil {
+		t.Fatal("expected error for invalid pushover priority resolved from default format, got nil")
+	}
+	if !strings.Contains(err.Error(), "PRIORITY") {
+		t.Fatalf("error %q does not mention PRIORITY", err.Error())
+	}
+}
+
+func TestNewWebhookNotifier_PushoverMethod(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+
+	tests := []struct {
+		name          string
+		method        string
+		format        string
+		defaultFormat string
+		expectError   bool
+	}{
+		{name: "explicit post", method: "POST", format: "pushover", expectError: false},
+		{name: "implicit post", method: "", format: "pushover", expectError: false},
+		{name: "default format post", method: "", format: "", defaultFormat: "pushover", expectError: false},
+		{name: "get rejected", method: "GET", format: "pushover", expectError: true},
+		{name: "head rejected", method: "HEAD", format: "pushover", expectError: true},
+		{name: "put rejected", method: "PUT", format: "pushover", expectError: true},
+		{name: "default format get rejected", method: "GET", format: "", defaultFormat: "pushover", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := pushoverTestEndpoint(0)
+			ep.Method = tt.method
+			ep.Format = tt.format
+
+			cfg := &config.WebhookConfig{
+				Enabled:       true,
+				DefaultFormat: tt.defaultFormat,
+				Timeout:       30,
+				Endpoints:     []config.WebhookEndpoint{ep},
+			}
+
+			_, err := NewWebhookNotifier(cfg, logger)
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "METHOD must be POST") {
+					t.Fatalf("error %q does not mention POST method requirement", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/notify/webhook_test.go
+++ b/internal/notify/webhook_test.go
@@ -658,7 +658,8 @@ func TestWebhookNotifier_buildPayload_CoversFormats(t *testing.T) {
 	for _, format := range formats {
 		format := format
 		t.Run(format, func(t *testing.T) {
-			payload, err := notifier.buildPayload(format, data)
+			ep := config.WebhookEndpoint{Name: "x", URL: "https://example.com", Format: format}
+			payload, err := notifier.buildPayload(ep, data)
 			if err != nil {
 				t.Fatalf("buildPayload(%q) error = %v", format, err)
 			}
@@ -1066,6 +1067,182 @@ func TestMaskHeaderValue(t *testing.T) {
 			}
 			if tt.expected == tt.value && result != tt.expected {
 				t.Errorf("maskHeaderValue(%s, %s) = %s, want %s", tt.key, tt.value, result, tt.expected)
+			}
+		})
+	}
+}
+
+func pushoverTestEndpoint(priority int) config.WebhookEndpoint {
+	return config.WebhookEndpoint{
+		Name:     "pushover",
+		URL:      "https://api.pushover.net/1/messages.json",
+		Format:   "pushover",
+		Method:   "POST",
+		Auth:     config.WebhookAuth{Type: "none", Token: "app-token-abc", User: "user-key-xyz"},
+		Priority: priority,
+	}
+}
+
+func TestBuildPushoverPayload_Success(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+
+	payload, err := buildPushoverPayload(pushoverTestEndpoint(0), data, logger)
+	if err != nil {
+		t.Fatalf("buildPushoverPayload() error: %v", err)
+	}
+
+	if got := payload["token"]; got != "app-token-abc" {
+		t.Errorf("token = %v, want app-token-abc", got)
+	}
+	if got := payload["user"]; got != "user-key-xyz" {
+		t.Errorf("user = %v, want user-key-xyz", got)
+	}
+	if got := payload["priority"]; got != 0 {
+		t.Errorf("priority = %v, want 0", got)
+	}
+
+	title, ok := payload["title"].(string)
+	if !ok {
+		t.Fatalf("title is not a string: %T", payload["title"])
+	}
+	if !strings.Contains(title, data.Hostname) {
+		t.Errorf("title %q does not contain hostname %q", title, data.Hostname)
+	}
+	if !strings.Contains(title, GetStatusEmoji(data.Status)) {
+		t.Errorf("title %q does not contain status emoji", title)
+	}
+
+	message, ok := payload["message"].(string)
+	if !ok {
+		t.Fatalf("message is not a string: %T", payload["message"])
+	}
+	for _, want := range []string{"Status:", "Duration:", "Size:", "Errors:", "Warnings:"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("message missing %q; got %q", want, message)
+		}
+	}
+}
+
+func TestBuildPushoverPayload_MissingToken(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+	ep := pushoverTestEndpoint(0)
+	ep.Auth.Token = ""
+
+	_, err := buildPushoverPayload(ep, data, logger)
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
+	}
+	if !strings.Contains(err.Error(), "AUTH_TOKEN") {
+		t.Errorf("error %q does not mention AUTH_TOKEN", err.Error())
+	}
+}
+
+func TestBuildPushoverPayload_MissingUser(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+	ep := pushoverTestEndpoint(0)
+	ep.Auth.User = ""
+
+	_, err := buildPushoverPayload(ep, data, logger)
+	if err == nil {
+		t.Fatal("expected error for missing user, got nil")
+	}
+	if !strings.Contains(err.Error(), "AUTH_USER") {
+		t.Errorf("error %q does not mention AUTH_USER", err.Error())
+	}
+}
+
+func TestBuildPushoverPayload_TitleTruncated(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+	data.Hostname = strings.Repeat("h", 300)
+
+	payload, err := buildPushoverPayload(pushoverTestEndpoint(0), data, logger)
+	if err != nil {
+		t.Fatalf("buildPushoverPayload() error: %v", err)
+	}
+
+	title := payload["title"].(string)
+	if got := len([]rune(title)); got > 250 {
+		t.Errorf("title rune length = %d, want <= 250", got)
+	}
+	if !strings.HasSuffix(title, "…") {
+		t.Errorf("truncated title should end with ellipsis; got %q", title)
+	}
+}
+
+func TestBuildPushoverPayload_MessageTruncated(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+	data.StatusMessage = strings.Repeat("x", 1100)
+
+	payload, err := buildPushoverPayload(pushoverTestEndpoint(0), data, logger)
+	if err != nil {
+		t.Fatalf("buildPushoverPayload() error: %v", err)
+	}
+
+	message := payload["message"].(string)
+	if got := len([]rune(message)); got > 1024 {
+		t.Errorf("message rune length = %d, want <= 1024", got)
+	}
+	if !strings.HasSuffix(message, "…") {
+		t.Errorf("truncated message should end with ellipsis; got %q", message)
+	}
+}
+
+func TestBuildPushoverPayload_PriorityPassthrough(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+
+	for _, p := range []int{-2, -1, 0, 1} {
+		payload, err := buildPushoverPayload(pushoverTestEndpoint(p), data, logger)
+		if err != nil {
+			t.Fatalf("priority=%d: buildPushoverPayload() error: %v", p, err)
+		}
+		if got := payload["priority"]; got != p {
+			t.Errorf("priority=%d: got %v", p, got)
+		}
+	}
+}
+
+func TestNewWebhookNotifier_PushoverPriority(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+
+	tests := []struct {
+		name        string
+		priority    int
+		expectError bool
+	}{
+		{"min valid", -2, false},
+		{"zero", 0, false},
+		{"max valid", 1, false},
+		{"too low", -3, true},
+		{"emergency rejected", 2, true},
+		{"too high", 3, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.WebhookConfig{
+				Enabled:       true,
+				DefaultFormat: "pushover",
+				Timeout:       30,
+				Endpoints:     []config.WebhookEndpoint{pushoverTestEndpoint(tt.priority)},
+			}
+			_, err := NewWebhookNotifier(cfg, logger)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("priority=%d: expected error, got nil", tt.priority)
+				}
+				if !strings.Contains(err.Error(), "PRIORITY") {
+					t.Errorf("error %q does not mention PRIORITY", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("priority=%d: unexpected error: %v", tt.priority, err)
 			}
 		})
 	}


### PR DESCRIPTION
Pushover requires the application token and user/group key in the JSON body (not in headers), and its API rejects proxsave's existing generic payload shape. Until now users had no way to wire Pushover up without running an external relay.

This adds `pushover` as a first-class `WEBHOOK_*_FORMAT` alongside discord/slack/teams/generic. It reuses the existing AUTH_TOKEN / AUTH_USER fields for Pushover credentials (AUTH_TYPE stays "none"), introduces an optional WEBHOOK_<NAME>_PRIORITY (-2..1, default 0; emergency priority 2 deferred), and produces a Pushover-shaped JSON body with rune-aware truncation to the API's 250-char title and 1024-char message limits.

Validation: missing token/user is reported at payload-build time; out-of-range priority is rejected by NewWebhookNotifier so misconfig fails fast at startup rather than per-send.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pushover as a supported webhook notification format with configurable priority settings.

* **Documentation**
  * Updated configuration documentation and examples to demonstrate Pushover endpoint setup alongside existing notification formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->