### PR TITLE
Fix per-notifier error/warning count drift in dispatch chain

### DIFF
--- a/internal/orchestrator/additional_helpers_test.go
+++ b/internal/orchestrator/additional_helpers_test.go
@@ -604,6 +604,7 @@ type stubNotifierChannel struct {
 	errorCount    int
 	warningCount  int
 	categoryCount int
+	exitCode      int
 }
 
 func (s *stubNotifierChannel) Name() string {
@@ -616,6 +617,7 @@ func (s *stubNotifierChannel) Notify(ctx context.Context, stats *BackupStats) er
 		s.errorCount = stats.ErrorCount
 		s.warningCount = stats.WarningCount
 		s.categoryCount = len(stats.LogCategories)
+		s.exitCode = stats.ExitCode
 	}
 	if s.warnOnNotify && s.logger != nil {
 		s.logger.Warning("%s notification warning after snapshot", s.name)
@@ -803,6 +805,12 @@ func TestDispatchPostBackupSnapshotsIssuesImmediatelyBeforeNotifications(t *test
 	}
 	if stats.WarningCount != 1 {
 		t.Fatalf("stats.WarningCount should remain at the pre-notification snapshot, got %d", stats.WarningCount)
+	}
+	if stats.ExitCode != types.ExitGenericError.Int() {
+		t.Fatalf("stats.ExitCode should reflect pre-notification warnings, got %d", stats.ExitCode)
+	}
+	if email.exitCode != types.ExitGenericError.Int() || telegram.exitCode != types.ExitGenericError.Int() {
+		t.Fatalf("notifiers should see warning exit code, got email=%d telegram=%d", email.exitCode, telegram.exitCode)
 	}
 	if got := logger.WarningCount(); got != 2 {
 		t.Fatalf("final logger warning count should include storage and notification warnings, got %d", got)

--- a/internal/orchestrator/additional_helpers_test.go
+++ b/internal/orchestrator/additional_helpers_test.go
@@ -597,8 +597,13 @@ func TestFinalizeAndCloseLogWithoutLogFile(t *testing.T) {
 }
 
 type stubNotifierChannel struct {
-	name   string
-	called bool
+	name          string
+	called        bool
+	logger        *logging.Logger
+	warnOnNotify  bool
+	errorCount    int
+	warningCount  int
+	categoryCount int
 }
 
 func (s *stubNotifierChannel) Name() string {
@@ -607,6 +612,25 @@ func (s *stubNotifierChannel) Name() string {
 
 func (s *stubNotifierChannel) Notify(ctx context.Context, stats *BackupStats) error {
 	s.called = true
+	if stats != nil {
+		s.errorCount = stats.ErrorCount
+		s.warningCount = stats.WarningCount
+		s.categoryCount = len(stats.LogCategories)
+	}
+	if s.warnOnNotify && s.logger != nil {
+		s.logger.Warning("%s notification warning after snapshot", s.name)
+	}
+	return nil
+}
+
+type warningStorageTarget struct {
+	logger *logging.Logger
+}
+
+func (w *warningStorageTarget) Sync(ctx context.Context, stats *BackupStats) error {
+	if w.logger != nil {
+		w.logger.Warning("storage warning before notification snapshot")
+	}
 	return nil
 }
 
@@ -718,6 +742,70 @@ func TestDispatchNotificationsUsesNameMappingNotRegistrationOrder(t *testing.T) 
 	// No warnings should be produced for missing channels.
 	if strings.Contains(buf.String(), "enabled but not initialized") {
 		t.Fatalf("unexpected warning in output: %s", buf.String())
+	}
+}
+
+func TestDispatchPostBackupSnapshotsIssuesImmediatelyBeforeNotifications(t *testing.T) {
+	logger := logging.New(types.LogLevelInfo, false)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+
+	logPath := filepath.Join(t.TempDir(), "run.log")
+	if err := logger.OpenLogFile(logPath); err != nil {
+		t.Fatalf("OpenLogFile: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.CloseLogFile()
+	})
+
+	email := &stubNotifierChannel{name: "Email", logger: logger, warnOnNotify: true}
+	telegram := &stubNotifierChannel{name: "Telegram"}
+	o := &Orchestrator{
+		logger: logger,
+		cfg: &config.Config{
+			EmailEnabled:    true,
+			TelegramEnabled: true,
+			GotifyEnabled:   false,
+			WebhookEnabled:  false,
+		},
+		storageTargets: []StorageTarget{
+			&warningStorageTarget{logger: logger},
+		},
+		notificationChannels: []NotificationChannel{
+			email,
+			telegram,
+		},
+	}
+	stats := &BackupStats{
+		LogFilePath:      logPath,
+		SecondaryEnabled: true,
+		SecondaryStatus:  "ok",
+		CloudStatus:      "disabled",
+		EmailStatus:      "unknown",
+		TelegramStatus:   "unknown",
+	}
+
+	if err := o.dispatchPostBackup(context.Background(), stats); err != nil {
+		t.Fatalf("dispatchPostBackup returned error: %v", err)
+	}
+
+	if !email.called || !telegram.called {
+		t.Fatalf("expected both notifiers to be called (email=%v telegram=%v)", email.called, telegram.called)
+	}
+	if email.warningCount != 1 || telegram.warningCount != 1 {
+		t.Fatalf("notifiers should see the same pre-notification warning snapshot, got email=%d telegram=%d", email.warningCount, telegram.warningCount)
+	}
+	if email.errorCount != 0 || telegram.errorCount != 0 {
+		t.Fatalf("notifiers should not see errors, got email=%d telegram=%d", email.errorCount, telegram.errorCount)
+	}
+	if email.categoryCount == 0 || telegram.categoryCount == 0 || len(stats.LogCategories) == 0 {
+		t.Fatalf("expected pre-notification log categories to be snapshotted")
+	}
+	if stats.WarningCount != 1 {
+		t.Fatalf("stats.WarningCount should remain at the pre-notification snapshot, got %d", stats.WarningCount)
+	}
+	if got := logger.WarningCount(); got != 2 {
+		t.Fatalf("final logger warning count should include storage and notification warnings, got %d", got)
 	}
 }
 

--- a/internal/orchestrator/backup_run_helpers.go
+++ b/internal/orchestrator/backup_run_helpers.go
@@ -60,9 +60,10 @@ func (o *Orchestrator) parseFailedBackupLogCounts(stats *BackupStats) {
 	}
 
 	o.logger.Debug("Parsing log file for error/warning counts after failure: %s", stats.LogFilePath)
-	_, errorCount, warningCount := ParseLogCounts(stats.LogFilePath, 0)
+	categories, errorCount, warningCount := ParseLogCounts(stats.LogFilePath, 10)
 	stats.ErrorCount = errorCount
 	stats.WarningCount = warningCount
+	stats.LogCategories = categories
 	if errorCount > 0 || warningCount > 0 {
 		o.logger.Debug("Found %d errors and %d warnings in log file (failure path)", errorCount, warningCount)
 	}

--- a/internal/orchestrator/backup_run_helpers.go
+++ b/internal/orchestrator/backup_run_helpers.go
@@ -60,12 +60,9 @@ func (o *Orchestrator) parseFailedBackupLogCounts(stats *BackupStats) {
 	}
 
 	o.logger.Debug("Parsing log file for error/warning counts after failure: %s", stats.LogFilePath)
-	categories, errorCount, warningCount := ParseLogCounts(stats.LogFilePath, 10)
-	stats.ErrorCount = errorCount
-	stats.WarningCount = warningCount
-	stats.LogCategories = categories
-	if errorCount > 0 || warningCount > 0 {
-		o.logger.Debug("Found %d errors and %d warnings in log file (failure path)", errorCount, warningCount)
+	o.refreshLogIssuesFromFile(stats, false)
+	if stats.ErrorCount > 0 || stats.WarningCount > 0 {
+		o.logger.Debug("Found %d errors and %d warnings in log file (failure path)", stats.ErrorCount, stats.WarningCount)
 	}
 }
 

--- a/internal/orchestrator/backup_run_phases.go
+++ b/internal/orchestrator/backup_run_phases.go
@@ -341,12 +341,9 @@ func (o *Orchestrator) finalizeBackupStats(run *backupRunContext) {
 
 	if stats.LogFilePath != "" {
 		o.logger.Debug("Parsing log file for error/warning counts: %s", stats.LogFilePath)
-		categories, errorCount, warningCount := ParseLogCounts(stats.LogFilePath, 10)
-		stats.ErrorCount = errorCount
-		stats.WarningCount = warningCount
-		stats.LogCategories = categories
-		if errorCount > 0 || warningCount > 0 {
-			o.logger.Debug("Found %d errors and %d warnings in log file", errorCount, warningCount)
+		o.refreshLogIssuesFromFile(stats, false)
+		if stats.ErrorCount > 0 || stats.WarningCount > 0 {
+			o.logger.Debug("Found %d errors and %d warnings in log file", stats.ErrorCount, stats.WarningCount)
 		}
 	} else {
 		o.logger.Debug("No log file path specified, error/warning counts will be 0")

--- a/internal/orchestrator/backup_run_phases.go
+++ b/internal/orchestrator/backup_run_phases.go
@@ -341,9 +341,10 @@ func (o *Orchestrator) finalizeBackupStats(run *backupRunContext) {
 
 	if stats.LogFilePath != "" {
 		o.logger.Debug("Parsing log file for error/warning counts: %s", stats.LogFilePath)
-		_, errorCount, warningCount := ParseLogCounts(stats.LogFilePath, 0)
+		categories, errorCount, warningCount := ParseLogCounts(stats.LogFilePath, 10)
 		stats.ErrorCount = errorCount
 		stats.WarningCount = warningCount
+		stats.LogCategories = categories
 		if errorCount > 0 || warningCount > 0 {
 			o.logger.Debug("Found %d errors and %d warnings in log file", errorCount, warningCount)
 		}

--- a/internal/orchestrator/backup_run_phases.go
+++ b/internal/orchestrator/backup_run_phases.go
@@ -339,24 +339,23 @@ func (o *Orchestrator) finalizeBackupStats(run *backupRunContext) {
 	stats := run.stats
 	stats.Duration = stats.EndTime.Sub(stats.StartTime)
 
-	if stats.LogFilePath != "" {
-		o.logger.Debug("Parsing log file for error/warning counts: %s", stats.LogFilePath)
-		o.refreshLogIssuesFromFile(stats, false)
-		if stats.ErrorCount > 0 || stats.WarningCount > 0 {
-			o.logger.Debug("Found %d errors and %d warnings in log file", stats.ErrorCount, stats.WarningCount)
-		}
-	} else {
-		o.logger.Debug("No log file path specified, error/warning counts will be 0")
+	if !o.dryRun {
+		return
 	}
 
-	switch {
-	case stats.ErrorCount > 0:
-		stats.ExitCode = types.ExitBackupError.Int()
-	case stats.WarningCount > 0:
-		stats.ExitCode = types.ExitGenericError.Int()
-	default:
-		stats.ExitCode = types.ExitSuccess.Int()
+	if stats.LogFilePath == "" {
+		o.logger.Debug("No log file path specified, error/warning counts will be 0")
+		applyIssueExitCode(stats)
+		o.logger.Debug("Aggregated exit code based on log analysis: %d", stats.ExitCode)
+		return
 	}
+
+	o.logger.Debug("Parsing log file for error/warning counts: %s", stats.LogFilePath)
+	o.refreshLogIssuesFromFile(stats, false)
+	if stats.ErrorCount > 0 || stats.WarningCount > 0 {
+		o.logger.Debug("Found %d errors and %d warnings in log file", stats.ErrorCount, stats.WarningCount)
+	}
+	applyIssueExitCode(stats)
 	o.logger.Debug("Aggregated exit code based on log analysis: %d", stats.ExitCode)
 }
 

--- a/internal/orchestrator/extensions.go
+++ b/internal/orchestrator/extensions.go
@@ -118,7 +118,11 @@ func (o *Orchestrator) dispatchNotifications(ctx context.Context, stats *BackupS
 // startNotificationGroup is the notification boundary. Keep the issue snapshot
 // immediately adjacent to dispatchNotifications; no logging belongs between them.
 func (o *Orchestrator) startNotificationGroup(ctx context.Context, stats *BackupStats) {
+	if o == nil {
+		return
+	}
 	o.snapshotPreNotificationIssues(stats)
+	applyIssueExitCode(stats)
 	o.dispatchNotifications(ctx, stats)
 }
 
@@ -142,6 +146,20 @@ func (o *Orchestrator) refreshLogIssuesFromFile(stats *BackupStats, includeCateg
 		stats.LogCategories = categories
 	} else {
 		stats.LogCategories = nil
+	}
+}
+
+func applyIssueExitCode(stats *BackupStats) {
+	if stats == nil {
+		return
+	}
+	switch {
+	case stats.ErrorCount > 0 && (stats.ExitCode == types.ExitSuccess.Int() || stats.ExitCode == types.ExitGenericError.Int()):
+		stats.ExitCode = types.ExitBackupError.Int()
+	case stats.WarningCount > 0 && stats.ExitCode == types.ExitSuccess.Int():
+		stats.ExitCode = types.ExitGenericError.Int()
+	case stats.ExitCode == 0:
+		stats.ExitCode = types.ExitSuccess.Int()
 	}
 }
 
@@ -209,8 +227,9 @@ func (o *Orchestrator) DispatchEarlyErrorNotification(ctx context.Context, early
 		stats.LogFilePath = logPath
 	}
 
-	// Dispatch notifications with minimal stats
-	o.startNotificationGroup(ctx, stats)
+	// Dispatch notifications with minimal stats. Early errors are already
+	// represented in stats and may not be present in the log file yet.
+	o.dispatchNotifications(ctx, stats)
 
 	return stats
 }

--- a/internal/orchestrator/extensions.go
+++ b/internal/orchestrator/extensions.go
@@ -115,6 +115,36 @@ func (o *Orchestrator) dispatchNotifications(ctx context.Context, stats *BackupS
 	}
 }
 
+// startNotificationGroup is the notification boundary. Keep the issue snapshot
+// immediately adjacent to dispatchNotifications; no logging belongs between them.
+func (o *Orchestrator) startNotificationGroup(ctx context.Context, stats *BackupStats) {
+	o.snapshotPreNotificationIssues(stats)
+	o.dispatchNotifications(ctx, stats)
+}
+
+func (o *Orchestrator) snapshotPreNotificationIssues(stats *BackupStats) {
+	o.refreshLogIssuesFromFile(stats, true)
+}
+
+func (o *Orchestrator) refreshLogIssuesFromFile(stats *BackupStats, includeCategories bool) {
+	if stats == nil || strings.TrimSpace(stats.LogFilePath) == "" {
+		return
+	}
+
+	categoryLimit := 0
+	if includeCategories {
+		categoryLimit = 10
+	}
+	categories, errorCount, warningCount := ParseLogCounts(stats.LogFilePath, categoryLimit)
+	stats.ErrorCount = errorCount
+	stats.WarningCount = warningCount
+	if includeCategories {
+		stats.LogCategories = categories
+	} else {
+		stats.LogCategories = nil
+	}
+}
+
 // DispatchEarlyErrorNotification sends notifications for errors that occurred before backup started
 // This creates a minimal BackupStats with error information for notification purposes
 func (o *Orchestrator) DispatchEarlyErrorNotification(ctx context.Context, earlyErr *EarlyErrorState) *BackupStats {
@@ -180,7 +210,7 @@ func (o *Orchestrator) DispatchEarlyErrorNotification(ctx context.Context, early
 	}
 
 	// Dispatch notifications with minimal stats
-	o.dispatchNotifications(ctx, stats)
+	o.startNotificationGroup(ctx, stats)
 
 	return stats
 }
@@ -208,7 +238,7 @@ func (o *Orchestrator) dispatchNotificationsAndLogs(ctx context.Context, stats *
 	// Notification errors are logged but never propagated
 	fmt.Println()
 	o.logStep(7, "Notifications - dispatching channels")
-	o.dispatchNotifications(ctx, stats)
+	o.startNotificationGroup(ctx, stats)
 }
 
 func (o *Orchestrator) dispatchPostBackup(ctx context.Context, stats *BackupStats) error {

--- a/internal/orchestrator/extensions_additional_test.go
+++ b/internal/orchestrator/extensions_additional_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -75,5 +76,39 @@ func TestDispatchEarlyErrorNotification_PopulatesMinimalStats(t *testing.T) {
 	}
 	if stats.Hostname == "" {
 		t.Fatalf("Hostname is empty")
+	}
+}
+
+func TestDispatchEarlyErrorNotificationPreservesSyntheticIssueWithLogFile(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	logger.SetOutput(io.Discard)
+	logPath := filepath.Join(t.TempDir(), "early.log")
+	if err := logger.OpenLogFile(logPath); err != nil {
+		t.Fatalf("OpenLogFile: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.CloseLogFile()
+	})
+
+	orch := &Orchestrator{logger: logger}
+	early := &EarlyErrorState{
+		Phase:     "config",
+		Error:     errors.New("boom"),
+		ExitCode:  types.ExitConfigError,
+		Timestamp: time.Unix(1700000000, 0),
+	}
+
+	stats := orch.DispatchEarlyErrorNotification(context.Background(), early)
+	if stats == nil {
+		t.Fatalf("expected stats, got nil")
+	}
+	if stats.ExitCode != types.ExitConfigError.Int() {
+		t.Fatalf("ExitCode=%d; want %d", stats.ExitCode, types.ExitConfigError.Int())
+	}
+	if stats.ErrorCount != 1 {
+		t.Fatalf("ErrorCount=%d; want synthetic early error count to be preserved", stats.ErrorCount)
+	}
+	if stats.LogFilePath != logPath {
+		t.Fatalf("LogFilePath=%q; want %q", stats.LogFilePath, logPath)
 	}
 }

--- a/internal/orchestrator/notification_adapter.go
+++ b/internal/orchestrator/notification_adapter.go
@@ -175,13 +175,13 @@ func (n *NotificationAdapter) convertBackupStatsToNotificationData(stats *Backup
 		secondaryPercent = formatPercentString(calculateUsagePercent(stats.SecondaryUsedSpace, stats.SecondaryTotalSpace))
 	}
 
-	// Issue counts and categories are snapshotted into stats at backup completion
-	// (finalizeBackupStats / parseFailedBackupLogCounts) so all notifiers see the
-	// same totals. Re-parsing the log here per-notifier would over-count warnings
+	// Issue counts and categories are snapshotted immediately before the
+	// notification group starts, so all notifiers see the same pre-notification
+	// totals. Re-parsing the log here per-notifier would over-count warnings
 	// emitted by earlier notifiers in the dispatch chain.
 	errorCount := stats.ErrorCount
 	warningCount := stats.WarningCount
-	logCategories := stats.LogCategories
+	logCategories := append([]notify.LogCategory(nil), stats.LogCategories...)
 	totalIssues := errorCount + warningCount
 
 	// Extract filename from full path for email display

--- a/internal/orchestrator/notification_adapter.go
+++ b/internal/orchestrator/notification_adapter.go
@@ -175,17 +175,13 @@ func (n *NotificationAdapter) convertBackupStatsToNotificationData(stats *Backup
 		secondaryPercent = formatPercentString(calculateUsagePercent(stats.SecondaryUsedSpace, stats.SecondaryTotalSpace))
 	}
 
-	// Parse log file for categories - use ParseLogCounts as primary source
-	logCategories, logErrors, logWarnings := ParseLogCounts(stats.LogFilePath, 10)
-
-	// Use parsed counts if available, otherwise fall back to stats
+	// Issue counts and categories are snapshotted into stats at backup completion
+	// (finalizeBackupStats / parseFailedBackupLogCounts) so all notifiers see the
+	// same totals. Re-parsing the log here per-notifier would over-count warnings
+	// emitted by earlier notifiers in the dispatch chain.
 	errorCount := stats.ErrorCount
 	warningCount := stats.WarningCount
-	if logErrors > 0 || logWarnings > 0 {
-		errorCount = logErrors
-		warningCount = logWarnings
-	}
-
+	logCategories := stats.LogCategories
 	totalIssues := errorCount + warningCount
 
 	// Extract filename from full path for email display

--- a/internal/orchestrator/notification_adapter_test.go
+++ b/internal/orchestrator/notification_adapter_test.go
@@ -312,20 +312,12 @@ func TestFormatHelpers(t *testing.T) {
 	}
 }
 
-func TestConvertBackupStatsUsesLogCountsAndCompressionFallback(t *testing.T) {
+func TestConvertBackupStatsPropagatesIssueSnapshotAndCompressionFallback(t *testing.T) {
 	logger := logging.New(types.LogLevelDebug, false)
 	adapter := NewNotificationAdapter(&stubNotifier{name: "Email", enabled: true}, logger)
 
-	// Prepare a temporary log file with known error/warning counts
-	tempDir := t.TempDir()
-	logFile := filepath.Join(tempDir, "notif.log")
-	content := `[2025-11-10 14:30:01] [WARNING] Something minor
-[2025-11-10 14:30:02] [ERROR] Something bad
-`
-	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
-		t.Fatalf("failed to write log file: %v", err)
-	}
-
+	// Issue counts and categories are snapshotted into stats at backup completion;
+	// conversion must propagate them as-is without re-parsing the log file.
 	stats := &BackupStats{
 		ExitCode:             0,
 		Hostname:             "host",
@@ -337,20 +329,25 @@ func TestConvertBackupStatsUsesLogCountsAndCompressionFallback(t *testing.T) {
 		CloudEnabled:         false,
 		MaxLocalBackups:      5,
 		LocalRetentionPolicy: "simple",
-		LogFilePath:          logFile,
-		ErrorCount:           0,
-		WarningCount:         0,
-		Compression:          types.CompressionZstd,
+		ErrorCount:           1,
+		WarningCount:         1,
+		LogCategories: []notify.LogCategory{
+			{Label: "Something minor", Type: "WARNING", Count: 1, Example: "Something minor"},
+			{Label: "Something bad", Type: "ERROR", Count: 1, Example: "Something bad"},
+		},
+		Compression: types.CompressionZstd,
 	}
 
 	data := adapter.convertBackupStatsToNotificationData(stats)
 
-	// Log counts should override stats.ErrorCount/WarningCount
 	if data.ErrorCount != 1 || data.WarningCount != 1 {
-		t.Fatalf("expected error/warning counts from log = 1/1; got %d/%d", data.ErrorCount, data.WarningCount)
+		t.Fatalf("expected error/warning counts from stats = 1/1; got %d/%d", data.ErrorCount, data.WarningCount)
 	}
-	if len(data.LogCategories) == 0 {
-		t.Fatalf("expected LogCategories to be populated from log")
+	if data.TotalIssues != 2 {
+		t.Fatalf("expected TotalIssues = 2; got %d", data.TotalIssues)
+	}
+	if len(data.LogCategories) != 2 {
+		t.Fatalf("expected LogCategories to be propagated from stats, got %d entries", len(data.LogCategories))
 	}
 
 	// Compression ratio should be computed from sizes when explicit savings is <= 0
@@ -367,6 +364,43 @@ func TestConvertBackupStatsUsesLogCountsAndCompressionFallback(t *testing.T) {
 	}
 	if data.CloudStatus != "disabled" {
 		t.Fatalf("CloudStatus = %q; want disabled", data.CloudStatus)
+	}
+}
+
+func TestConvertBackupStatsDoesNotRereadLogFile(t *testing.T) {
+	// Regression test: conversion must trust stats.ErrorCount/WarningCount/LogCategories
+	// and never re-parse stats.LogFilePath, so warnings emitted during the notification
+	// phase aren't double-counted across notifiers in the dispatch chain.
+	logger := logging.New(types.LogLevelDebug, false)
+	adapter := NewNotificationAdapter(&stubNotifier{name: "Email", enabled: true}, logger)
+
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "notif.log")
+	// Log file contains 5 warnings that are NOT yet snapshotted into stats.
+	content := `[2025-11-10 14:30:01] [WARNING] one
+[2025-11-10 14:30:02] [WARNING] two
+[2025-11-10 14:30:03] [WARNING] three
+[2025-11-10 14:30:04] [WARNING] four
+[2025-11-10 14:30:05] [WARNING] five
+`
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+
+	stats := &BackupStats{
+		ExitCode:     0,
+		Hostname:     "host",
+		ArchivePath:  "/var/tmp/backup.tar",
+		LogFilePath:  logFile,
+		ErrorCount:   0,
+		WarningCount: 0,
+		Compression:  types.CompressionZstd,
+	}
+
+	data := adapter.convertBackupStatsToNotificationData(stats)
+
+	if data.WarningCount != 0 || data.ErrorCount != 0 {
+		t.Fatalf("conversion must trust stats counts (0/0); got errors=%d warnings=%d", data.ErrorCount, data.WarningCount)
 	}
 }
 

--- a/internal/orchestrator/notification_adapter_test.go
+++ b/internal/orchestrator/notification_adapter_test.go
@@ -316,7 +316,7 @@ func TestConvertBackupStatsPropagatesIssueSnapshotAndCompressionFallback(t *test
 	logger := logging.New(types.LogLevelDebug, false)
 	adapter := NewNotificationAdapter(&stubNotifier{name: "Email", enabled: true}, logger)
 
-	// Issue counts and categories are snapshotted into stats at backup completion;
+	// Issue counts and categories are snapshotted before the notification group;
 	// conversion must propagate them as-is without re-parsing the log file.
 	stats := &BackupStats{
 		ExitCode:             0,
@@ -348,6 +348,10 @@ func TestConvertBackupStatsPropagatesIssueSnapshotAndCompressionFallback(t *test
 	}
 	if len(data.LogCategories) != 2 {
 		t.Fatalf("expected LogCategories to be propagated from stats, got %d entries", len(data.LogCategories))
+	}
+	data.LogCategories[0].Label = "mutated"
+	if stats.LogCategories[0].Label == "mutated" {
+		t.Fatalf("LogCategories should be copied into NotificationData")
 	}
 
 	// Compression ratio should be computed from sizes when explicit savings is <= 0

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tis24dev/proxsave/internal/environment"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/metrics"
+	"github.com/tis24dev/proxsave/internal/notify"
 	"github.com/tis24dev/proxsave/internal/storage"
 	"github.com/tis24dev/proxsave/internal/types"
 )
@@ -151,9 +152,10 @@ type BackupStats struct {
 	CloudGFSCurrentYearly      int
 
 	// Error/warning counts
-	ErrorCount   int
-	WarningCount int
-	LogFilePath  string
+	ErrorCount    int
+	WarningCount  int
+	LogFilePath   string
+	LogCategories []notify.LogCategory
 
 	// Exit code
 	ExitCode       int


### PR DESCRIPTION
Snapshot ErrorCount, WarningCount and LogCategories into BackupStats once at backup completion (finalizeBackupStats / parseFailedBackupLogCounts) and have convertBackupStatsToNotificationData read them as-is. Re-parsing the log file per-notifier was over-counting warnings emitted by earlier notifiers in the dispatch chain, so e.g. Pushover reported 5 warnings while Email reported 0 on the same run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Notifications now capture consistent pre-send snapshots of backup stats (error/warning counts and log categories), preventing timing-related mismatches.
  * Backup reporting includes categorized log information and no longer re-reads log files during notification dispatch.
  * Dry-run behavior now centralizes how issue counts affect exit codes.

* **Tests**
  * Added behavioral tests to verify snapshot timing, warning propagation, and early-error log preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tis24dev/proxsave/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->