### PR TITLE
fix PXAR parallel collection, test coverage, and CI hardening

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -34,7 +34,7 @@ jobs:
           go test $(go list ./... | grep -v -E '/cmd/|/pbs$|/bech32$|^github.com/tis24dev/proxsave$') -coverprofile=coverage.out
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       # GORELEASER
       ########################################
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           version: latest
           workdir: ${{ github.workspace }}

--- a/.github/workflows/security-ultimate.yml
+++ b/.github/workflows/security-ultimate.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
+      - name: Download modules
+        run: go mod download
+
       - name: Run govulncheck
         run: govulncheck ./...
 

--- a/.github/workflows/security-ultimate.yml
+++ b/.github/workflows/security-ultimate.yml
@@ -91,7 +91,7 @@ jobs:
       # UPLOAD SARIF
       ########################################
       - name: Upload GoSec SARIF
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
         with:
           sarif_file: gosec.sarif
 
@@ -107,7 +107,7 @@ jobs:
       # CODEQL
       ########################################
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
         with:
           languages: go
 
@@ -117,4 +117,4 @@ jobs:
           go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	filippo.io/age v1.3.1
 	github.com/gdamore/tcell/v2 v2.13.9
 	github.com/rivo/tview v0.42.0
-	golang.org/x/crypto v0.51.0
+	golang.org/x/crypto v0.52.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 )
@@ -17,5 +17,5 @@ require (
 	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -38,6 +40,7 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/internal/backup/checksum.go
+++ b/internal/backup/checksum.go
@@ -168,7 +168,11 @@ func LoadManifest(manifestPath string) (*Manifest, error) {
 		return legacyManifest, nil
 	}
 
-	return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
+	return nil, fmt.Errorf(
+		"failed to parse manifest as JSON (%v) and legacy metadata (%v)",
+		err,
+		legacyErr,
+	)
 }
 
 // loadLegacyManifest attempts to parse legacy Bash metadata files (KEY=VALUE format).

--- a/internal/backup/checksum.go
+++ b/internal/backup/checksum.go
@@ -195,7 +195,9 @@ func loadLegacyManifest(manifestPath string, data []byte) (*Manifest, error) {
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
-	parseLegacyMetadata(scanner, legacy)
+	if err := parseLegacyMetadata(scanner, legacy); err != nil {
+		return nil, fmt.Errorf("parse legacy metadata: %w", err)
+	}
 
 	loadLegacyChecksum(archivePath, legacy)
 	inferEncryptionMode(archivePath, legacy)
@@ -203,7 +205,7 @@ func loadLegacyManifest(manifestPath string, data []byte) (*Manifest, error) {
 	return legacy, nil
 }
 
-func parseLegacyMetadata(scanner *bufio.Scanner, legacy *Manifest) {
+func parseLegacyMetadata(scanner *bufio.Scanner, legacy *Manifest) error {
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -261,6 +263,10 @@ func parseLegacyMetadata(scanner *bufio.Scanner, legacy *Manifest) {
 			legacy.EncryptionMode = value
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan legacy metadata: %w", err)
+	}
+	return nil
 }
 
 func loadLegacyChecksum(archivePath string, legacy *Manifest) {

--- a/internal/backup/checksum.go
+++ b/internal/backup/checksum.go
@@ -159,7 +159,8 @@ func LoadManifest(manifestPath string) (*Manifest, error) {
 	}
 
 	var manifest Manifest
-	if err := json.Unmarshal(data, &manifest); err == nil {
+	unmarshalErr := json.Unmarshal(data, &manifest)
+	if unmarshalErr == nil {
 		return &manifest, nil
 	}
 
@@ -170,7 +171,7 @@ func LoadManifest(manifestPath string) (*Manifest, error) {
 
 	return nil, fmt.Errorf(
 		"failed to parse manifest as JSON (%v) and legacy metadata (%v)",
-		err,
+		unmarshalErr,
 		legacyErr,
 	)
 }

--- a/internal/backup/checksum_additional_test.go
+++ b/internal/backup/checksum_additional_test.go
@@ -164,7 +164,9 @@ func TestParseLegacyMetadata_AllFieldsAndTargetMerge(t *testing.T) {
 		"ENCRYPTION_MODE=age",
 	}, "\n")))
 
-	parseLegacyMetadata(scanner, legacy)
+	if err := parseLegacyMetadata(scanner, legacy); err != nil {
+		t.Fatalf("parseLegacyMetadata error: %v", err)
+	}
 
 	if legacy.CompressionType != "zst" {
 		t.Fatalf("CompressionType = %q; want zst", legacy.CompressionType)
@@ -183,6 +185,20 @@ func TestParseLegacyMetadata_AllFieldsAndTargetMerge(t *testing.T) {
 	}
 	if legacy.Hostname != "dual-node" || legacy.ScriptVersion != "2.0.0" || legacy.EncryptionMode != "age" {
 		t.Fatalf("unexpected identity/encryption fields: %+v", legacy)
+	}
+}
+
+func TestParseLegacyMetadata_PropagatesScannerErrors(t *testing.T) {
+	legacy := &Manifest{}
+	scanner := bufio.NewScanner(strings.NewReader("COMPRESSION_TYPE=" + strings.Repeat("x", 128)))
+	scanner.Buffer(make([]byte, 0, 8), 32)
+
+	err := parseLegacyMetadata(scanner, legacy)
+	if err == nil {
+		t.Fatal("expected scanner error, got nil")
+	}
+	if !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("error=%v; want token-too-long scanner failure", err)
 	}
 }
 

--- a/internal/backup/checksum_legacy_test.go
+++ b/internal/backup/checksum_legacy_test.go
@@ -89,3 +89,19 @@ func TestLoadManifestInvalidJSONError(t *testing.T) {
 		t.Fatalf("expected error for invalid JSON manifest")
 	}
 }
+
+func TestLoadManifestMetadataErrorIncludesLegacyCause(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "missing-archive.tar.zst.metadata")
+	if err := os.WriteFile(path, []byte("{"), 0o640); err != nil {
+		t.Fatalf("write invalid metadata: %v", err)
+	}
+
+	_, err := LoadManifest(path)
+	if err == nil {
+		t.Fatal("expected error for metadata with missing archive")
+	}
+	if !strings.Contains(err.Error(), "cannot stat archive") {
+		t.Fatalf("error=%v; want legacy stat cause", err)
+	}
+}

--- a/internal/backup/checksum_legacy_test.go
+++ b/internal/backup/checksum_legacy_test.go
@@ -85,8 +85,15 @@ func TestLoadManifestInvalidJSONError(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{"), 0o640); err != nil {
 		t.Fatalf("write invalid json: %v", err)
 	}
-	if _, err := LoadManifest(path); err == nil {
+	_, err := LoadManifest(path)
+	if err == nil {
 		t.Fatalf("expected error for invalid JSON manifest")
+	}
+	if strings.Contains(err.Error(), "(<nil>)") {
+		t.Fatalf("error message should include JSON parse cause, not <nil>; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to parse manifest as JSON") {
+		t.Fatalf("unexpected error format; got: %v", err)
 	}
 }
 
@@ -100,6 +107,12 @@ func TestLoadManifestMetadataErrorIncludesLegacyCause(t *testing.T) {
 	_, err := LoadManifest(path)
 	if err == nil {
 		t.Fatal("expected error for metadata with missing archive")
+	}
+	if !strings.Contains(err.Error(), "failed to parse manifest as JSON") {
+		t.Fatalf("error=%v; want JSON parse cause in combined error", err)
+	}
+	if strings.Contains(err.Error(), "JSON (<nil>)") {
+		t.Fatalf("error=%v; JSON parse cause must not be <nil>", err)
 	}
 	if !strings.Contains(err.Error(), "cannot stat archive") {
 		t.Fatalf("error=%v; want legacy stat cause", err)

--- a/internal/backup/collector_bricks.go
+++ b/internal/backup/collector_bricks.go
@@ -321,6 +321,14 @@ func isContextCancellationError(ctx context.Context, err error) bool {
 	return ctxErr != nil && errors.Is(err, ctxErr)
 }
 
+func isParentContextError(ctx context.Context, err error) bool {
+	if err == nil || ctx == nil {
+		return false
+	}
+	ctxErr := ctx.Err()
+	return ctxErr != nil && errors.Is(err, ctxErr)
+}
+
 func (s *collectionState) ensurePVECommandsDir() (string, error) {
 	if s.pve.commandsDir != "" {
 		return s.pve.commandsDir, nil

--- a/internal/backup/collector_bricks_pbs_features.go
+++ b/internal/backup/collector_bricks_pbs_features.go
@@ -56,6 +56,18 @@ func newPBSPXARBricks() []collectionBrick {
 	bricks = append(bricks, newPBSPXARCTListBricks()...)
 	return bricks
 }
+
+func (c *Collector) handlePBSPXARStepError(ctx context.Context, message string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if isParentContextError(ctx, err) {
+		return err
+	}
+	c.logger.Warning("%s: %v", message, err)
+	return nil
+}
+
 func newPBSPXARPrepareBricks() []collectionBrick {
 	return []collectionBrick{
 		{
@@ -69,8 +81,7 @@ func newPBSPXARPrepareBricks() []collectionBrick {
 				}
 				pxarState, err := state.ensurePBSPXARState(ctx)
 				if err != nil {
-					c.logger.Warning("Failed to prepare PBS PXAR state: %v", err)
-					return nil
+					return c.handlePBSPXARStepError(ctx, "Failed to prepare PBS PXAR state", err)
 				}
 				state.pbs.pxar = pxarState
 				return nil
@@ -90,11 +101,10 @@ func newPBSPXARMetadataBricks() []collectionBrick {
 				}
 				pxarState, err := state.ensurePBSPXARState(ctx)
 				if err != nil {
-					state.collector.logger.Warning("Failed to prepare PBS PXAR state: %v", err)
-					return nil
+					return state.collector.handlePBSPXARStepError(ctx, "Failed to prepare PBS PXAR state", err)
 				}
 				if err := state.collector.collectPBSPXARMetadataStep(ctx, pxarState); err != nil {
-					state.collector.logger.Warning("Failed to collect PBS PXAR metadata: %v", err)
+					return state.collector.handlePBSPXARStepError(ctx, "Failed to collect PBS PXAR metadata", err)
 				}
 				return nil
 			},
@@ -113,11 +123,10 @@ func newPBSPXARSubdirReportBricks() []collectionBrick {
 				}
 				pxarState, err := state.ensurePBSPXARState(ctx)
 				if err != nil {
-					state.collector.logger.Warning("Failed to prepare PBS PXAR state: %v", err)
-					return nil
+					return state.collector.handlePBSPXARStepError(ctx, "Failed to prepare PBS PXAR state", err)
 				}
 				if err := state.collector.collectPBSPXARSubdirReportsStep(ctx, pxarState); err != nil {
-					state.collector.logger.Warning("Failed to collect PBS PXAR subdir reports: %v", err)
+					return state.collector.handlePBSPXARStepError(ctx, "Failed to collect PBS PXAR subdir reports", err)
 				}
 				return nil
 			},
@@ -136,11 +145,10 @@ func newPBSPXARVMListBricks() []collectionBrick {
 				}
 				pxarState, err := state.ensurePBSPXARState(ctx)
 				if err != nil {
-					state.collector.logger.Warning("Failed to prepare PBS PXAR state: %v", err)
-					return nil
+					return state.collector.handlePBSPXARStepError(ctx, "Failed to prepare PBS PXAR state", err)
 				}
 				if err := state.collector.collectPBSPXARVMListsStep(ctx, pxarState); err != nil {
-					state.collector.logger.Warning("Failed to collect PBS PXAR VM lists: %v", err)
+					return state.collector.handlePBSPXARStepError(ctx, "Failed to collect PBS PXAR VM lists", err)
 				}
 				return nil
 			},
@@ -159,11 +167,10 @@ func newPBSPXARCTListBricks() []collectionBrick {
 				}
 				pxarState, err := state.ensurePBSPXARState(ctx)
 				if err != nil {
-					state.collector.logger.Warning("Failed to prepare PBS PXAR state: %v", err)
-					return nil
+					return state.collector.handlePBSPXARStepError(ctx, "Failed to prepare PBS PXAR state", err)
 				}
 				if err := state.collector.collectPBSPXARCTListsStep(ctx, pxarState); err != nil {
-					state.collector.logger.Warning("Failed to collect PBS PXAR CT lists: %v", err)
+					return state.collector.handlePBSPXARStepError(ctx, "Failed to collect PBS PXAR CT lists", err)
 				}
 				return nil
 			},

--- a/internal/backup/collector_pbs_datastore.go
+++ b/internal/backup/collector_pbs_datastore.go
@@ -550,14 +550,11 @@ func (c *Collector) runPBSPXARStep(ctx context.Context, state *pbsPxarState, fn 
 		dsWorkers = 1
 	}
 
-	childCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	var (
-		wg       sync.WaitGroup
-		sem      = make(chan struct{}, dsWorkers)
-		errMu    sync.Mutex
-		firstErr error
+		wg    sync.WaitGroup
+		sem   = make(chan struct{}, dsWorkers)
+		errMu sync.Mutex
+		errs  []error
 	)
 
 	for _, ds := range state.eligible {
@@ -567,23 +564,22 @@ func (c *Collector) runPBSPXARStep(ctx context.Context, state *pbsPxarState, fn 
 			defer wg.Done()
 			select {
 			case sem <- struct{}{}:
-			case <-childCtx.Done():
+			case <-ctx.Done():
 				return
 			}
 			defer func() { <-sem }()
-			if err := childCtx.Err(); err != nil {
+
+			if err := ctx.Err(); err != nil {
 				return
 			}
 
-			if err := fn(childCtx, ds, state); err != nil {
-				if errors.Is(err, context.Canceled) {
+			if err := fn(ctx, ds, state); err != nil {
+				if isParentContextError(ctx, err) {
 					return
 				}
+				c.logger.Debug("PXAR: datastore %s step failed: %v", ds.Name, err)
 				errMu.Lock()
-				if firstErr == nil {
-					firstErr = err
-					cancel()
-				}
+				errs = append(errs, err)
 				errMu.Unlock()
 			}
 		}()
@@ -591,13 +587,13 @@ func (c *Collector) runPBSPXARStep(ctx context.Context, state *pbsPxarState, fn 
 
 	wg.Wait()
 
-	if firstErr != nil {
-		return firstErr
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if len(errs) > 0 {
+			return errors.Join(ctxErr, errors.Join(errs...))
+		}
+		return ctxErr
 	}
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (c *Collector) collectPBSPXARMetadataForDatastore(ctx context.Context, ds pbsDatastore, state *pbsPxarState) error {

--- a/internal/backup/collector_pve_coverage_test.go
+++ b/internal/backup/collector_pve_coverage_test.go
@@ -1,0 +1,1173 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func pveTestBool(v bool) *bool {
+	b := v
+	return &b
+}
+
+func newPVEHappyCommandCollector(t *testing.T) *Collector {
+	t.Helper()
+	return newPVECollectorWithDeps(t, CollectorDeps{
+		LookPath: func(cmd string) (string, error) {
+			return "/usr/bin/" + cmd, nil
+		},
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			switch name {
+			case "pveversion":
+				return []byte("pve-manager/8.2"), nil
+			case "pvenode":
+				return []byte(`{"wakeonlan":"00:11:22:33:44:55"}`), nil
+			case "pveum", "pvesm":
+				return []byte("[]"), nil
+			case "pvecm":
+				return []byte("Cluster information\n"), nil
+			case "pvesh":
+				if len(args) >= 2 {
+					switch {
+					case args[1] == "/nodes":
+						return []byte(`[{"node":"zeta"},{"node":"alpha"},{"node":"  "}]`), nil
+					case args[1] == "/version":
+						return []byte(`{"version":"8.2"}`), nil
+					case strings.Contains(args[1], "/storage"):
+						return []byte(`[
+							{"storage":"zstore","path":"/z","type":"dir","content":"backup","active":"on","enabled":"yes","status":"available"},
+							{"storage":"astore","path":"/a","type":"dir","content":"iso","active":"off","enabled":"no","status":"disabled"}
+						]`), nil
+					}
+				}
+				return []byte("[]"), nil
+			default:
+				return []byte("[]"), nil
+			}
+		},
+	})
+}
+
+func markOutputPathAsDir(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+		t.Fatalf("mkdir output marker %s: %v", name, err)
+	}
+}
+
+func TestPVEManifestHelpersAdditionalBranches(t *testing.T) {
+	var nilCollector *Collector
+	nilCollector.populatePVEManifest()
+
+	collector := newPVECollector(t)
+	if got := pveManifestKey("", "etc/pve/user.cfg"); got != "etc/pve/user.cfg" {
+		t.Fatalf("pveManifestKey empty temp = %q", got)
+	}
+	if got := pveManifestKey(collector.tempDir, collector.tempDir); got != filepath.ToSlash(collector.tempDir) {
+		t.Fatalf("pveManifestKey self = %q", got)
+	}
+
+	srcDir := filepath.Join(t.TempDir(), "srcdir")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir srcDir: %v", err)
+	}
+	srcFile := filepath.Join(t.TempDir(), "src.txt")
+	if err := os.WriteFile(srcFile, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write srcFile: %v", err)
+	}
+	destDir := filepath.Join(t.TempDir(), "destdir")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("mkdir destDir: %v", err)
+	}
+
+	if got := collector.describePathForManifest(srcFile, "", false); got.Status != StatusDisabled {
+		t.Fatalf("disabled manifest status = %s", got.Status)
+	}
+	if got := collector.describePathForManifest(filepath.Join(t.TempDir(), "missing"), "", true); got.Status != StatusNotFound {
+		t.Fatalf("missing manifest status = %s", got.Status)
+	}
+	if got := collector.describePathForManifest(srcFile, filepath.Join(t.TempDir(), "missing-dest"), true); got.Status != StatusFailed {
+		t.Fatalf("missing dest manifest status = %s", got.Status)
+	}
+	if got := collector.describePathForManifest(srcDir, destDir, true); got.Status != StatusCollected || got.Size != 0 {
+		t.Fatalf("directory manifest entry = %+v", got)
+	}
+
+	dryRunCollector := newPVECollector(t)
+	dryRunCollector.dryRun = true
+	if got := dryRunCollector.describePathForManifest(srcDir, "", true); got.Status != StatusCollected || got.Size != 0 {
+		t.Fatalf("dry-run directory manifest entry = %+v", got)
+	}
+
+	manifestCollector := newPVECollector(t)
+	pveRoot := manifestCollector.config.PVEConfigPath
+	qemuDir := filepath.Join(pveRoot, "qemu-server")
+	if err := os.MkdirAll(qemuDir, 0o755); err != nil {
+		t.Fatalf("mkdir qemu dir: %v", err)
+	}
+	if err := os.MkdirAll(manifestCollector.targetPathFor(qemuDir), 0o755); err != nil {
+		t.Fatalf("mkdir qemu dest: %v", err)
+	}
+	userCfg := filepath.Join(pveRoot, "user.cfg")
+	if err := os.WriteFile(userCfg, []byte("user"), 0o644); err != nil {
+		t.Fatalf("write user.cfg: %v", err)
+	}
+	userDest := manifestCollector.targetPathFor(userCfg)
+	if err := os.MkdirAll(filepath.Dir(userDest), 0o755); err != nil {
+		t.Fatalf("mkdir user dest: %v", err)
+	}
+	if err := os.WriteFile(userDest, []byte("user"), 0o644); err != nil {
+		t.Fatalf("write user dest: %v", err)
+	}
+	manifestCollector.config.BackupPVEFirewall = false
+	manifestCollector.populatePVEManifest()
+	if len(manifestCollector.pveManifest) == 0 {
+		t.Fatal("expected populatePVEManifest to record entries")
+	}
+}
+
+func TestPVERuntimeCommandSuccessAndFailureBranches(t *testing.T) {
+	t.Run("success paths parse runtime info", func(t *testing.T) {
+		collector := newPVEHappyCommandCollector(t)
+		commandsDir := t.TempDir()
+		info := &pveRuntimeInfo{}
+
+		if err := collector.collectPVECoreRuntime(context.Background(), commandsDir, info); err != nil {
+			t.Fatalf("collectPVECoreRuntime: %v", err)
+		}
+		if err := collector.collectPVEACLRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectPVEACLRuntime: %v", err)
+		}
+		if err := collector.collectPVEClusterRuntime(context.Background(), commandsDir, true); err != nil {
+			t.Fatalf("collectPVEClusterRuntime: %v", err)
+		}
+		if err := collector.collectPVEStorageRuntime(context.Background(), commandsDir, info); err != nil {
+			t.Fatalf("collectPVEStorageRuntime: %v", err)
+		}
+
+		if len(info.Storages) != 2 || info.Storages[0].Name != "astore" || info.Storages[1].Name != "zstore" {
+			t.Fatalf("storages not parsed and sorted: %+v", info.Storages)
+		}
+		collector.finalizePVERuntimeInfo(info)
+		if len(info.Nodes) != 2 || info.Nodes[0] != "alpha" || info.Nodes[1] != "zeta" {
+			t.Fatalf("nodes not finalized and sorted: %+v", info.Nodes)
+		}
+	})
+
+	t.Run("acl disabled returns before commands", func(t *testing.T) {
+		calls := 0
+		collector := newPVECollectorWithDeps(t, CollectorDeps{
+			LookPath: func(cmd string) (string, error) { return "/usr/bin/" + cmd, nil },
+			RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+				calls++
+				return []byte("[]"), nil
+			},
+		})
+		collector.config.BackupPVEACL = false
+		if err := collector.collectPVEACLRuntime(context.Background(), t.TempDir()); err != nil {
+			t.Fatalf("collectPVEACLRuntime disabled: %v", err)
+		}
+		if calls != 0 {
+			t.Fatalf("expected no pveum calls when ACL backup disabled, got %d", calls)
+		}
+	})
+
+	t.Run("critical pveversion failure is returned", func(t *testing.T) {
+		collector := newPVECollectorWithDeps(t, CollectorDeps{
+			LookPath: func(cmd string) (string, error) { return "/usr/bin/" + cmd, nil },
+			RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+				return []byte("boom"), errors.New("failed")
+			},
+		})
+		if err := collector.collectPVECoreRuntime(context.Background(), t.TempDir(), &pveRuntimeInfo{}); err == nil {
+			t.Fatal("expected critical pveversion failure")
+		}
+	})
+
+	t.Run("core runtime output write errors", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			blockFile string
+			wantErr   bool
+		}{
+			{name: "node config", blockFile: "node_config.txt", wantErr: true},
+			{name: "api version", blockFile: "api_version.json", wantErr: true},
+			{name: "nodes status warning", blockFile: "nodes_status.json", wantErr: false},
+		}
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				collector := newPVEHappyCommandCollector(t)
+				commandsDir := t.TempDir()
+				markOutputPathAsDir(t, commandsDir, tt.blockFile)
+				err := collector.collectPVECoreRuntime(context.Background(), commandsDir, &pveRuntimeInfo{})
+				if tt.wantErr && err == nil {
+					t.Fatal("expected output write error")
+				}
+				if !tt.wantErr && err != nil {
+					t.Fatalf("expected warning-only output error, got %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("acl runtime output write errors", func(t *testing.T) {
+		for _, blockFile := range []string{"pve_users.json", "pve_groups.json", "pve_roles.json", "pools.json"} {
+			t.Run(blockFile, func(t *testing.T) {
+				collector := newPVEHappyCommandCollector(t)
+				commandsDir := t.TempDir()
+				markOutputPathAsDir(t, commandsDir, blockFile)
+				if err := collector.collectPVEACLRuntime(context.Background(), commandsDir); err == nil {
+					t.Fatal("expected ACL output write error")
+				}
+			})
+		}
+	})
+
+	t.Run("cluster runtime output write errors", func(t *testing.T) {
+		for _, blockFile := range []string{
+			"cluster_status.txt",
+			"cluster_nodes.txt",
+			"ha_status.json",
+			"mapping_pci.json",
+			"mapping_usb.json",
+			"mapping_dir.json",
+		} {
+			t.Run(blockFile, func(t *testing.T) {
+				collector := newPVEHappyCommandCollector(t)
+				commandsDir := t.TempDir()
+				markOutputPathAsDir(t, commandsDir, blockFile)
+				if err := collector.collectPVEClusterRuntime(context.Background(), commandsDir, true); err == nil {
+					t.Fatal("expected cluster output write error")
+				}
+			})
+		}
+	})
+
+	t.Run("storage runtime output write errors", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			blockFile string
+			wantErr   bool
+		}{
+			{name: "disks list", blockFile: "disks_list.json", wantErr: true},
+			{name: "storage status warning", blockFile: "storage_status.json", wantErr: false},
+			{name: "pvesm status", blockFile: "pvesm_status.txt", wantErr: true},
+		}
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				collector := newPVEHappyCommandCollector(t)
+				commandsDir := t.TempDir()
+				markOutputPathAsDir(t, commandsDir, tt.blockFile)
+				err := collector.collectPVEStorageRuntime(context.Background(), commandsDir, &pveRuntimeInfo{})
+				if tt.wantErr && err == nil {
+					t.Fatal("expected storage runtime output write error")
+				}
+				if !tt.wantErr && err != nil {
+					t.Fatalf("expected storage status warning only, got %v", err)
+				}
+			})
+		}
+	})
+}
+
+func TestPVEJobScheduleAndReplicationAdditionalBranches(t *testing.T) {
+	collector := newPVECollectorWithDeps(t, CollectorDeps{
+		LookPath: func(cmd string) (string, error) { return "/usr/bin/" + cmd, nil },
+		RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+			return []byte("[]"), nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := collector.collectPVEBackupJobDefinitions(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("collectPVEBackupJobDefinitions canceled = %v", err)
+	}
+	if err := collector.collectPVEScheduleCrontab(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("collectPVEScheduleCrontab canceled = %v", err)
+	}
+	if err := collector.collectPVEScheduleTimers(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("collectPVEScheduleTimers canceled = %v", err)
+	}
+	if err := collector.collectPVEScheduleCronFiles(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("collectPVEScheduleCronFiles canceled = %v", err)
+	}
+	if err := collector.collectPVEReplicationDefinitions(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("collectPVEReplicationDefinitions canceled = %v", err)
+	}
+	if err := collector.collectPVEVZDumpCronSnapshot(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("collectPVEVZDumpCronSnapshot canceled = %v", err)
+	}
+
+	historyCalls := make(map[string]int)
+	historyCollector := newPVECollectorWithDeps(t, CollectorDeps{
+		LookPath: func(cmd string) (string, error) { return "/usr/bin/" + cmd, nil },
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			if name == "pvesh" && len(args) >= 2 {
+				historyCalls[args[1]]++
+			}
+			return []byte("[]"), nil
+		},
+	})
+	if err := historyCollector.collectPVEBackupJobHistory(context.Background(), []string{"", "node1", " node1 ", "node2", "node2"}); err != nil {
+		t.Fatalf("collectPVEBackupJobHistory: %v", err)
+	}
+	if historyCalls["/nodes/node1/tasks"] != 1 || historyCalls["/nodes/node2/tasks"] != 1 || len(historyCalls) != 2 {
+		t.Fatalf("job history calls not deduplicated: %+v", historyCalls)
+	}
+
+	replicationCalls := make(map[string]int)
+	replicationCollector := newPVECollectorWithDeps(t, CollectorDeps{
+		LookPath: func(cmd string) (string, error) { return "/usr/bin/" + cmd, nil },
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			if name == "pvesh" && len(args) >= 2 {
+				replicationCalls[args[1]]++
+			}
+			return []byte("[]"), nil
+		},
+	})
+	if err := replicationCollector.collectPVEReplicationStatus(context.Background(), []string{"", "node1", " node1 ", "node2", "node2"}); err != nil {
+		t.Fatalf("collectPVEReplicationStatus: %v", err)
+	}
+	if replicationCalls["/nodes/node1/replication"] != 1 || replicationCalls["/nodes/node2/replication"] != 1 || len(replicationCalls) != 2 {
+		t.Fatalf("replication calls not deduplicated: %+v", replicationCalls)
+	}
+
+	root := t.TempDir()
+	cronDir := filepath.Join(root, "etc", "cron.d")
+	if err := os.MkdirAll(filepath.Join(cronDir, "pve-dir"), 0o755); err != nil {
+		t.Fatalf("mkdir cron subdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cronDir, "pve-backup"), []byte("* * * * * root true"), 0o644); err != nil {
+		t.Fatalf("write pve cron: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cronDir, "unrelated"), []byte("* * * * * root true"), 0o644); err != nil {
+		t.Fatalf("write unrelated cron: %v", err)
+	}
+	cfg := GetDefaultCollectorConfig()
+	cfg.SystemRootPrefix = root
+	cronCollector := NewCollector(newTestLogger(), cfg, t.TempDir(), "pve", false)
+	if err := cronCollector.collectPVEScheduleCronFiles(context.Background()); err != nil {
+		t.Fatalf("collectPVEScheduleCronFiles: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cronCollector.tempDir, "etc/cron.d/pve-backup")); err != nil {
+		t.Fatalf("expected pve cron copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cronCollector.tempDir, "etc/cron.d/unrelated")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unrelated cron should not be copied, got %v", err)
+	}
+}
+
+func TestPVEGuestVMJobReplicationAndScheduleErrorBranches(t *testing.T) {
+	t.Run("guest inventory success and output failures", func(t *testing.T) {
+		collector := newPVEHappyCommandCollector(t)
+		if err := collector.collectPVEGuestInventory(context.Background()); err != nil {
+			t.Fatalf("collectPVEGuestInventory success: %v", err)
+		}
+
+		for _, blockFile := range []string{"qemu_vms.json", "lxc_containers.json"} {
+			t.Run(blockFile, func(t *testing.T) {
+				collector := newPVEHappyCommandCollector(t)
+				commandsDir := collector.proxsaveCommandsDir("pve")
+				if err := os.MkdirAll(commandsDir, 0o755); err != nil {
+					t.Fatalf("mkdir commands dir: %v", err)
+				}
+				markOutputPathAsDir(t, commandsDir, blockFile)
+				if err := collector.collectPVEGuestInventory(context.Background()); err == nil {
+					t.Fatal("expected guest inventory output write error")
+				}
+			})
+		}
+
+		tempFile := filepath.Join(t.TempDir(), "temp-file")
+		if err := os.WriteFile(tempFile, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		collector = NewCollector(newTestLogger(), GetDefaultCollectorConfig(), tempFile, "pve", false)
+		if err := collector.collectPVEGuestInventory(context.Background()); err == nil {
+			t.Fatal("expected commands directory creation error")
+		}
+	})
+
+	t.Run("vm config wrappers return copy errors", func(t *testing.T) {
+		collector := newPVECollector(t)
+		qemuDir := filepath.Join(collector.config.PVEConfigPath, "qemu-server")
+		if err := os.MkdirAll(qemuDir, 0o755); err != nil {
+			t.Fatalf("mkdir qemu dir: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(collector.targetPathFor(qemuDir)), 0o755); err != nil {
+			t.Fatalf("mkdir qemu dest parent: %v", err)
+		}
+		if err := os.WriteFile(collector.targetPathFor(qemuDir), []byte("block"), 0o644); err != nil {
+			t.Fatalf("write qemu dest blocker: %v", err)
+		}
+		if err := collector.collectPVEQEMUConfigs(context.Background()); err == nil {
+			t.Fatal("expected qemu config copy error")
+		}
+
+		collector = newPVECollector(t)
+		lxcDir := filepath.Join(collector.config.PVEConfigPath, "lxc")
+		if err := os.MkdirAll(lxcDir, 0o755); err != nil {
+			t.Fatalf("mkdir lxc dir: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(collector.targetPathFor(lxcDir)), 0o755); err != nil {
+			t.Fatalf("mkdir lxc dest parent: %v", err)
+		}
+		if err := os.WriteFile(collector.targetPathFor(lxcDir), []byte("block"), 0o644); err != nil {
+			t.Fatalf("write lxc dest blocker: %v", err)
+		}
+		if err := collector.collectPVELXCConfigs(context.Background()); err == nil {
+			t.Fatal("expected lxc config copy error")
+		}
+		if err := collector.collectVMConfigs(context.Background()); err == nil {
+			t.Fatal("expected collectVMConfigs to return lxc copy error")
+		}
+	})
+
+	t.Run("job replication and schedule write failures", func(t *testing.T) {
+		collector := newPVEHappyCommandCollector(t)
+		jobsDir := collector.pveJobsDir()
+		if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+			t.Fatalf("mkdir jobs dir: %v", err)
+		}
+		markOutputPathAsDir(t, jobsDir, "backup_jobs.json")
+		if err := collector.collectPVEBackupJobDefinitions(context.Background()); err == nil {
+			t.Fatal("expected backup job definition write error")
+		}
+
+		tempFile := filepath.Join(t.TempDir(), "temp-file")
+		if err := os.WriteFile(tempFile, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		collector = NewCollector(newTestLogger(), GetDefaultCollectorConfig(), tempFile, "pve", false)
+		if err := collector.collectPVEBackupJobDefinitions(context.Background()); err == nil {
+			t.Fatal("expected backup job definition ensureDir error")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		collector = newPVEHappyCommandCollector(t)
+		if err := collector.collectPVEBackupJobHistory(ctx, []string{"node1"}); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectPVEBackupJobHistory canceled = %v", err)
+		}
+		if err := collector.collectPVEReplicationStatus(ctx, []string{"node1"}); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectPVEReplicationStatus canceled = %v", err)
+		}
+
+		collector = newPVEHappyCommandCollector(t)
+		repDir := collector.pveReplicationDir()
+		if err := os.MkdirAll(repDir, 0o755); err != nil {
+			t.Fatalf("mkdir replication dir: %v", err)
+		}
+		markOutputPathAsDir(t, repDir, "replication_jobs.json")
+		if err := collector.collectPVEReplicationDefinitions(context.Background()); err == nil {
+			t.Fatal("expected replication definitions write error")
+		}
+
+		collector = NewCollector(newTestLogger(), GetDefaultCollectorConfig(), tempFile, "pve", false)
+		if err := collector.collectPVEReplicationDefinitions(context.Background()); err == nil {
+			t.Fatal("expected replication definitions ensureDir error")
+		}
+
+		collector = NewCollector(newTestLogger(), GetDefaultCollectorConfig(), tempFile, "pve", false)
+		if err := collector.collectPVEScheduleCrontab(context.Background()); err == nil {
+			t.Fatal("expected crontab schedule ensureDir error")
+		}
+		if err := collector.collectPVEScheduleTimers(context.Background()); err == nil {
+			t.Fatal("expected timer schedule ensureDir error")
+		}
+	})
+}
+
+func TestPVESnapshotAdditionalBranches(t *testing.T) {
+	t.Run("cluster snapshot copies relative corosync cluster db and authkey", func(t *testing.T) {
+		root := t.TempDir()
+		pveRoot := filepath.Join(root, "etc", "pve")
+		clusterRoot := filepath.Join(root, "var", "lib", "pve-cluster")
+		authDir := filepath.Join(root, "etc", "corosync")
+		for _, dir := range []string{pveRoot, clusterRoot, authDir} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", dir, err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(pveRoot, "relative-corosync.conf"), []byte("cluster_name: test"), 0o644); err != nil {
+			t.Fatalf("write corosync: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(clusterRoot, "config.db"), []byte("db"), 0o644); err != nil {
+			t.Fatalf("write config.db: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(authDir, "authkey"), []byte("key"), 0o600); err != nil {
+			t.Fatalf("write authkey: %v", err)
+		}
+		cfg := GetDefaultCollectorConfig()
+		cfg.SystemRootPrefix = root
+		cfg.PVEConfigPath = "/etc/pve"
+		cfg.PVEClusterPath = "/var/lib/pve-cluster"
+		cfg.CorosyncConfigPath = "relative-corosync.conf"
+		collector := NewCollector(newTestLogger(), cfg, t.TempDir(), "pve", false)
+		if err := collector.collectPVEClusterSnapshot(context.Background(), true); err != nil {
+			t.Fatalf("collectPVEClusterSnapshot: %v", err)
+		}
+		for _, src := range []string{
+			filepath.Join(pveRoot, "relative-corosync.conf"),
+			filepath.Join(clusterRoot, "config.db"),
+			filepath.Join(authDir, "authkey"),
+		} {
+			if _, err := os.Stat(collector.targetPathFor(src)); err != nil {
+				t.Fatalf("expected %s copied: %v", src, err)
+			}
+		}
+	})
+
+	t.Run("firewall file is copied", func(t *testing.T) {
+		collector := newPVECollector(t)
+		firewallPath := filepath.Join(collector.config.PVEConfigPath, "firewall")
+		if err := os.WriteFile(firewallPath, []byte("[OPTIONS]\n"), 0o644); err != nil {
+			t.Fatalf("write firewall file: %v", err)
+		}
+		if err := collector.collectPVEFirewallSnapshot(context.Background()); err != nil {
+			t.Fatalf("collectPVEFirewallSnapshot: %v", err)
+		}
+		if _, err := os.Stat(collector.targetPathFor(firewallPath)); err != nil {
+			t.Fatalf("expected firewall file copied: %v", err)
+		}
+	})
+
+	t.Run("vzdump relative path is copied from PVE config dir", func(t *testing.T) {
+		pveRoot := t.TempDir()
+		if err := os.WriteFile(filepath.Join(pveRoot, "vzdump.conf"), []byte("mode: snapshot\n"), 0o644); err != nil {
+			t.Fatalf("write vzdump.conf: %v", err)
+		}
+		cfg := GetDefaultCollectorConfig()
+		cfg.PVEConfigPath = pveRoot
+		cfg.VzdumpConfigPath = "vzdump.conf"
+		collector := NewCollector(newTestLogger(), cfg, t.TempDir(), "pve", false)
+		if err := collector.collectPVEVZDumpSnapshot(context.Background()); err != nil {
+			t.Fatalf("collectPVEVZDumpSnapshot: %v", err)
+		}
+		src := filepath.Join(pveRoot, "vzdump.conf")
+		if _, err := os.Stat(collector.targetPathFor(src)); err != nil {
+			t.Fatalf("expected vzdump config copied: %v", err)
+		}
+	})
+}
+
+func TestPVEStorageScanMetadataAndSummaryEdges(t *testing.T) {
+	collector := newPVECollector(t)
+
+	if result, err := collector.preparePVEStorageScan(context.Background(), pveStorageEntry{Name: "empty"}, t.TempDir(), 0); err != nil || result != nil {
+		t.Fatalf("empty storage path result=%v err=%v", result, err)
+	}
+	if result, err := collector.preparePVEStorageScan(context.Background(), pveStorageEntry{Name: "bad", Path: "/missing", Status: "error"}, t.TempDir(), 0); err != nil || result != nil {
+		t.Fatalf("unavailable storage result=%v err=%v", result, err)
+	}
+
+	filePath := filepath.Join(t.TempDir(), "not-dir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write filePath: %v", err)
+	}
+	if result, err := collector.preparePVEStorageScan(context.Background(), pveStorageEntry{Name: "file", Path: filePath}, t.TempDir(), 0); err != nil || result != nil {
+		t.Fatalf("file storage path result=%v err=%v", result, err)
+	}
+
+	storageDir := t.TempDir()
+	baseFile := filepath.Join(t.TempDir(), "base-file")
+	if err := os.WriteFile(baseFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write base file: %v", err)
+	}
+	if _, err := collector.preparePVEStorageScan(context.Background(), pveStorageEntry{Name: "local", Path: storageDir}, baseFile, 0); err == nil {
+		t.Fatal("expected metadata directory creation failure")
+	}
+
+	validBase := t.TempDir()
+	validResult, err := collector.preparePVEStorageScan(context.Background(), pveStorageEntry{Name: "local", Path: storageDir, Type: "dir", Content: "backup"}, validBase, 0)
+	if err != nil {
+		t.Fatalf("preparePVEStorageScan valid: %v", err)
+	}
+	if validResult == nil {
+		t.Fatal("expected valid scan result")
+	}
+
+	dumpDir := filepath.Join(storageDir, "dump")
+	if err := os.MkdirAll(dumpDir, 0o755); err != nil {
+		t.Fatalf("mkdir dump dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dumpDir, "backup.vma"), []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+	if err := collector.collectPVEStorageMetadataJSONStep(context.Background(), validResult, 0); err != nil {
+		t.Fatalf("collectPVEStorageMetadataJSONStep valid: %v", err)
+	}
+	if err := collector.collectPVEStorageMetadataTextStep(context.Background(), validResult, 0); err != nil {
+		t.Fatalf("collectPVEStorageMetadataTextStep valid: %v", err)
+	}
+	if len(validResult.DirSamples) == 0 || len(validResult.SampleFiles) == 0 || len(validResult.FileSampleLines) == 0 {
+		t.Fatalf("expected metadata samples, got %+v", validResult)
+	}
+
+	missingResult := &pveStorageScanResult{
+		Storage: pveStorageEntry{Name: "missing", Path: filepath.Join(t.TempDir(), "missing"), Type: "dir"},
+		MetaDir: t.TempDir(),
+	}
+	if err := collector.collectPVEStorageMetadataJSONStep(context.Background(), missingResult, 0); err != nil {
+		t.Fatalf("metadata JSON with missing path should write partial report: %v", err)
+	}
+	if err := collector.collectPVEStorageMetadataTextStep(context.Background(), missingResult, 0); err != nil {
+		t.Fatalf("metadata text with missing path should write partial report: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cancelResult := &pveStorageScanResult{Storage: pveStorageEntry{Name: "cancel", Path: storageDir}, MetaDir: t.TempDir()}
+	if err := collector.collectPVEStorageMetadataJSONStep(ctx, cancelResult, 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("metadata JSON canceled = %v", err)
+	}
+	if err := collector.collectPVEStorageMetadataTextStep(ctx, cancelResult, 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("metadata text canceled = %v", err)
+	}
+
+	metaFile := filepath.Join(t.TempDir(), "meta-file")
+	if err := os.WriteFile(metaFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write metaFile: %v", err)
+	}
+	if err := collector.collectPVEStorageMetadataJSONStep(context.Background(), &pveStorageScanResult{
+		Storage: pveStorageEntry{Name: "local", Path: storageDir},
+		MetaDir: metaFile,
+	}, 0); err == nil {
+		t.Fatal("expected metadata JSON write failure")
+	}
+	if err := collector.collectPVEStorageMetadataTextStep(context.Background(), &pveStorageScanResult{
+		Storage: pveStorageEntry{Name: "local", Path: storageDir},
+		MetaDir: metaFile,
+	}, 0); err != nil {
+		t.Fatalf("metadata text write failure is logged, not returned: %v", err)
+	}
+
+	for _, step := range []func(context.Context, *pveStorageScanResult, time.Duration) error{
+		collector.collectPVEStorageMetadataJSONStep,
+		collector.collectPVEStorageMetadataTextStep,
+		collector.collectPVEStorageBackupAnalysisStep,
+	} {
+		if err := step(context.Background(), nil, 0); err != nil {
+			t.Fatalf("nil storage scan result returned error: %v", err)
+		}
+		if err := step(context.Background(), &pveStorageScanResult{SkipRemaining: true}, 0); err != nil {
+			t.Fatalf("skipped storage scan result returned error: %v", err)
+		}
+	}
+
+	if err := collector.writePVEStorageSummary(ctx, []pveStorageEntry{{Name: "local"}}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("writePVEStorageSummary canceled = %v", err)
+	}
+	if err := collector.writePVEStorageSummary(context.Background(), nil); err != nil {
+		t.Fatalf("writePVEStorageSummary empty: %v", err)
+	}
+
+	if _, err := collector.sampleMetadataFileStats(ctx, storageDir, 3, 10, 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("sampleMetadataFileStats canceled = %v", err)
+	}
+	brokenLink := filepath.Join(storageDir, "broken-sample")
+	if err := os.Symlink(filepath.Join(storageDir, "missing-target"), brokenLink); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+	if _, err := collector.sampleMetadataFileStats(context.Background(), storageDir, 3, 10, 0); err != nil {
+		t.Fatalf("sampleMetadataFileStats with broken symlink: %v", err)
+	}
+	if err := collector.writeDatastoreMetadataText(t.TempDir(), pveStorageEntry{Name: "local", Path: storageDir}, []string{""}, nil, "ok", nil, []string{"sample"}, nil); err != nil {
+		t.Fatalf("writeDatastoreMetadataText empty rel sample: %v", err)
+	}
+	if got := relativeDepth("/tmp/base", "/tmp/base/."); got != 0 {
+		t.Fatalf("relativeDepth dot path = %d", got)
+	}
+}
+
+func TestPVEStorageFormattingParsingAndPatternEdges(t *testing.T) {
+	collector := newPVECollector(t)
+	storage := pveStorageEntry{
+		Name:    "local",
+		Path:    "/var/lib/vz",
+		Active:  pveTestBool(true),
+		Enabled: pveTestBool(false),
+		Status:  "weird",
+	}
+	if got := collector.formatPVEStorageRuntime(storage); got != " (active=true enabled=false status=weird)" {
+		t.Fatalf("formatPVEStorageRuntime = %q", got)
+	}
+	if got := collector.formatPVEStorageRuntime(pveStorageEntry{}); got != "" {
+		t.Fatalf("empty formatPVEStorageRuntime = %q", got)
+	}
+	for _, tt := range []struct {
+		storage pveStorageEntry
+		want    string
+	}{
+		{storage: pveStorageEntry{Enabled: pveTestBool(false)}, want: "enabled=false"},
+		{storage: pveStorageEntry{Active: pveTestBool(false)}, want: "active=false"},
+		{storage: pveStorageEntry{Status: "available"}, want: ""},
+		{storage: pveStorageEntry{Status: "inactive"}, want: "status=inactive"},
+		{storage: pveStorageEntry{Status: "error"}, want: "status=error"},
+	} {
+		if got := collector.pveStorageUnavailableReason(tt.storage); got != tt.want {
+			t.Fatalf("pveStorageUnavailableReason(%+v) = %q, want %q", tt.storage, got, tt.want)
+		}
+	}
+
+	parsed, err := parseNodeStorageList([]byte(`[
+		{"storage":"yes-off","active":"yes","enabled":"off"},
+		{"storage":"empty","active":"","enabled":"maybe"},
+		{"storage":"array","active":[],"enabled":{}}
+	]`))
+	if err != nil {
+		t.Fatalf("parseNodeStorageList: %v", err)
+	}
+	if len(parsed) != 3 {
+		t.Fatalf("parsed storage count = %d", len(parsed))
+	}
+	if parsed[0].Active == nil || !*parsed[0].Active || parsed[0].Enabled == nil || *parsed[0].Enabled {
+		t.Fatalf("yes/off bool parsing failed: %+v", parsed[0])
+	}
+	if parsed[1].Active != nil || parsed[1].Enabled != nil || parsed[2].Active != nil || parsed[2].Enabled != nil {
+		t.Fatalf("invalid bool values should be nil: %+v", parsed)
+	}
+
+	if matchPattern("backup.vma", "[") {
+		t.Fatal("invalid glob pattern should not match")
+	}
+
+	analysisDir := t.TempDir()
+	writers := collector.newPatternWriters(pveStorageEntry{Name: "local", Path: "/storage"}, analysisDir, []string{"", "*.vma", "*.vma"})
+	if len(writers) != 1 {
+		t.Fatalf("expected one unique writer, got %d", len(writers))
+	}
+	for _, writer := range writers {
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close writer: %v", err)
+		}
+	}
+	if _, err := newPatternWriter("local", "/storage", filepath.Join(t.TempDir(), "missing"), "*.vma", false); err == nil {
+		t.Fatal("expected newPatternWriter open failure for missing analysis dir")
+	}
+	if writers := collector.newPatternWriters(pveStorageEntry{Name: "local", Path: "/storage"}, filepath.Join(t.TempDir(), "missing"), []string{"*.vma"}); len(writers) != 0 {
+		t.Fatalf("expected no writers when analysis dir is missing, got %d", len(writers))
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.vma")
+	if err := os.WriteFile(outside, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	info, err := os.Stat(outside)
+	if err != nil {
+		t.Fatalf("stat outside file: %v", err)
+	}
+	writer, err := newPatternWriter("local", filepath.Join(t.TempDir(), "storage"), t.TempDir(), "*.vma", false)
+	if err != nil {
+		t.Fatalf("newPatternWriter: %v", err)
+	}
+	if err := writer.Write(outside, info); err != nil {
+		t.Fatalf("writer.Write outside: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close outside: %v", err)
+	}
+	content, err := os.ReadFile(writer.filePath)
+	if err != nil {
+		t.Fatalf("read writer output: %v", err)
+	}
+	if !strings.Contains(string(content), outside) {
+		t.Fatalf("expected fallback absolute path in writer output, got %q", string(content))
+	}
+
+	flushWriter, err := newPatternWriter("local", "/storage", t.TempDir(), "*.vma", false)
+	if err != nil {
+		t.Fatalf("newPatternWriter flush: %v", err)
+	}
+	if err := flushWriter.file.Close(); err != nil {
+		t.Fatalf("close underlying file: %v", err)
+	}
+	if err := flushWriter.Close(); err == nil {
+		t.Fatal("expected flush/close error after closing underlying file")
+	}
+	closeOnlyFile, err := os.Create(filepath.Join(t.TempDir(), "close-only"))
+	if err != nil {
+		t.Fatalf("create close-only file: %v", err)
+	}
+	if err := closeOnlyFile.Close(); err != nil {
+		t.Fatalf("close close-only file: %v", err)
+	}
+	if err := (&patternWriter{file: closeOnlyFile}).Close(); err == nil {
+		t.Fatal("expected close error from already closed file")
+	}
+
+	if err := collector.writePatternSummary(pveStorageEntry{Name: "local"}, filepath.Join(t.TempDir(), "missing"), nil, 0, 0); err == nil {
+		t.Fatal("expected writePatternSummary open failure")
+	}
+	destBase := filepath.Join(t.TempDir(), "file-base")
+	if err := os.WriteFile(destBase, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write destBase: %v", err)
+	}
+	if err := collector.copyBackupSample(context.Background(), outside, filepath.Join(destBase, "samples"), "sample"); err == nil {
+		t.Fatal("expected copyBackupSample ensureDir failure")
+	}
+}
+
+func TestCollectDetailedPVEBackupsAdditionalEdges(t *testing.T) {
+	t.Run("blank include patterns skip writer creation", func(t *testing.T) {
+		storagePath := t.TempDir()
+		cfg := GetDefaultCollectorConfig()
+		cfg.PxarFileIncludePatterns = []string{"   "}
+		collector := NewCollector(newTestLogger(), cfg, t.TempDir(), "pve", false)
+		if err := collector.collectDetailedPVEBackups(context.Background(), pveStorageEntry{Name: "local", Path: storagePath}, t.TempDir(), 0); err != nil {
+			t.Fatalf("collectDetailedPVEBackups blank patterns: %v", err)
+		}
+	})
+
+	t.Run("broken symlink stat errors are skipped", func(t *testing.T) {
+		storagePath := t.TempDir()
+		if err := os.Symlink(filepath.Join(storagePath, "missing-target"), filepath.Join(storagePath, "broken.vma")); err != nil {
+			t.Fatalf("symlink broken backup: %v", err)
+		}
+		collector := NewCollector(newTestLogger(), GetDefaultCollectorConfig(), t.TempDir(), "pve", false)
+		if err := collector.collectDetailedPVEBackups(context.Background(), pveStorageEntry{Name: "local", Path: storagePath}, t.TempDir(), 0); err != nil {
+			t.Fatalf("collectDetailedPVEBackups broken symlink: %v", err)
+		}
+	})
+
+	t.Run("sample directory creation failures are logged", func(t *testing.T) {
+		storagePath := t.TempDir()
+		if err := os.WriteFile(filepath.Join(storagePath, "backup.vma"), []byte("payload"), 0o644); err != nil {
+			t.Fatalf("write backup: %v", err)
+		}
+		tempFile := filepath.Join(t.TempDir(), "temp-file")
+		if err := os.WriteFile(tempFile, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		cfg := GetDefaultCollectorConfig()
+		cfg.BackupSmallPVEBackups = true
+		cfg.MaxPVEBackupSizeBytes = 1024
+		cfg.PVEBackupIncludePattern = "backup"
+		collector := NewCollector(newTestLogger(), cfg, tempFile, "pve", false)
+		if err := collector.collectDetailedPVEBackups(context.Background(), pveStorageEntry{Name: "local", Path: storagePath}, t.TempDir(), 0); err != nil {
+			t.Fatalf("collectDetailedPVEBackups sample dir failure: %v", err)
+		}
+	})
+
+	t.Run("analysis and summary write failures", func(t *testing.T) {
+		storagePath := t.TempDir()
+		if err := os.WriteFile(filepath.Join(storagePath, "backup.vma"), []byte("payload"), 0o644); err != nil {
+			t.Fatalf("write backup: %v", err)
+		}
+		collector := NewCollector(newTestLogger(), GetDefaultCollectorConfig(), t.TempDir(), "pve", false)
+
+		metaFile := filepath.Join(t.TempDir(), "meta-file")
+		if err := os.WriteFile(metaFile, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write meta file: %v", err)
+		}
+		if err := collector.collectDetailedPVEBackups(context.Background(), pveStorageEntry{Name: "local", Path: storagePath}, metaFile, 0); err == nil {
+			t.Fatal("expected analysis directory creation error")
+		}
+
+		metaDir := t.TempDir()
+		analysisDir := filepath.Join(metaDir, "backup_analysis")
+		if err := os.MkdirAll(filepath.Join(analysisDir, "local_backup_summary.txt"), 0o755); err != nil {
+			t.Fatalf("mkdir summary blocker: %v", err)
+		}
+		if err := collector.collectDetailedPVEBackups(context.Background(), pveStorageEntry{Name: "local", Path: storagePath}, metaDir, 0); err == nil {
+			t.Fatal("expected summary write error")
+		}
+	})
+
+	t.Run("exclude patterns skip roots and files", func(t *testing.T) {
+		storagePath := t.TempDir()
+		if err := os.WriteFile(filepath.Join(storagePath, "backup.vma"), []byte("payload"), 0o644); err != nil {
+			t.Fatalf("write backup: %v", err)
+		}
+		cfg := GetDefaultCollectorConfig()
+		cfg.ExcludePatterns = []string{"backup.vma"}
+		collector := NewCollector(newTestLogger(), cfg, t.TempDir(), "pve", false)
+		if err := collector.collectDetailedPVEBackups(context.Background(), pveStorageEntry{Name: "local", Path: storagePath}, t.TempDir(), 0); err != nil {
+			t.Fatalf("collectDetailedPVEBackups file exclude: %v", err)
+		}
+
+		cfg.ExcludePatterns = []string{storagePath}
+		collector = NewCollector(newTestLogger(), cfg, t.TempDir(), "pve", false)
+		if err := collector.collectDetailedPVEBackups(context.Background(), pveStorageEntry{Name: "local", Path: storagePath}, t.TempDir(), 0); err != nil {
+			t.Fatalf("collectDetailedPVEBackups root exclude: %v", err)
+		}
+	})
+}
+
+func TestPVECephAdditionalBranches(t *testing.T) {
+	t.Run("ceph config paths ignore blank custom path", func(t *testing.T) {
+		root := t.TempDir()
+		cfg := GetDefaultCollectorConfig()
+		cfg.SystemRootPrefix = root
+		cfg.PVEConfigPath = "/etc/pve"
+		cfg.CephConfigPath = "   "
+		collector := NewCollector(newTestLogger(), cfg, t.TempDir(), "pve", false)
+		paths := collector.cephConfigPaths()
+		if len(paths) != 2 {
+			t.Fatalf("expected only default ceph paths, got %+v", paths)
+		}
+	})
+
+	for _, tt := range []struct {
+		name       string
+		pvesmOK    bool
+		cephOK     bool
+		pgrepOK    bool
+		wantResult bool
+	}{
+		{name: "storage configured", pvesmOK: true, wantResult: true},
+		{name: "status available", cephOK: true, wantResult: true},
+		{name: "process running", pgrepOK: true, wantResult: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			cfg := GetDefaultCollectorConfig()
+			cfg.SystemRootPrefix = root
+			cfg.PVEConfigPath = "/etc/pve"
+			collector := NewCollectorWithDeps(newTestLogger(), cfg, t.TempDir(), "pve", false, CollectorDeps{
+				LookPath: func(cmd string) (string, error) {
+					switch cmd {
+					case "systemctl":
+						return "/usr/bin/systemctl", nil
+					case "pvesm":
+						if tt.pvesmOK {
+							return "/usr/bin/pvesm", nil
+						}
+					case "ceph":
+						if tt.cephOK {
+							return "/usr/bin/ceph", nil
+						}
+					case "pgrep":
+						if tt.pgrepOK {
+							return "/usr/bin/pgrep", nil
+						}
+					}
+					return "", errors.New("missing")
+				},
+				RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					switch name {
+					case "systemctl":
+						return nil, errors.New("inactive")
+					case "pvesm":
+						return []byte("rbd cephfs"), nil
+					case "ceph":
+						return []byte("HEALTH_OK"), nil
+					case "pgrep":
+						return []byte("1234"), nil
+					default:
+						return nil, errors.New("unexpected command")
+					}
+				},
+			})
+			if got := collector.isCephConfigured(context.Background()); got != tt.wantResult {
+				t.Fatalf("isCephConfigured = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+
+	t.Run("config snapshot returns ensureDir error after detection", func(t *testing.T) {
+		cephDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(cephDir, "ceph.conf"), []byte("fsid = abc"), 0o644); err != nil {
+			t.Fatalf("write ceph.conf: %v", err)
+		}
+		tempFile := filepath.Join(t.TempDir(), "temp-file")
+		if err := os.WriteFile(tempFile, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		cfg := GetDefaultCollectorConfig()
+		cfg.CephConfigPath = cephDir
+		collector := NewCollector(newTestLogger(), cfg, tempFile, "pve", false)
+		if err := collector.collectPVECephConfigSnapshot(context.Background()); err == nil {
+			t.Fatal("expected ceph config ensureDir error")
+		}
+	})
+
+	t.Run("runtime propagates output write error", func(t *testing.T) {
+		collector := newPVECollectorWithDeps(t, CollectorDeps{
+			LookPath: func(cmd string) (string, error) {
+				if cmd == "ceph" {
+					return "/usr/bin/ceph", nil
+				}
+				return "", errors.New("missing")
+			},
+			RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+				return []byte("ok"), nil
+			},
+		})
+		cephDir := collector.pveCephDir()
+		if err := os.MkdirAll(filepath.Join(cephDir, "ceph_osd_df.txt"), 0o755); err != nil {
+			t.Fatalf("mkdir ceph output blocker: %v", err)
+		}
+		if err := collector.collectPVECephRuntime(context.Background()); err == nil {
+			t.Fatal("expected ceph runtime output write error")
+		}
+	})
+
+	t.Run("context and ensureDir errors", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		collector := newPVECollector(t)
+		if err := collector.collectPVECephConfigSnapshot(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectPVECephConfigSnapshot canceled = %v", err)
+		}
+		if err := collector.collectPVECephRuntime(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectPVECephRuntime canceled = %v", err)
+		}
+
+		tempFile := filepath.Join(t.TempDir(), "temp-file")
+		if err := os.WriteFile(tempFile, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		cfg := GetDefaultCollectorConfig()
+		collector = NewCollector(newTestLogger(), cfg, tempFile, "pve", false)
+		if err := collector.collectPVECephRuntime(context.Background()); err == nil {
+			t.Fatal("expected ceph runtime ensureDir error")
+		}
+	})
+}
+
+func TestPVEFinalizeAggregateAndVersionErrorBranches(t *testing.T) {
+	tempFile := filepath.Join(t.TempDir(), "temp-file")
+	if err := os.WriteFile(tempFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	for _, tt := range []struct {
+		name string
+		run  func(*Collector, context.Context) error
+	}{
+		{name: "aliases", run: (*Collector).createPVECoreAliases},
+		{name: "backup history aggregate", run: (*Collector).createPVEBackupHistoryAggregate},
+		{name: "replication aggregate", run: (*Collector).createPVEReplicationAggregate},
+		{name: "version info", run: (*Collector).createPVEVersionInfo},
+	} {
+		t.Run(tt.name+" ensureDir", func(t *testing.T) {
+			collector := NewCollector(newTestLogger(), GetDefaultCollectorConfig(), tempFile, "pve", false)
+			if err := tt.run(collector, context.Background()); err == nil {
+				t.Fatal("expected ensureDir error")
+			}
+		})
+	}
+
+	collector := newPVEHappyCommandCollector(t)
+	baseInfoDir := collector.pveInfoDir()
+	if err := os.MkdirAll(filepath.Join(baseInfoDir, "pve_version.txt"), 0o755); err != nil {
+		t.Fatalf("mkdir version blocker: %v", err)
+	}
+	if err := collector.createPVEVersionInfo(context.Background()); err == nil {
+		t.Fatal("expected version info write error")
+	}
+	if err := collector.writePVEVersionInfo(context.Background(), baseInfoDir); err == nil {
+		t.Fatal("expected writePVEVersionInfo error")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := collector.aggregateBackupHistory(ctx, t.TempDir(), filepath.Join(t.TempDir(), "out.json")); !errors.Is(err, context.Canceled) {
+		t.Fatalf("aggregateBackupHistory canceled = %v", err)
+	}
+	if err := collector.aggregateReplicationStatus(ctx, t.TempDir(), filepath.Join(t.TempDir(), "out.json")); !errors.Is(err, context.Canceled) {
+		t.Fatalf("aggregateReplicationStatus canceled = %v", err)
+	}
+
+	jobsDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(jobsDir, "node_backup_history.json"), 0o755); err != nil {
+		t.Fatalf("mkdir history dir entry: %v", err)
+	}
+	if err := collector.aggregateBackupHistory(context.Background(), jobsDir, filepath.Join(t.TempDir(), "history.json")); err != nil {
+		t.Fatalf("aggregateBackupHistory dir entry: %v", err)
+	}
+
+	repDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repDir, "node_replication_status.json"), 0o755); err != nil {
+		t.Fatalf("mkdir replication dir entry: %v", err)
+	}
+	if err := collector.aggregateReplicationStatus(context.Background(), repDir, filepath.Join(t.TempDir(), "replication.json")); err != nil {
+		t.Fatalf("aggregateReplicationStatus dir entry: %v", err)
+	}
+}
+
+func TestPVEClusterDetectionAdditionalBranches(t *testing.T) {
+	t.Run("multiple nodes with corosync file", func(t *testing.T) {
+		collector := newPVECollectorWithDeps(t, CollectorDeps{
+			LookPath: func(cmd string) (string, error) {
+				return "", errors.New("should not need commands")
+			},
+		})
+		pveRoot := collector.config.PVEConfigPath
+		collector.config.CorosyncConfigPath = filepath.Join(pveRoot, "corosync.conf")
+		if err := os.WriteFile(filepath.Join(pveRoot, "corosync.conf"), []byte("totem {}"), 0o644); err != nil {
+			t.Fatalf("write corosync.conf: %v", err)
+		}
+		for _, node := range []string{"node1", "node2"} {
+			if err := os.MkdirAll(filepath.Join(pveRoot, "nodes", node), 0o755); err != nil {
+				t.Fatalf("mkdir node %s: %v", node, err)
+			}
+		}
+		clustered, err := collector.isClusteredPVE(context.Background())
+		if err != nil {
+			t.Fatalf("isClusteredPVE: %v", err)
+		}
+		if !clustered {
+			t.Fatal("expected clustered from nodes directory with corosync file")
+		}
+	})
+
+	t.Run("active corosync service with corosync file", func(t *testing.T) {
+		collector := newPVECollectorWithDeps(t, CollectorDeps{
+			LookPath: func(cmd string) (string, error) {
+				if cmd == "systemctl" {
+					return "/usr/bin/systemctl", nil
+				}
+				return "", errors.New("missing")
+			},
+			RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+				return []byte("active"), nil
+			},
+		})
+		collector.config.CorosyncConfigPath = filepath.Join(collector.config.PVEConfigPath, "corosync.conf")
+		if err := os.WriteFile(filepath.Join(collector.config.PVEConfigPath, "corosync.conf"), []byte("totem {}"), 0o644); err != nil {
+			t.Fatalf("write corosync.conf: %v", err)
+		}
+		clustered, err := collector.isClusteredPVE(context.Background())
+		if err != nil {
+			t.Fatalf("isClusteredPVE: %v", err)
+		}
+		if !clustered {
+			t.Fatal("expected clustered from active corosync service with config")
+		}
+	})
+
+	t.Run("pvecm generic failure is returned", func(t *testing.T) {
+		collector := newPVECollectorWithDeps(t, CollectorDeps{
+			LookPath: func(cmd string) (string, error) {
+				switch cmd {
+				case "systemctl":
+					return "", errors.New("missing systemctl")
+				case "pvecm":
+					return "/usr/bin/pvecm", nil
+				default:
+					return "", errors.New("missing")
+				}
+			},
+			RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+				return []byte("generic failure"), errors.New("exit status 1")
+			},
+		})
+		if _, err := collector.isClusteredPVE(context.Background()); err == nil {
+			t.Fatal("expected pvecm generic failure")
+		}
+	})
+
+	if isPvecmMissingCorosyncConfig("") {
+		t.Fatal("empty pvecm output should not be treated as missing corosync config")
+	}
+	if newPVECollector(t).isServiceActive(context.Background(), "") {
+		t.Fatal("empty service name should be inactive")
+	}
+}

--- a/internal/backup/collector_pxar_datastore_test.go
+++ b/internal/backup/collector_pxar_datastore_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/tis24dev/proxsave/internal/types"
 )
@@ -55,9 +56,9 @@ func TestWritePxarListReportWithFiles(t *testing.T) {
 	}
 }
 
-func TestRunPBSPXARStepCancelsPendingWorkersOnFirstError(t *testing.T) {
+func TestRunPBSPXARStepContinuesAllDatastoresOnError(t *testing.T) {
 	cfg := GetDefaultCollectorConfig()
-	cfg.PxarDatastoreConcurrency = 1
+	cfg.PxarDatastoreConcurrency = 2
 	c := NewCollector(newTestLogger(), cfg, t.TempDir(), types.ProxmoxBS, false)
 	state := &pbsPxarState{
 		eligible: []pbsDatastore{
@@ -77,7 +78,179 @@ func TestRunPBSPXARStepCancelsPendingWorkersOnFirstError(t *testing.T) {
 	if !errors.Is(err, errBoom) {
 		t.Fatalf("runPBSPXARStep error = %v, want %v", err, errBoom)
 	}
-	if got := atomic.LoadInt32(&calls); got != 1 {
-		t.Fatalf("fn called %d times, want 1", got)
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("fn called %d times, want 3", got)
+	}
+}
+
+func TestRunPBSPXARStepPartialFailure(t *testing.T) {
+	cfg := GetDefaultCollectorConfig()
+	cfg.PxarDatastoreConcurrency = 2
+	c := NewCollector(newTestLogger(), cfg, t.TempDir(), types.ProxmoxBS, false)
+
+	okPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(okPath, "vm"), 0o755); err != nil {
+		t.Fatalf("mkdir vm: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(okPath, "vm", "backup.pxar"), []byte("data"), 0o640); err != nil {
+		t.Fatalf("write pxar: %v", err)
+	}
+
+	metaRoot := filepath.Join(c.tempDir, "var/lib/proxsave-info", "pbs", "pxar", "metadata")
+	if err := os.MkdirAll(metaRoot, 0o755); err != nil {
+		t.Fatalf("mkdir metaRoot: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(metaRoot, "badds"), []byte("file"), 0o640); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+
+	state := &pbsPxarState{
+		eligible: []pbsDatastore{
+			{Name: "badds", Path: t.TempDir()},
+			{Name: "okds", Path: okPath},
+		},
+		metaRoot: metaRoot,
+	}
+
+	var calls int32
+	err := c.runPBSPXARStep(context.Background(), state, func(ctx context.Context, ds pbsDatastore, st *pbsPxarState) error {
+		atomic.AddInt32(&calls, 1)
+		return c.collectPBSPXARMetadataForDatastore(ctx, ds, st)
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "failed to create PXAR metadata directory for badds") {
+		t.Fatalf("runPBSPXARStep error = %v, want broken datastore metadata directory error", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("fn called %d times, want 2", got)
+	}
+
+	okMeta := filepath.Join(metaRoot, "okds", "metadata.json")
+	if _, err := os.Stat(okMeta); err != nil {
+		t.Fatalf("expected okds metadata.json: %v", err)
+	}
+	badMeta := filepath.Join(metaRoot, "badds", "metadata.json")
+	if _, err := os.Stat(badMeta); err == nil {
+		t.Fatalf("expected no metadata for broken datastore badds")
+	}
+}
+
+func TestRunPBSPXARStepRespectsParentContextCancellation(t *testing.T) {
+	cfg := GetDefaultCollectorConfig()
+	cfg.PxarDatastoreConcurrency = 2
+	c := NewCollector(newTestLogger(), cfg, t.TempDir(), types.ProxmoxBS, false)
+	state := &pbsPxarState{
+		eligible: []pbsDatastore{
+			{Name: "ds1", Path: "/tmp/ds1"},
+			{Name: "ds2", Path: "/tmp/ds2"},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := c.runPBSPXARStep(ctx, state, func(context.Context, pbsDatastore, *pbsPxarState) error {
+		t.Fatal("fn should not run when parent context is already canceled")
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runPBSPXARStep error = %v, want context.Canceled", err)
+	}
+}
+
+func TestRunPBSPXARStepPropagatesParentDeadlineExceeded(t *testing.T) {
+	cfg := GetDefaultCollectorConfig()
+	cfg.PxarDatastoreConcurrency = 1
+	c := NewCollector(newTestLogger(), cfg, t.TempDir(), types.ProxmoxBS, false)
+	state := &pbsPxarState{
+		eligible: []pbsDatastore{
+			{Name: "ds1", Path: "/tmp/ds1"},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := c.runPBSPXARStep(ctx, state, func(ctx context.Context, _ pbsDatastore, _ *pbsPxarState) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runPBSPXARStep error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestRunPBSPXARStepKeepsLocalCancellationError(t *testing.T) {
+	cfg := GetDefaultCollectorConfig()
+	cfg.PxarDatastoreConcurrency = 1
+	c := NewCollector(newTestLogger(), cfg, t.TempDir(), types.ProxmoxBS, false)
+	state := &pbsPxarState{
+		eligible: []pbsDatastore{
+			{Name: "ds1", Path: "/tmp/ds1"},
+		},
+	}
+
+	err := c.runPBSPXARStep(context.Background(), state, func(context.Context, pbsDatastore, *pbsPxarState) error {
+		return context.Canceled
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runPBSPXARStep error = %v, want local context.Canceled", err)
+	}
+}
+
+func TestRunPBSPXARStepJoinsParentCancellationWithDatastoreErrors(t *testing.T) {
+	cfg := GetDefaultCollectorConfig()
+	cfg.PxarDatastoreConcurrency = 1
+	c := NewCollector(newTestLogger(), cfg, t.TempDir(), types.ProxmoxBS, false)
+	state := &pbsPxarState{
+		eligible: []pbsDatastore{
+			{Name: "ds1", Path: "/tmp/ds1"},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errBoom := errors.New("pxar failed")
+	err := c.runPBSPXARStep(ctx, state, func(context.Context, pbsDatastore, *pbsPxarState) error {
+		cancel()
+		return errBoom
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runPBSPXARStep error = %v, want context.Canceled", err)
+	}
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("runPBSPXARStep error = %v, want datastore error %v", err, errBoom)
+	}
+}
+
+func TestPBSPXARBrickPropagatesParentCancellation(t *testing.T) {
+	cfg := GetDefaultCollectorConfig()
+	c := NewCollector(newTestLogger(), cfg, t.TempDir(), types.ProxmoxBS, false)
+	state := newCollectionState(c)
+	state.pbs.datastores = []pbsDatastore{
+		{Name: "ds1", Path: t.TempDir()},
+	}
+	brick := requireBrick(t, newPBSPXARRecipe(), brickPBSPXARMetadata)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := brick.Run(ctx, state)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("brick.Run error = %v, want context.Canceled", err)
+	}
+}
+
+func TestHandlePBSPXARStepErrorOnlyPropagatesParentContext(t *testing.T) {
+	c := NewCollector(newTestLogger(), GetDefaultCollectorConfig(), t.TempDir(), types.ProxmoxBS, false)
+
+	if err := c.handlePBSPXARStepError(context.Background(), "local cancel", context.Canceled); err != nil {
+		t.Fatalf("local context.Canceled should remain a best-effort warning, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := c.handlePBSPXARStepError(ctx, "parent cancel", context.Canceled)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("parent context.Canceled should propagate, got %v", err)
 	}
 }

--- a/internal/backup/collector_system_test.go
+++ b/internal/backup/collector_system_test.go
@@ -697,6 +697,2133 @@ func TestBuildNetworkReportAggregatesOutputs(t *testing.T) {
 	// Report is written only to the primary directory (no secondary mirror).
 }
 
+func TestSystemProbeAvailabilityBranches(t *testing.T) {
+	t.Run("systemctl runtime directory", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		if err := os.MkdirAll(filepath.Join(root, "run", "systemd", "system"), 0o755); err != nil {
+			t.Fatalf("mkdir systemd runtime: %v", err)
+		}
+		if ok, reason := collector.systemctlProbeAvailable(); !ok || reason != "" {
+			t.Fatalf("systemctlProbeAvailable() = %t, %q; want true, empty reason", ok, reason)
+		}
+	})
+
+	t.Run("systemctl proc comm", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		if err := os.MkdirAll(filepath.Join(root, "proc", "1"), 0o755); err != nil {
+			t.Fatalf("mkdir proc/1: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "proc", "1", "comm"), []byte("systemd\n"), 0o644); err != nil {
+			t.Fatalf("write comm: %v", err)
+		}
+		if ok, reason := collector.systemctlProbeAvailable(); !ok || reason != "" {
+			t.Fatalf("systemctlProbeAvailable() = %t, %q; want true, empty reason", ok, reason)
+		}
+	})
+
+	t.Run("systemctl container reason", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			DetectUnprivilegedContainer: func() (bool, string) { return true, "lxc test" },
+		})
+		collector.config.SystemRootPrefix = t.TempDir()
+		ok, reason := collector.systemctlProbeAvailable()
+		if ok || !strings.Contains(reason, "lxc test") {
+			t.Fatalf("systemctlProbeAvailable() = %t, %q; want false with container detail", ok, reason)
+		}
+	})
+
+	t.Run("systemctl generic unavailable", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			DetectUnprivilegedContainer: func() (bool, string) { return false, "" },
+		})
+		collector.config.SystemRootPrefix = t.TempDir()
+		ok, reason := collector.systemctlProbeAvailable()
+		if ok || reason != "systemd runtime not detected" {
+			t.Fatalf("systemctlProbeAvailable() = %t, %q; want generic unavailable", ok, reason)
+		}
+	})
+
+	t.Run("sensors availability", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		if ok, reason := collector.sensorsProbeAvailable(); ok || reason == "" {
+			t.Fatalf("sensorsProbeAvailable() = %t, %q; want false with reason", ok, reason)
+		}
+		if err := os.MkdirAll(filepath.Join(root, "sys", "class", "hwmon"), 0o755); err != nil {
+			t.Fatalf("mkdir hwmon: %v", err)
+		}
+		if ok, reason := collector.sensorsProbeAvailable(); !ok || reason != "" {
+			t.Fatalf("sensorsProbeAvailable() = %t, %q; want true", ok, reason)
+		}
+	})
+
+	t.Run("dmidecode availability", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+
+		if os.Geteuid() != 0 {
+			ok, reason := collector.dmidecodeProbeAvailable()
+			if ok || !strings.Contains(reason, "requires root") {
+				t.Fatalf("dmidecodeProbeAvailable() = %t, %q; want non-root reason", ok, reason)
+			}
+			return
+		}
+
+		if ok, reason := collector.dmidecodeProbeAvailable(); ok || reason != "DMI tables not accessible" {
+			t.Fatalf("dmidecodeProbeAvailable() = %t, %q; want inaccessible", ok, reason)
+		}
+		if err := os.MkdirAll(filepath.Join(root, "sys", "firmware", "dmi", "tables"), 0o755); err != nil {
+			t.Fatalf("mkdir dmi tables: %v", err)
+		}
+		if ok, reason := collector.dmidecodeProbeAvailable(); !ok || reason != "" {
+			t.Fatalf("dmidecodeProbeAvailable() tables = %t, %q; want true", ok, reason)
+		}
+
+		collector = newTestCollector(t)
+		root = t.TempDir()
+		collector.config.SystemRootPrefix = root
+		if err := os.MkdirAll(filepath.Join(root, "dev"), 0o755); err != nil {
+			t.Fatalf("mkdir dev: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "dev", "mem"), []byte("mem"), 0o600); err != nil {
+			t.Fatalf("write dev mem: %v", err)
+		}
+		if ok, reason := collector.dmidecodeProbeAvailable(); !ok || reason != "" {
+			t.Fatalf("dmidecodeProbeAvailable() devmem = %t, %q; want true", ok, reason)
+		}
+	})
+}
+
+func TestDetectZFSUsageIndicators(t *testing.T) {
+	collector := newTestCollector(t)
+	root := t.TempDir()
+	collector.config.SystemRootPrefix = root
+
+	writeRootFile(t, root, "proc/mounts", "tank/ds /tank zfs rw 0 0\n", 0o644)
+	writeRootFile(t, root, "etc/zfs/zpool.cache", "cache", 0o600)
+	writeRootFile(t, root, "etc/fstab", "# tank /old zfs defaults 0 0\ntank/home /home zfs defaults 0 0\n", 0o644)
+	writeRootFile(t, root, "etc/pve/storage.cfg", "zfspool: fast\n\tpool tank\n", 0o644)
+
+	ok, indicators := collector.detectZFSUsage()
+	if !ok {
+		t.Fatalf("detectZFSUsage() ok=false, indicators=%q", indicators)
+	}
+	for _, want := range []string{"mounted_zfs", "zpool_cache", "fstab_zfs", "pve_storage_zfspool"} {
+		if !strings.Contains(indicators, want) {
+			t.Fatalf("detectZFSUsage indicators %q missing %s", indicators, want)
+		}
+	}
+
+	collector = newTestCollector(t)
+	collector.config.SystemRootPrefix = t.TempDir()
+	ok, indicators = collector.detectZFSUsage()
+	if ok || indicators != "none" {
+		t.Fatalf("detectZFSUsage() = %t, %q; want false, none", ok, indicators)
+	}
+}
+
+func TestCollectBestEffortProbeBranches(t *testing.T) {
+	t.Run("missing command skips", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+		})
+		err := collector.collectBestEffortProbe(context.Background(), commandSpec("missing"), filepath.Join(t.TempDir(), "out.txt"), "missing", nil)
+		if err != nil {
+			t.Fatalf("collectBestEffortProbe missing command = %v", err)
+		}
+	})
+
+	t.Run("lookpath cancellation wins", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(string) (string, error) {
+				cancel()
+				return "", os.ErrNotExist
+			},
+		})
+		err := collector.collectBestEffortProbe(ctx, commandSpec("missing"), filepath.Join(t.TempDir(), "out.txt"), "missing", nil)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectBestEffortProbe error=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("availability false skips command", func(t *testing.T) {
+		calls := 0
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(string) (string, error) { return "/bin/tool", nil },
+			RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+				calls++
+				return []byte("unexpected"), nil
+			},
+		})
+		err := collector.collectBestEffortProbe(context.Background(), commandSpec("tool"), filepath.Join(t.TempDir(), "out.txt"), "tool", func() (bool, string) {
+			return false, ""
+		})
+		if err != nil {
+			t.Fatalf("collectBestEffortProbe unavailable = %v", err)
+		}
+		if calls != 0 {
+			t.Fatalf("RunCommand calls=%d; want 0", calls)
+		}
+	})
+
+	t.Run("availability cancellation wins", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(string) (string, error) { return "/bin/tool", nil },
+		})
+		err := collector.collectBestEffortProbe(ctx, commandSpec("tool"), filepath.Join(t.TempDir(), "out.txt"), "tool", func() (bool, string) {
+			cancel()
+			return true, ""
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectBestEffortProbe error=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("write failure is best effort", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath:   func(string) (string, error) { return "/bin/tool", nil },
+			RunCommand: func(context.Context, string, ...string) ([]byte, error) { return []byte("ok"), nil },
+		})
+		blocker := filepath.Join(t.TempDir(), "blocked")
+		if err := os.WriteFile(blocker, []byte("file"), 0o644); err != nil {
+			t.Fatalf("write blocker: %v", err)
+		}
+		err := collector.collectBestEffortProbe(context.Background(), commandSpec("tool"), filepath.Join(blocker, "out.txt"), "tool", nil)
+		if err != nil {
+			t.Fatalf("collectBestEffortProbe write failure should be swallowed, got %v", err)
+		}
+	})
+}
+
+func TestCollectSystemStaticCopiesEnabledFiles(t *testing.T) {
+	collector := newTestCollector(t)
+	root := t.TempDir()
+	collector.config.SystemRootPrefix = root
+
+	for _, item := range []struct {
+		rel     string
+		content string
+		mode    os.FileMode
+	}{
+		{"etc/network/interfaces", "auto lo\n", 0o644},
+		{"etc/network/interfaces.d/vmbr0", "iface vmbr0 inet static\n", 0o644},
+		{"etc/cloud/cloud.cfg.d/99-disable-network-config.cfg", "network: {config: disabled}\n", 0o644},
+		{"etc/dnsmasq.d/lxc-vmbr1.conf", "dhcp-range=1.2.3.4\n", 0o644},
+		{"etc/netplan/01-netcfg.yaml", "network: {}\n", 0o644},
+		{"etc/systemd/network/10-eth0.network", "[Match]\nName=eth0\n", 0o644},
+		{"etc/NetworkManager/system-connections/test.nmconnection", "[connection]\n", 0o600},
+		{"etc/hostname", "node1\n", 0o644},
+		{"etc/hosts", "127.0.0.1 localhost\n", 0o644},
+		{"etc/resolv.conf", "nameserver 1.1.1.1\n", 0o644},
+		{"etc/timezone", "UTC\n", 0o644},
+		{"etc/apt/sources.list", "deb http://example stable main\n", 0o644},
+		{"etc/apt/sources.list.d/vendor.list", "deb http://vendor stable main\n", 0o644},
+		{"etc/apt/preferences", "Package: *\n", 0o644},
+		{"etc/apt/preferences.d/pin", "Pin: release *\n", 0o644},
+		{"etc/apt/trusted.gpg.d/vendor.gpg", "key", 0o644},
+		{"etc/apt/apt.conf.d/99local", "APT::Get::Assume-Yes false;\n", 0o644},
+		{"etc/apt/auth.conf.d/private.conf", "machine example\n", 0o600},
+		{"etc/apt/keyrings/vendor.gpg", "key", 0o644},
+		{"etc/apt/listchanges.conf", "[apt]\n", 0o644},
+		{"etc/apt/listchanges.conf.d/local.conf", "[local]\n", 0o644},
+		{"etc/crontab", "* * * * * root true\n", 0o644},
+		{"etc/cron.d/job", "* * * * * root true\n", 0o644},
+		{"etc/cron.daily/job", "#!/bin/sh\n", 0o755},
+		{"etc/cron.hourly/job", "#!/bin/sh\n", 0o755},
+		{"etc/cron.monthly/job", "#!/bin/sh\n", 0o755},
+		{"etc/cron.weekly/job", "#!/bin/sh\n", 0o755},
+		{"var/spool/cron/crontabs/root", "* * * * * true\n", 0o600},
+		{"etc/systemd/system/example.service", "[Service]\n", 0o644},
+		{"etc/logrotate.d/app", "/var/log/app.log {}\n", 0o644},
+		{"etc/ssl/certs/cert.pem", "cert", 0o644},
+		{"etc/ssl/private/key.pem", "key", 0o600},
+		{"etc/ssl/openssl.cnf", "openssl_conf = default\n", 0o644},
+		{"etc/sysctl.conf", "net.ipv4.ip_forward=0\n", 0o644},
+		{"etc/sysctl.d/99.conf", "vm.swappiness=1\n", 0o644},
+		{"etc/modules", "loop\n", 0o644},
+		{"etc/modprobe.d/local.conf", "options loop max_loop=8\n", 0o644},
+		{"etc/zfs/zpool.cache", "cache", 0o600},
+		{"etc/hostid", "hostid", 0o644},
+		{"etc/iptables/rules.v4", "*filter\n", 0o644},
+		{"etc/nftables.d/filter.nft", "table inet filter {}\n", 0o644},
+		{"etc/nftables.conf", "include \"/etc/nftables.d/*.nft\"\n", 0o644},
+	} {
+		writeRootFile(t, root, item.rel, item.content, item.mode)
+	}
+
+	for name, fn := range map[string]func(context.Context) error{
+		"network":        collector.collectSystemNetworkStatic,
+		"identity":       collector.collectSystemIdentityStatic,
+		"apt":            collector.collectSystemAptStatic,
+		"cron":           collector.collectSystemCronStatic,
+		"services":       collector.collectSystemServicesStatic,
+		"logging":        collector.collectSystemLoggingStatic,
+		"ssl":            collector.collectSystemSSLStatic,
+		"sysctl":         collector.collectSystemSysctlStatic,
+		"kernel_modules": collector.collectSystemKernelModuleStatic,
+		"zfs":            collector.collectSystemZFSStatic,
+		"firewall":       collector.collectSystemFirewallStatic,
+	} {
+		if err := fn(context.Background()); err != nil {
+			t.Fatalf("%s static collection failed: %v", name, err)
+		}
+	}
+
+	for _, rel := range []string{
+		"etc/network/interfaces",
+		"etc/network/interfaces.d/vmbr0",
+		"etc/cloud/cloud.cfg.d/99-disable-network-config.cfg",
+		"etc/dnsmasq.d/lxc-vmbr1.conf",
+		"etc/netplan/01-netcfg.yaml",
+		"etc/systemd/network/10-eth0.network",
+		"etc/NetworkManager/system-connections/test.nmconnection",
+		"etc/hostname",
+		"etc/hosts",
+		"etc/resolv.conf",
+		"etc/timezone",
+		"etc/apt/sources.list",
+		"etc/apt/sources.list.d/vendor.list",
+		"etc/apt/preferences",
+		"etc/apt/preferences.d/pin",
+		"etc/apt/trusted.gpg.d/vendor.gpg",
+		"etc/apt/apt.conf.d/99local",
+		"etc/apt/auth.conf.d/private.conf",
+		"etc/apt/keyrings/vendor.gpg",
+		"etc/apt/listchanges.conf",
+		"etc/apt/listchanges.conf.d/local.conf",
+		"etc/crontab",
+		"etc/cron.d/job",
+		"etc/cron.daily/job",
+		"etc/cron.hourly/job",
+		"etc/cron.monthly/job",
+		"etc/cron.weekly/job",
+		"var/spool/cron/crontabs/root",
+		"etc/systemd/system/example.service",
+		"etc/logrotate.d/app",
+		"etc/ssl/certs/cert.pem",
+		"etc/ssl/private/key.pem",
+		"etc/ssl/openssl.cnf",
+		"etc/sysctl.conf",
+		"etc/sysctl.d/99.conf",
+		"etc/modules",
+		"etc/modprobe.d/local.conf",
+		"etc/zfs/zpool.cache",
+		"etc/hostid",
+		"etc/iptables/rules.v4",
+		"etc/nftables.d/filter.nft",
+		"etc/nftables.conf",
+	} {
+		assertFileExists(t, filepath.Join(collector.tempDir, filepath.FromSlash(rel)))
+	}
+}
+
+func TestCollectSystemStaticDisabledAndCanceledBranches(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*Collector)
+		fn        func(*Collector, context.Context) error
+		wantRel   string
+	}{
+		{
+			name:      "network",
+			configure: func(c *Collector) { c.config.BackupNetworkConfigs = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemNetworkStatic(ctx) },
+			wantRel:   "etc/network/interfaces",
+		},
+		{
+			name:      "apt",
+			configure: func(c *Collector) { c.config.BackupAptSources = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemAptStatic(ctx) },
+			wantRel:   "etc/apt/sources.list",
+		},
+		{
+			name:      "cron",
+			configure: func(c *Collector) { c.config.BackupCronJobs = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemCronStatic(ctx) },
+			wantRel:   "etc/crontab",
+		},
+		{
+			name:      "services",
+			configure: func(c *Collector) { c.config.BackupSystemdServices = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemServicesStatic(ctx) },
+			wantRel:   "etc/systemd/system/example.service",
+		},
+		{
+			name:      "ssl",
+			configure: func(c *Collector) { c.config.BackupSSLCerts = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemSSLStatic(ctx) },
+			wantRel:   "etc/ssl/openssl.cnf",
+		},
+		{
+			name:      "sysctl",
+			configure: func(c *Collector) { c.config.BackupSysctlConfig = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemSysctlStatic(ctx) },
+			wantRel:   "etc/sysctl.conf",
+		},
+		{
+			name:      "kernel modules",
+			configure: func(c *Collector) { c.config.BackupKernelModules = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemKernelModuleStatic(ctx) },
+			wantRel:   "etc/modules",
+		},
+		{
+			name:      "zfs",
+			configure: func(c *Collector) { c.config.BackupZFSConfig = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemZFSStatic(ctx) },
+			wantRel:   "etc/hostid",
+		},
+		{
+			name:      "firewall",
+			configure: func(c *Collector) { c.config.BackupFirewallRules = false },
+			fn:        func(c *Collector, ctx context.Context) error { return c.collectSystemFirewallStatic(ctx) },
+			wantRel:   "etc/nftables.conf",
+		},
+	} {
+		t.Run(tc.name+"_disabled", func(t *testing.T) {
+			collector := newTestCollector(t)
+			root := t.TempDir()
+			collector.config.SystemRootPrefix = root
+			writeRootFile(t, root, tc.wantRel, "data\n", 0o644)
+			tc.configure(collector)
+			if err := tc.fn(collector, context.Background()); err != nil {
+				t.Fatalf("disabled branch returned error: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(collector.tempDir, filepath.FromSlash(tc.wantRel))); !os.IsNotExist(err) {
+				t.Fatalf("expected disabled branch not to copy %s, stat err=%v", tc.wantRel, err)
+			}
+		})
+
+		t.Run(tc.name+"_canceled", func(t *testing.T) {
+			collector := newTestCollector(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			if err := tc.fn(collector, ctx); !errors.Is(err, context.Canceled) {
+				t.Fatalf("canceled branch error=%v; want context.Canceled", err)
+			}
+		})
+	}
+}
+
+func TestCollectSystemStaticMissingSourceBranches(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   func(*Collector, context.Context) error
+	}{
+		{name: "network", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemNetworkStatic(ctx) }},
+		{name: "identity", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemIdentityStatic(ctx) }},
+		{name: "apt", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemAptStatic(ctx) }},
+		{name: "cron", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemCronStatic(ctx) }},
+		{name: "services", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemServicesStatic(ctx) }},
+		{name: "logging", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemLoggingStatic(ctx) }},
+		{name: "ssl", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemSSLStatic(ctx) }},
+		{name: "sysctl", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemSysctlStatic(ctx) }},
+		{name: "kernel modules", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemKernelModuleStatic(ctx) }},
+		{name: "zfs", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemZFSStatic(ctx) }},
+		{name: "firewall", fn: func(c *Collector, ctx context.Context) error { return c.collectSystemFirewallStatic(ctx) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			collector := newTestCollector(t)
+			collector.config.SystemRootPrefix = t.TempDir()
+			if err := tc.fn(collector, context.Background()); err != nil {
+				t.Fatalf("missing static sources should be tolerated: %v", err)
+			}
+		})
+	}
+}
+
+func TestCollectSystemStaticCopyErrorBranches(t *testing.T) {
+	collector := newTestCollector(t)
+	root := t.TempDir()
+	collector.config.SystemRootPrefix = root
+
+	for _, path := range []struct {
+		rel string
+		dir bool
+	}{
+		{rel: "etc/network/interfaces"},
+		{rel: "etc/network/interfaces.d", dir: true},
+		{rel: "etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"},
+		{rel: "etc/dnsmasq.d/lxc-vmbr1.conf"},
+		{rel: "etc/netplan", dir: true},
+		{rel: "etc/systemd/network", dir: true},
+		{rel: "etc/NetworkManager/system-connections", dir: true},
+		{rel: "etc/hostname"},
+		{rel: "etc/hosts"},
+		{rel: "etc/resolv.conf"},
+		{rel: "etc/timezone"},
+		{rel: "etc/apt/sources.list"},
+		{rel: "etc/apt/sources.list.d", dir: true},
+		{rel: "etc/apt/preferences"},
+		{rel: "etc/apt/preferences.d", dir: true},
+		{rel: "etc/apt/trusted.gpg.d", dir: true},
+		{rel: "etc/apt/apt.conf.d", dir: true},
+		{rel: "etc/apt/auth.conf.d", dir: true},
+		{rel: "etc/apt/keyrings", dir: true},
+		{rel: "etc/apt/listchanges.conf"},
+		{rel: "etc/apt/listchanges.conf.d", dir: true},
+		{rel: "etc/crontab"},
+		{rel: "etc/cron.d", dir: true},
+		{rel: "etc/cron.daily", dir: true},
+		{rel: "etc/cron.hourly", dir: true},
+		{rel: "etc/cron.monthly", dir: true},
+		{rel: "etc/cron.weekly", dir: true},
+		{rel: "var/spool/cron/crontabs", dir: true},
+		{rel: "etc/systemd/system", dir: true},
+		{rel: "etc/logrotate.d", dir: true},
+		{rel: "etc/ssl/certs", dir: true},
+		{rel: "etc/ssl/private", dir: true},
+		{rel: "etc/ssl/openssl.cnf"},
+		{rel: "etc/sysctl.conf"},
+		{rel: "etc/sysctl.d", dir: true},
+		{rel: "etc/modules"},
+		{rel: "etc/modprobe.d", dir: true},
+		{rel: "etc/zfs", dir: true},
+		{rel: "etc/hostid"},
+		{rel: "etc/iptables", dir: true},
+		{rel: "etc/nftables.d", dir: true},
+		{rel: "etc/nftables.conf"},
+	} {
+		prepareStaticCopyErrorPath(t, collector, root, path.rel, path.dir)
+	}
+
+	for name, fn := range map[string]func(context.Context) error{
+		"network":        collector.collectSystemNetworkStatic,
+		"identity":       collector.collectSystemIdentityStatic,
+		"apt":            collector.collectSystemAptStatic,
+		"cron":           collector.collectSystemCronStatic,
+		"services":       collector.collectSystemServicesStatic,
+		"logging":        collector.collectSystemLoggingStatic,
+		"ssl":            collector.collectSystemSSLStatic,
+		"sysctl":         collector.collectSystemSysctlStatic,
+		"kernel_modules": collector.collectSystemKernelModuleStatic,
+		"zfs":            collector.collectSystemZFSStatic,
+		"firewall":       collector.collectSystemFirewallStatic,
+	} {
+		if err := fn(context.Background()); err != nil {
+			t.Fatalf("%s static copy error branches should be tolerated: %v", name, err)
+		}
+	}
+}
+
+func TestCollectSystemRuntimeBranchCoverage(t *testing.T) {
+	t.Run("zfs disabled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.BackupZFSConfig = false
+		commandsDir := t.TempDir()
+		if err := collector.collectSystemZFSRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemZFSRuntime disabled: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(commandsDir, "zfs")); !os.IsNotExist(err) {
+			t.Fatalf("expected zfs dir absent when disabled, stat err=%v", err)
+		}
+	})
+
+	t.Run("zfs detected and command outputs", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				switch name {
+				case "zpool", "zfs":
+					return "/usr/sbin/" + name, nil
+				default:
+					return "", os.ErrNotExist
+				}
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(name + " " + strings.Join(args, " ") + "\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/fstab", "tank/home /home zfs defaults 0 0\n", 0o644)
+		commandsDir := t.TempDir()
+
+		if err := collector.collectSystemZFSRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemZFSRuntime detected: %v", err)
+		}
+		for _, name := range []string{"zpool_status.txt", "zpool_list.txt", "zfs_list.txt", "zfs_get_all.txt"} {
+			assertFileExists(t, filepath.Join(commandsDir, "zfs", name))
+		}
+	})
+
+	t.Run("zfs info dir blocked", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/fstab", "tank/home /home zfs defaults 0 0\n", 0o644)
+		commandsDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(commandsDir, "zfs"), []byte("blocker"), 0o644); err != nil {
+			t.Fatalf("write zfs blocker: %v", err)
+		}
+		if err := collector.collectSystemZFSRuntime(context.Background(), commandsDir); err == nil {
+			t.Fatalf("expected zfs dir blocker error")
+		}
+	})
+
+	t.Run("lvm command matrix", func(t *testing.T) {
+		calls := make(map[string]int)
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				switch name {
+				case "pvs", "vgs", "lvs":
+					return "/usr/sbin/" + name, nil
+				default:
+					return "", os.ErrNotExist
+				}
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				calls[name]++
+				return []byte(name + "\n"), nil
+			},
+		})
+		commandsDir := t.TempDir()
+		if err := collector.collectSystemLVMRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemLVMRuntime: %v", err)
+		}
+		for _, name := range []string{"pvs", "vgs", "lvs"} {
+			if calls[name] != 1 {
+				t.Fatalf("%s calls=%d; want 1", name, calls[name])
+			}
+		}
+		for _, name := range []string{"lvm_pvs.txt", "lvm_vgs.txt", "lvm_lvs.txt"} {
+			assertFileExists(t, filepath.Join(commandsDir, name))
+		}
+	})
+
+	t.Run("lvm missing commands", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+		})
+		commandsDir := t.TempDir()
+		if err := collector.collectSystemLVMRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemLVMRuntime missing commands: %v", err)
+		}
+		if entries, err := os.ReadDir(commandsDir); err != nil {
+			t.Fatalf("read commands dir: %v", err)
+		} else if len(entries) != 0 {
+			t.Fatalf("expected no LVM outputs when commands missing, got %d entries", len(entries))
+		}
+	})
+}
+
+func TestCollectConfigFileBranches(t *testing.T) {
+	t.Run("empty path skips", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.ConfigFilePath = ""
+		if err := collector.collectConfigFile(context.Background()); err != nil {
+			t.Fatalf("collectConfigFile empty: %v", err)
+		}
+	})
+
+	t.Run("absolute path uses system root", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		collector.config.ConfigFilePath = "/etc/proxsave/backup.env"
+		writeRootFile(t, root, "etc/proxsave/backup.env", "BACKUP=true\n", 0o600)
+		if err := collector.collectConfigFile(context.Background()); err != nil {
+			t.Fatalf("collectConfigFile absolute: %v", err)
+		}
+		assertFileExists(t, filepath.Join(collector.tempDir, "etc/proxsave/backup.env"))
+	})
+
+	t.Run("missing file tolerated", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.SystemRootPrefix = t.TempDir()
+		collector.config.ConfigFilePath = "/etc/proxsave/missing.env"
+		if err := collector.collectConfigFile(context.Background()); err != nil {
+			t.Fatalf("collectConfigFile missing should be tolerated: %v", err)
+		}
+	})
+
+	t.Run("copy error returned", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		collector.config.ConfigFilePath = "/etc/proxsave/backup.env"
+		writeRootFile(t, root, "etc/proxsave/backup.env", "BACKUP=true\n", 0o600)
+		if err := os.WriteFile(filepath.Join(collector.tempDir, "etc"), []byte("dest blocker"), 0o644); err != nil {
+			t.Fatalf("write destination blocker: %v", err)
+		}
+		if err := collector.collectConfigFile(context.Background()); err == nil {
+			t.Fatalf("expected collectConfigFile to return destination copy error")
+		}
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectConfigFile(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectConfigFile canceled=%v; want context.Canceled", err)
+		}
+	})
+}
+
+func TestCollectScriptRepositoryCopiesAndSkipsRuntimeDirs(t *testing.T) {
+	collector := newTestCollector(t)
+	repo := t.TempDir()
+	collector.config.ScriptRepositoryPath = repo
+
+	writeFileAt(t, filepath.Join(repo, "keep.sh"), "#!/bin/sh\n")
+	writeFileAt(t, filepath.Join(repo, "nested", "config.env"), "A=1\n")
+	writeFileAt(t, filepath.Join(repo, "backup", "skip.tar"), "backup\n")
+	writeFileAt(t, filepath.Join(repo, "log", "skip.log"), "log\n")
+
+	if err := collector.collectScriptRepository(context.Background()); err != nil {
+		t.Fatalf("collectScriptRepository: %v", err)
+	}
+
+	target := collector.proxsaveInfoDir("script-repository", filepath.Base(repo))
+	assertFileExists(t, filepath.Join(target, "keep.sh"))
+	assertFileExists(t, filepath.Join(target, "nested", "config.env"))
+	if _, err := os.Stat(filepath.Join(target, "backup", "skip.tar")); !os.IsNotExist(err) {
+		t.Fatalf("expected backup dir skipped, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "log", "skip.log")); !os.IsNotExist(err) {
+		t.Fatalf("expected log dir skipped, stat err=%v", err)
+	}
+}
+
+func TestCollectScriptRepositorySkipAndCancelBranches(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "empty", path: ""},
+		{name: "missing", path: filepath.Join(t.TempDir(), "missing")},
+		{name: "file", path: filepath.Join(t.TempDir(), "repo-file")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			collector := newTestCollector(t)
+			if tc.name == "file" {
+				writeFileAt(t, tc.path, "not a dir\n")
+			}
+			collector.config.ScriptRepositoryPath = tc.path
+			if err := collector.collectScriptRepository(context.Background()); err != nil {
+				t.Fatalf("collectScriptRepository %s: %v", tc.name, err)
+			}
+		})
+	}
+
+	t.Run("canceled during walk", func(t *testing.T) {
+		collector := newTestCollector(t)
+		repo := t.TempDir()
+		collector.config.ScriptRepositoryPath = repo
+		writeFileAt(t, filepath.Join(repo, "file.txt"), "data\n")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectScriptRepository(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectScriptRepository canceled=%v; want context.Canceled", err)
+		}
+	})
+}
+
+func TestCollectSSHKeysCopiesRootAndUsers(t *testing.T) {
+	collector := newTestCollector(t)
+	root := t.TempDir()
+	collector.config.SystemRootPrefix = root
+
+	writeRootFile(t, root, "etc/ssh/sshd_config", "Port 22\n", 0o600)
+	writeRootFile(t, root, "root/.ssh/id_rsa", "root-key\n", 0o600)
+	writeRootFile(t, root, "home/alice/.ssh/id_ed25519", "alice-key\n", 0o600)
+	writeRootFile(t, root, "home/bob/note.txt", "not ssh\n", 0o644)
+	writeRootFile(t, root, "home/README", "top-level file\n", 0o644)
+
+	if err := collector.collectSSHKeys(context.Background()); err != nil {
+		t.Fatalf("collectSSHKeys: %v", err)
+	}
+
+	assertFileExists(t, filepath.Join(collector.tempDir, "etc/ssh/sshd_config"))
+	assertFileExists(t, filepath.Join(collector.tempDir, "root/.ssh/id_rsa"))
+	assertFileExists(t, filepath.Join(collector.tempDir, "home/alice/.ssh/id_ed25519"))
+	if _, err := os.Stat(filepath.Join(collector.tempDir, "home/bob/.ssh")); !os.IsNotExist(err) {
+		t.Fatalf("expected bob .ssh absent, stat err=%v", err)
+	}
+}
+
+func TestCollectSSHKeysMissingAndCanceledBranches(t *testing.T) {
+	t.Run("canceled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectSSHKeys(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectSSHKeys canceled=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("missing sources are tolerated", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.SystemRootPrefix = t.TempDir()
+		if err := collector.collectSSHKeys(context.Background()); err != nil {
+			t.Fatalf("collectSSHKeys missing sources: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(collector.tempDir, "etc/ssh")); !os.IsNotExist(err) {
+			t.Fatalf("expected missing etc ssh skipped, stat err=%v", err)
+		}
+	})
+}
+
+func TestCollectRootAndUserHomeAdditionalBranches(t *testing.T) {
+	t.Run("root missing skips", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.SystemRootPrefix = t.TempDir()
+		if err := collector.collectRootHome(context.Background()); err != nil {
+			t.Fatalf("collectRootHome missing root: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(collector.tempDir, "root")); !os.IsNotExist(err) {
+			t.Fatalf("expected no root output when root is missing, stat err=%v", err)
+		}
+	})
+
+	t.Run("root canceled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectRootHome(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectRootHome canceled=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("root target blocker returns error", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "root/.bashrc", "alias ll='ls -l'\n", 0o644)
+		if err := os.WriteFile(filepath.Join(collector.tempDir, "root"), []byte("blocker"), 0o644); err != nil {
+			t.Fatalf("write root blocker: %v", err)
+		}
+		if err := collector.collectRootHome(context.Background()); err == nil {
+			t.Fatalf("expected root target blocker error")
+		}
+	})
+
+	t.Run("root copies profiles histories config and ssh", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		collector.config.BackupSSHKeys = true
+
+		writeRootFile(t, root, "root/.bashrc", "alias ll='ls -l'\n", 0o644)
+		writeRootFile(t, root, "root/.bash_history", "ls\n", 0o600)
+		writeRootFile(t, root, "root/.bash_history-1", "cd /\n", 0o600)
+		writeRootFile(t, root, "root/.ssh/id_rsa", "key\n", 0o600)
+		writeRootFile(t, root, "root/.config/tool/config.json", "{}\n", 0o600)
+		writeRootFile(t, root, "root/.config/.wrangler/logs/wrangler.log", "log\n", 0o600)
+
+		if err := collector.collectRootHome(context.Background()); err != nil {
+			t.Fatalf("collectRootHome: %v", err)
+		}
+		for _, rel := range []string{
+			"root/.bashrc",
+			"root/.bash_history",
+			"root/.bash_history-1",
+			"root/.ssh/id_rsa",
+			"root/.config/tool/config.json",
+			"root/.config/.wrangler/logs/wrangler.log",
+		} {
+			assertFileExists(t, filepath.Join(collector.tempDir, filepath.FromSlash(rel)))
+		}
+	})
+
+	t.Run("root skips ssh when disabled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		collector.config.BackupSSHKeys = false
+		writeRootFile(t, root, "root/.ssh/id_rsa", "key\n", 0o600)
+
+		if err := collector.collectRootHome(context.Background()); err != nil {
+			t.Fatalf("collectRootHome: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(collector.tempDir, "root/.ssh")); !os.IsNotExist(err) {
+			t.Fatalf("expected root .ssh skipped when disabled, stat err=%v", err)
+		}
+	})
+
+	t.Run("user homes missing skips", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.SystemRootPrefix = t.TempDir()
+		if err := collector.collectUserHomes(context.Background()); err != nil {
+			t.Fatalf("collectUserHomes missing home: %v", err)
+		}
+	})
+
+	t.Run("user homes canceled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectUserHomes(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectUserHomes canceled=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("user homes unreadable path returns error", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "home", "not a directory\n", 0o644)
+		if err := collector.collectUserHomes(context.Background()); err == nil {
+			t.Fatalf("expected /home file to return read error")
+		}
+	})
+
+	t.Run("user homes copy file entry and ssh when enabled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		collector.config.BackupSSHKeys = true
+
+		writeRootFile(t, root, "home/alice/.ssh/id_ed25519", "key\n", 0o600)
+		writeRootFile(t, root, "home/alice/note.txt", "note\n", 0o644)
+		writeRootFile(t, root, "home/README", "top-level file\n", 0o644)
+
+		if err := collector.collectUserHomes(context.Background()); err != nil {
+			t.Fatalf("collectUserHomes: %v", err)
+		}
+		for _, rel := range []string{
+			"home/alice/.ssh/id_ed25519",
+			"home/alice/note.txt",
+			"home/README",
+		} {
+			assertFileExists(t, filepath.Join(collector.tempDir, filepath.FromSlash(rel)))
+		}
+	})
+
+	t.Run("user homes exclude ssh when disabled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		collector.config.BackupSSHKeys = false
+		writeRootFile(t, root, "home/alice/.ssh/id_ed25519", "key\n", 0o600)
+		writeRootFile(t, root, "home/alice/note.txt", "note\n", 0o644)
+
+		if err := collector.collectUserHomes(context.Background()); err != nil {
+			t.Fatalf("collectUserHomes: %v", err)
+		}
+		assertFileExists(t, filepath.Join(collector.tempDir, "home/alice/note.txt"))
+		if _, err := os.Stat(filepath.Join(collector.tempDir, "home/alice/.ssh")); !os.IsNotExist(err) {
+			t.Fatalf("expected alice .ssh skipped when disabled, stat err=%v", err)
+		}
+	})
+}
+
+func TestCollectKernelAndHardwareInfoBranches(t *testing.T) {
+	t.Run("kernel command failure is non critical", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "cat" {
+					return "/bin/cat", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				if len(args) == 1 && strings.HasSuffix(args[0], "/proc/version") {
+					return []byte("broken version"), errors.New("version failed")
+				}
+				return []byte("BOOT_IMAGE=/vmlinuz\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "proc/cmdline", "BOOT_IMAGE=/vmlinuz\n", 0o644)
+		writeRootFile(t, root, "proc/version", "Linux version\n", 0o644)
+		if err := collector.collectKernelInfo(context.Background()); err != nil {
+			t.Fatalf("non-critical kernel version command failure should be swallowed: %v", err)
+		}
+		assertFileExists(t, filepath.Join(collector.proxsaveCommandsDir("system"), "kernel_cmdline.txt"))
+		if _, err := os.Stat(filepath.Join(collector.proxsaveCommandsDir("system"), "kernel_version.txt")); !os.IsNotExist(err) {
+			t.Fatalf("expected no kernel_version output after command failure, stat err=%v", err)
+		}
+	})
+
+	t.Run("kernel success and write failure", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "cat" {
+					return "/bin/cat", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(filepath.Base(args[0]) + "\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "proc/cmdline", "BOOT_IMAGE=/vmlinuz\n", 0o644)
+		writeRootFile(t, root, "proc/version", "Linux version\n", 0o644)
+
+		if err := collector.collectKernelInfo(context.Background()); err != nil {
+			t.Fatalf("collectKernelInfo success: %v", err)
+		}
+		assertFileExists(t, filepath.Join(collector.proxsaveCommandsDir("system"), "kernel_cmdline.txt"))
+		assertFileExists(t, filepath.Join(collector.proxsaveCommandsDir("system"), "kernel_version.txt"))
+
+		collector = newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "cat" {
+					return "/bin/cat", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(filepath.Base(args[0]) + "\n"), nil
+			},
+		})
+		collector.config.SystemRootPrefix = root
+		commandsDir := collector.proxsaveCommandsDir("system")
+		if err := os.MkdirAll(commandsDir, 0o755); err != nil {
+			t.Fatalf("mkdir commands dir: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(commandsDir, "kernel_version.txt"), 0o755); err != nil {
+			t.Fatalf("mkdir kernel_version blocker: %v", err)
+		}
+		if err := collector.collectKernelInfo(context.Background()); err == nil {
+			t.Fatalf("expected kernel version write failure")
+		}
+	})
+
+	t.Run("hardware probes success where available", func(t *testing.T) {
+		calls := make(map[string]int)
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				switch name {
+				case "dmidecode", "sensors", "smartctl":
+					return "/usr/sbin/" + name, nil
+				default:
+					return "", os.ErrNotExist
+				}
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				calls[name]++
+				return []byte(name + "\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "sys/class/hwmon/hwmon0/name", "coretemp\n", 0o644)
+		writeRootFile(t, root, "usr/sbin/smartctl", "#!/bin/sh\n", 0o755)
+		if os.Geteuid() == 0 {
+			if err := os.MkdirAll(filepath.Join(root, "sys", "firmware", "dmi", "tables"), 0o755); err != nil {
+				t.Fatalf("mkdir dmi tables: %v", err)
+			}
+		}
+
+		if err := collector.collectHardwareInfo(context.Background()); err != nil {
+			t.Fatalf("collectHardwareInfo: %v", err)
+		}
+		if os.Geteuid() == 0 && calls["dmidecode"] != 1 {
+			t.Fatalf("dmidecode calls=%d; want 1 when root", calls["dmidecode"])
+		}
+		if calls["sensors"] != 1 {
+			t.Fatalf("sensors calls=%d; want 1", calls["sensors"])
+		}
+		if calls["smartctl"] != 1 {
+			t.Fatalf("smartctl calls=%d; want 1", calls["smartctl"])
+		}
+		assertFileExists(t, filepath.Join(collector.proxsaveCommandsDir("system"), "sensors.txt"))
+		assertFileExists(t, filepath.Join(collector.proxsaveCommandsDir("system"), "smartctl_scan.txt"))
+	})
+}
+
+func TestCollectSystemAdditionalRuntimeBranches(t *testing.T) {
+	t.Run("runtime leases canceled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectSystemRuntimeLeases(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectSystemRuntimeLeases canceled=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("runtime leases copies available directories", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "var/lib/dhcp/lease", "lease\n", 0o644)
+		writeRootFile(t, root, "var/lib/NetworkManager/lease", "lease\n", 0o644)
+		writeRootFile(t, root, "run/systemd/netif/leases/2", "lease\n", 0o644)
+
+		if err := collector.collectSystemRuntimeLeases(context.Background()); err != nil {
+			t.Fatalf("collectSystemRuntimeLeases: %v", err)
+		}
+		for _, path := range []string{
+			filepath.Join(collector.proxsaveRuntimeDir("var/lib/dhcp"), "lease"),
+			filepath.Join(collector.proxsaveRuntimeDir("var/lib/NetworkManager"), "lease"),
+			filepath.Join(collector.proxsaveRuntimeDir("run/systemd/netif/leases"), "2"),
+		} {
+			assertFileExists(t, path)
+		}
+	})
+
+	t.Run("core runtime critical command missing", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+		})
+		if err := collector.collectSystemCoreRuntime(context.Background(), t.TempDir()); err == nil {
+			t.Fatalf("expected critical os-release command failure")
+		}
+	})
+
+	t.Run("core runtime hostname missing is tolerated", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				switch name {
+				case "cat", "uname":
+					return "/bin/" + name, nil
+				default:
+					return "", os.ErrNotExist
+				}
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(name + " " + strings.Join(args, " ") + "\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/os-release", "ID=debian\n", 0o644)
+		commandsDir := t.TempDir()
+
+		if err := collector.collectSystemCoreRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemCoreRuntime: %v", err)
+		}
+		assertFileExists(t, filepath.Join(commandsDir, "os_release.txt"))
+		assertFileExists(t, filepath.Join(commandsDir, "uname.txt"))
+		if _, err := os.Stat(filepath.Join(commandsDir, "hostname.txt")); !os.IsNotExist(err) {
+			t.Fatalf("expected missing hostname command to produce no file, stat err=%v", err)
+		}
+	})
+
+	t.Run("network primary write failures", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "ip" {
+					return "/usr/sbin/ip", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(strings.Join(args, " ") + "\n"), nil
+			},
+		})
+		for _, tc := range []struct {
+			name    string
+			blocker string
+			fn      func(*Collector, context.Context, string) error
+		}{
+			{
+				name:    "addr",
+				blocker: "ip_addr.txt",
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemNetworkAddrRuntime(ctx, dir)
+				},
+			},
+			{
+				name:    "rules",
+				blocker: "ip_rule.txt",
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemNetworkRulesRuntime(ctx, dir)
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				commandsDir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(commandsDir, tc.blocker), 0o755); err != nil {
+					t.Fatalf("mkdir blocker: %v", err)
+				}
+				if err := tc.fn(collector, context.Background(), commandsDir); err == nil {
+					t.Fatalf("expected %s write failure", tc.name)
+				}
+			})
+		}
+	})
+
+	t.Run("network neighbors ipv6 write failure", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "ip" {
+					return "/usr/sbin/ip", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(strings.Join(args, " ") + "\n"), nil
+			},
+		})
+		commandsDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(commandsDir, "ip6_neigh.txt"), 0o755); err != nil {
+			t.Fatalf("mkdir blocker: %v", err)
+		}
+		if err := collector.collectSystemNetworkNeighborsRuntime(context.Background(), commandsDir); err == nil {
+			t.Fatalf("expected IPv6 neighbor write failure")
+		}
+		assertFileExists(t, filepath.Join(commandsDir, "ip_neigh.txt"))
+	})
+
+	t.Run("network inventory write failure is logged and swallowed", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		if err := os.MkdirAll(filepath.Join(root, "sys/class/net/eth0"), 0o755); err != nil {
+			t.Fatalf("mkdir sys net: %v", err)
+		}
+		writeRootFile(t, root, "sys/class/net/eth0/address", "02:00:00:00:00:01\n", 0o644)
+		commandsDir := filepath.Join(t.TempDir(), "commands-file")
+		if err := os.WriteFile(commandsDir, []byte("blocker"), 0o644); err != nil {
+			t.Fatalf("write commands blocker: %v", err)
+		}
+		if err := collector.collectSystemNetworkInventoryRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("inventory wrapper should swallow write error: %v", err)
+		}
+	})
+
+	t.Run("network bonding canceled and copies files", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectSystemNetworkBondingRuntime(ctx, t.TempDir()); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectSystemNetworkBondingRuntime canceled=%v; want context.Canceled", err)
+		}
+
+		collector = newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "proc/net/bonding/bond0", "bonding\n", 0o644)
+		if err := os.MkdirAll(filepath.Join(root, "proc/net/bonding/subdir"), 0o755); err != nil {
+			t.Fatalf("mkdir bonding subdir: %v", err)
+		}
+		commandsDir := t.TempDir()
+		if err := collector.collectSystemNetworkBondingRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemNetworkBondingRuntime: %v", err)
+		}
+		assertFileExists(t, filepath.Join(commandsDir, "bonding_bond0.txt"))
+		if _, err := os.Stat(filepath.Join(commandsDir, "bonding_subdir.txt")); !os.IsNotExist(err) {
+			t.Fatalf("expected bonding subdir skipped, stat err=%v", err)
+		}
+	})
+
+	t.Run("storage and compute write failures", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				switch name {
+				case "df", "mount", "free", "lscpu", "lspci", "lsusb", "lsblk":
+					return "/usr/bin/" + name, nil
+				default:
+					return "", os.ErrNotExist
+				}
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(name + "\n"), nil
+			},
+		})
+		for _, tc := range []struct {
+			name    string
+			blocker string
+			fn      func(*Collector, context.Context, string) error
+		}{
+			{
+				name:    "mounts second command",
+				blocker: "mount.txt",
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemStorageMountsRuntime(ctx, dir)
+				},
+			},
+			{
+				name:    "block devices primary",
+				blocker: "lsblk.txt",
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemStorageBlockDevicesRuntime(ctx, dir)
+				},
+			},
+			{
+				name:    "memory cpu second command",
+				blocker: "lscpu.txt",
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemComputeMemoryCPURuntime(ctx, dir)
+				},
+			},
+			{
+				name:    "bus inventory primary",
+				blocker: "lspci.txt",
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemComputeBusInventoryRuntime(ctx, dir)
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				commandsDir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(commandsDir, tc.blocker), 0o755); err != nil {
+					t.Fatalf("mkdir blocker: %v", err)
+				}
+				if err := tc.fn(collector, context.Background(), commandsDir); err == nil {
+					t.Fatalf("expected %s write failure", tc.name)
+				}
+			})
+		}
+	})
+
+	t.Run("services runtime disabled unavailable and available", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.BackupSystemdServices = false
+		commandsDir := t.TempDir()
+		if err := collector.collectSystemServicesRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemServicesRuntime disabled: %v", err)
+		}
+		if entries, err := os.ReadDir(commandsDir); err != nil {
+			t.Fatalf("read commands dir: %v", err)
+		} else if len(entries) != 0 {
+			t.Fatalf("expected disabled services runtime to write no files, got %d", len(entries))
+		}
+
+		calls := 0
+		collector = newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "systemctl" {
+					return "/usr/bin/systemctl", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				calls++
+				return []byte("unexpected\n"), nil
+			},
+			DetectUnprivilegedContainer: func() (bool, string) { return false, "" },
+		})
+		collector.config.SystemRootPrefix = t.TempDir()
+		commandsDir = t.TempDir()
+		if err := collector.collectSystemServicesRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemServicesRuntime unavailable: %v", err)
+		}
+		if calls != 0 {
+			t.Fatalf("systemctl calls=%d; want 0 when runtime unavailable", calls)
+		}
+
+		collector = newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "systemctl" {
+					return "/usr/bin/systemctl", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(strings.Join(args, " ") + "\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "proc/1/comm", "systemd\n", 0o644)
+		commandsDir = t.TempDir()
+		if err := collector.collectSystemServicesRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemServicesRuntime available: %v", err)
+		}
+		assertFileExists(t, filepath.Join(commandsDir, "systemctl_services.txt"))
+		assertFileExists(t, filepath.Join(commandsDir, "systemctl_service_files.txt"))
+	})
+
+	t.Run("packages runtime disabled blocked and success", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.BackupInstalledPackages = false
+		commandsDir := t.TempDir()
+		if err := collector.collectSystemPackagesInstalledRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemPackagesInstalledRuntime disabled: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(commandsDir, "packages")); !os.IsNotExist(err) {
+			t.Fatalf("expected no packages dir when disabled, stat err=%v", err)
+		}
+
+		collector = newTestCollector(t)
+		collector.config.BackupInstalledPackages = true
+		commandsDir = t.TempDir()
+		if err := os.WriteFile(filepath.Join(commandsDir, "packages"), []byte("blocker"), 0o644); err != nil {
+			t.Fatalf("write packages blocker: %v", err)
+		}
+		if err := collector.collectSystemPackagesInstalledRuntime(context.Background(), commandsDir); err == nil {
+			t.Fatalf("expected packages directory creation failure")
+		}
+
+		collector = newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "dpkg" {
+					return "/usr/bin/dpkg", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte("ii proxsave\n"), nil
+			},
+		})
+		collector.config.BackupInstalledPackages = true
+		commandsDir = t.TempDir()
+		if err := collector.collectSystemPackagesInstalledRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemPackagesInstalledRuntime success: %v", err)
+		}
+		assertFileExists(t, filepath.Join(commandsDir, "packages/dpkg_list.txt"))
+	})
+
+	t.Run("sysctl runtime disabled success and write failure", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.BackupSysctlConfig = false
+		commandsDir := t.TempDir()
+		if err := collector.collectSystemSysctlRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemSysctlRuntime disabled: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(commandsDir, "sysctl.txt")); !os.IsNotExist(err) {
+			t.Fatalf("expected no sysctl output when disabled, stat err=%v", err)
+		}
+
+		collector = newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "sysctl" {
+					return "/usr/sbin/sysctl", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte("kernel.hostname = test\n"), nil
+			},
+		})
+		commandsDir = t.TempDir()
+		if err := collector.collectSystemSysctlRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("collectSystemSysctlRuntime success: %v", err)
+		}
+		assertFileExists(t, filepath.Join(commandsDir, "sysctl.txt"))
+
+		commandsDir = t.TempDir()
+		if err := os.MkdirAll(filepath.Join(commandsDir, "sysctl.txt"), 0o755); err != nil {
+			t.Fatalf("mkdir sysctl blocker: %v", err)
+		}
+		if err := collector.collectSystemSysctlRuntime(context.Background(), commandsDir); err == nil {
+			t.Fatalf("expected sysctl write failure")
+		}
+	})
+
+	t.Run("lvm write failures after earlier commands", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				switch name {
+				case "pvs", "vgs", "lvs":
+					return "/usr/sbin/" + name, nil
+				default:
+					return "", os.ErrNotExist
+				}
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(name + "\n"), nil
+			},
+		})
+		for _, tc := range []struct {
+			name    string
+			blocker string
+			before  []string
+		}{
+			{name: "pvs", blocker: "lvm_pvs.txt"},
+			{name: "vgs", blocker: "lvm_vgs.txt", before: []string{"lvm_pvs.txt"}},
+			{name: "lvs", blocker: "lvm_lvs.txt", before: []string{"lvm_pvs.txt", "lvm_vgs.txt"}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				commandsDir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(commandsDir, tc.blocker), 0o755); err != nil {
+					t.Fatalf("mkdir blocker: %v", err)
+				}
+				if err := collector.collectSystemLVMRuntime(context.Background(), commandsDir); err == nil {
+					t.Fatalf("expected %s write failure", tc.name)
+				}
+				for _, rel := range tc.before {
+					assertFileExists(t, filepath.Join(commandsDir, rel))
+				}
+			})
+		}
+	})
+}
+
+func TestCollectBestEffortProbeLateCancellationBranches(t *testing.T) {
+	t.Run("write error observes canceled context", func(t *testing.T) {
+		var cancel context.CancelFunc
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) { return "/bin/" + name, nil },
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				cancel()
+				return []byte("ok\n"), nil
+			},
+		})
+		ctx, cancelFn := context.WithCancel(context.Background())
+		cancel = cancelFn
+		output := filepath.Join(t.TempDir(), "probe.txt")
+		if err := os.MkdirAll(output, 0o755); err != nil {
+			t.Fatalf("mkdir output blocker: %v", err)
+		}
+		if err := collector.collectBestEffortProbe(ctx, commandSpec("probe"), output, "probe", nil); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectBestEffortProbe error=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("successful command observes canceled context before returning", func(t *testing.T) {
+		var cancel context.CancelFunc
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) { return "/bin/" + name, nil },
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				cancel()
+				return []byte("ok\n"), nil
+			},
+		})
+		ctx, cancelFn := context.WithCancel(context.Background())
+		cancel = cancelFn
+		output := filepath.Join(t.TempDir(), "probe.txt")
+		if err := collector.collectBestEffortProbe(ctx, commandSpec("probe"), output, "probe", nil); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectBestEffortProbe error=%v; want context.Canceled", err)
+		}
+		assertFileExists(t, output)
+	})
+}
+
+func TestCollectSystemRemainingRuntimeErrorBranches(t *testing.T) {
+	t.Run("identity and logging canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		collector := newTestCollector(t)
+		if err := collector.collectSystemIdentityStatic(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectSystemIdentityStatic canceled=%v; want context.Canceled", err)
+		}
+		if err := collector.collectSystemLoggingStatic(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectSystemLoggingStatic canceled=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("runtime lease copy errors are logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "var/lib/dhcp/lease", "lease\n", 0o644)
+		writeRootFile(t, root, "var/lib/NetworkManager/lease", "lease\n", 0o644)
+		writeRootFile(t, root, "run/systemd/netif/leases/2", "lease\n", 0o644)
+		for _, dest := range []string{
+			collector.proxsaveRuntimeDir("var/lib/dhcp"),
+			collector.proxsaveRuntimeDir("var/lib/NetworkManager"),
+			collector.proxsaveRuntimeDir("run/systemd/netif/leases"),
+		} {
+			writeFileAt(t, dest, "blocker\n")
+		}
+		if err := collector.collectSystemRuntimeLeases(context.Background()); err != nil {
+			t.Fatalf("collectSystemRuntimeLeases should log copy errors: %v", err)
+		}
+	})
+
+	t.Run("core runtime uname critical failure", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "cat" {
+					return "/bin/cat", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(name + "\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/os-release", "ID=debian\n", 0o644)
+		if err := collector.collectSystemCoreRuntime(context.Background(), t.TempDir()); err == nil {
+			t.Fatalf("expected critical uname failure")
+		}
+	})
+
+	t.Run("core runtime hostname cancellation propagates", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) { return "/bin/" + name, nil },
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				if name == "hostname" {
+					return nil, context.Canceled
+				}
+				return []byte(name + "\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/os-release", "ID=debian\n", 0o644)
+		if err := collector.collectSystemCoreRuntime(context.Background(), t.TempDir()); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectSystemCoreRuntime hostname cancellation=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("remaining command write failures", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(name + "\n"), nil
+			},
+		})
+		collector.config.BackupFirewallRules = true
+		collector.config.BackupInstalledPackages = true
+		for _, tc := range []struct {
+			name    string
+			blocker string
+			fn      func(context.Context, string) error
+		}{
+			{name: "routes", blocker: "ip_route.txt", fn: collector.collectSystemNetworkRoutesRuntime},
+			{name: "neighbors first command", blocker: "ip_neigh.txt", fn: collector.collectSystemNetworkNeighborsRuntime},
+			{name: "mounts first command", blocker: "df.txt", fn: collector.collectSystemStorageMountsRuntime},
+			{name: "compute first command", blocker: "free.txt", fn: collector.collectSystemComputeMemoryCPURuntime},
+			{name: "packages dpkg", blocker: "packages/dpkg_list.txt", fn: collector.collectSystemPackagesInstalledRuntime},
+			{name: "iptables", blocker: "iptables.txt", fn: collector.collectSystemFirewallIPTablesRuntime},
+			{name: "ip6tables", blocker: "ip6tables.txt", fn: collector.collectSystemFirewallIP6TablesRuntime},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				commandsDir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(commandsDir, tc.blocker), 0o755); err != nil {
+					t.Fatalf("mkdir blocker: %v", err)
+				}
+				if err := tc.fn(context.Background(), commandsDir); err == nil {
+					t.Fatalf("expected %s write failure", tc.name)
+				}
+			})
+		}
+	})
+
+	t.Run("bonding copy error is logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "proc/net/bonding/bond0", "bonding\n", 0o644)
+		commandsDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(commandsDir, "bonding_bond0.txt"), 0o755); err != nil {
+			t.Fatalf("mkdir bonding blocker: %v", err)
+		}
+		if err := collector.collectSystemNetworkBondingRuntime(context.Background(), commandsDir); err != nil {
+			t.Fatalf("bonding copy errors should be logged: %v", err)
+		}
+	})
+
+	t.Run("best effort runtime cancellations propagate", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			setup func(*Collector)
+			fn    func(*Collector, context.Context, string) error
+		}{
+			{
+				name: "bus lsusb",
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemComputeBusInventoryRuntime(ctx, dir)
+				},
+			},
+			{
+				name:  "services first",
+				setup: func(c *Collector) { writeRootFile(t, c.config.SystemRootPrefix, "proc/1/comm", "systemd\n", 0o644) },
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemServicesRuntime(ctx, dir)
+				},
+			},
+			{
+				name:  "ufw systemctl",
+				setup: func(c *Collector) { writeRootFile(t, c.config.SystemRootPrefix, "proc/1/comm", "systemd\n", 0o644) },
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemFirewallUFWRuntime(ctx, dir)
+				},
+			},
+			{
+				name:  "firewalld systemctl",
+				setup: func(c *Collector) { writeRootFile(t, c.config.SystemRootPrefix, "proc/1/comm", "systemd\n", 0o644) },
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemFirewallFirewalldRuntime(ctx, dir)
+				},
+			},
+			{
+				name: "kernel modules lsmod",
+				fn: func(c *Collector, ctx context.Context, dir string) error {
+					return c.collectSystemKernelModulesRuntime(ctx, dir)
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				collector := newTestCollectorWithDeps(t, CollectorDeps{
+					LookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+					RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+						switch {
+						case tc.name == "bus lsusb" && name == "lsusb":
+							return nil, context.Canceled
+						case tc.name == "services first" && name == "systemctl":
+							return nil, context.Canceled
+						case tc.name == "ufw systemctl" && name == "systemctl":
+							return nil, context.Canceled
+						case tc.name == "firewalld systemctl" && name == "systemctl":
+							return nil, context.Canceled
+						case tc.name == "kernel modules lsmod" && name == "lsmod":
+							return nil, context.Canceled
+						default:
+							return []byte(name + "\n"), nil
+						}
+					},
+				})
+				collector.config.SystemRootPrefix = t.TempDir()
+				collector.config.BackupFirewallRules = true
+				collector.config.BackupKernelModules = true
+				collector.config.BackupSystemdServices = true
+				if tc.setup != nil {
+					tc.setup(collector)
+				}
+				if err := tc.fn(collector, context.Background(), t.TempDir()); !errors.Is(err, context.Canceled) {
+					t.Fatalf("%s error=%v; want context.Canceled", tc.name, err)
+				}
+			})
+		}
+	})
+
+	t.Run("services second command cancellation propagates", func(t *testing.T) {
+		calls := 0
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				calls++
+				if calls == 2 {
+					return nil, context.Canceled
+				}
+				return []byte("ok\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "proc/1/comm", "systemd\n", 0o644)
+		if err := collector.collectSystemServicesRuntime(context.Background(), t.TempDir()); !errors.Is(err, context.Canceled) {
+			t.Fatalf("services second command error=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("kernel modules disabled and lvm canceled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.BackupKernelModules = false
+		if err := collector.collectSystemKernelModulesRuntime(context.Background(), t.TempDir()); err != nil {
+			t.Fatalf("collectSystemKernelModulesRuntime disabled: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectSystemLVMRuntime(ctx, t.TempDir()); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectSystemLVMRuntime canceled=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("network report canceled and write failure", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.buildNetworkReport(ctx, t.TempDir()); !errors.Is(err, context.Canceled) {
+			t.Fatalf("buildNetworkReport canceled=%v; want context.Canceled", err)
+		}
+
+		commandsDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(commandsDir, "network_report.txt"), 0o755); err != nil {
+			t.Fatalf("mkdir network report blocker: %v", err)
+		}
+		if err := collector.buildNetworkReport(context.Background(), commandsDir); err == nil {
+			t.Fatalf("expected network report write failure")
+		}
+	})
+
+	t.Run("ensure system path skips blanks and duplicates", func(t *testing.T) {
+		t.Setenv("PATH", strings.Join([]string{"/usr/bin", "", "/usr/bin"}, string(os.PathListSeparator)))
+		ensureSystemPath()
+		got := strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))
+		if got[0] != "/usr/bin" {
+			t.Fatalf("PATH first entry=%q; want /usr/bin", got[0])
+		}
+		for _, seg := range got {
+			if seg == "" {
+				t.Fatalf("PATH should not contain blank entries: %q", os.Getenv("PATH"))
+			}
+		}
+	})
+}
+
+func TestCollectSystemAdditionalFileBranches(t *testing.T) {
+	t.Run("critical files canceled and copies existing", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectCriticalFiles(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectCriticalFiles canceled=%v; want context.Canceled", err)
+		}
+
+		collector = newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/passwd", "root:x:0:0:root:/root:/bin/bash\n", 0o644)
+		writeRootFile(t, root, "etc/group", "root:x:0:\n", 0o644)
+		if err := collector.collectCriticalFiles(context.Background()); err != nil {
+			t.Fatalf("collectCriticalFiles: %v", err)
+		}
+		assertFileExists(t, filepath.Join(collector.tempDir, "etc/passwd"))
+		assertFileExists(t, filepath.Join(collector.tempDir, "etc/group"))
+		if _, err := os.Stat(filepath.Join(collector.tempDir, "etc/shadow")); !os.IsNotExist(err) {
+			t.Fatalf("expected missing shadow skipped, stat err=%v", err)
+		}
+	})
+
+	t.Run("custom paths trim deduplicate relative and absolute entries", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "var/lib/app/config.yml", "enabled: true\n", 0o644)
+		writeRootFile(t, root, "opt/app/bin/run", "#!/bin/sh\n", 0o755)
+		collector.config.CustomBackupPaths = []string{
+			" ",
+			"var/lib/app/config.yml",
+			"/var/lib/app/config.yml",
+			"/opt/app",
+			"/missing",
+		}
+
+		if err := collector.collectCustomPaths(context.Background()); err != nil {
+			t.Fatalf("collectCustomPaths: %v", err)
+		}
+		assertFileExists(t, filepath.Join(collector.tempDir, "var/lib/app/config.yml"))
+		assertFileExists(t, filepath.Join(collector.tempDir, "opt/app/bin/run"))
+		if _, err := os.Stat(filepath.Join(collector.tempDir, "missing")); !os.IsNotExist(err) {
+			t.Fatalf("expected missing custom path skipped, stat err=%v", err)
+		}
+	})
+
+	t.Run("custom paths canceled", func(t *testing.T) {
+		collector := newTestCollector(t)
+		collector.config.CustomBackupPaths = []string{"/etc/passwd"}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectCustomPaths(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectCustomPaths canceled=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("script directories canceled copies and skips missing", func(t *testing.T) {
+		collector := newTestCollector(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.collectScriptDirectories(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectScriptDirectories canceled=%v; want context.Canceled", err)
+		}
+
+		collector = newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "usr/local/bin/tool", "#!/bin/sh\n", 0o755)
+		if err := collector.collectScriptDirectories(context.Background()); err != nil {
+			t.Fatalf("collectScriptDirectories: %v", err)
+		}
+		assertFileExists(t, filepath.Join(collector.tempDir, "usr/local/bin/tool"))
+		if _, err := os.Stat(filepath.Join(collector.tempDir, "usr/local/sbin")); !os.IsNotExist(err) {
+			t.Fatalf("expected missing /usr/local/sbin skipped, stat err=%v", err)
+		}
+	})
+}
+
+func TestCollectSystemRemainingFileErrorBranches(t *testing.T) {
+	t.Run("kernel first command write failure", func(t *testing.T) {
+		collector := newTestCollectorWithDeps(t, CollectorDeps{
+			LookPath: func(name string) (string, error) {
+				if name == "cat" {
+					return "/bin/cat", nil
+				}
+				return "", os.ErrNotExist
+			},
+			RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return []byte(filepath.Base(args[0]) + "\n"), nil
+			},
+		})
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "proc/cmdline", "BOOT_IMAGE=/vmlinuz\n", 0o644)
+		writeRootFile(t, root, "proc/version", "Linux version\n", 0o644)
+		if err := os.MkdirAll(filepath.Join(collector.proxsaveCommandsDir("system"), "kernel_cmdline.txt"), 0o755); err != nil {
+			t.Fatalf("mkdir kernel cmdline blocker: %v", err)
+		}
+		if err := collector.collectKernelInfo(context.Background()); err == nil {
+			t.Fatalf("expected kernel cmdline write failure")
+		}
+	})
+
+	t.Run("hardware cancellation branches", func(t *testing.T) {
+		for _, tc := range []string{"dmidecode", "sensors", "smartctl"} {
+			t.Run(tc, func(t *testing.T) {
+				if tc == "dmidecode" && os.Geteuid() != 0 {
+					t.Skip("dmidecode availability requires root")
+				}
+				collector := newTestCollectorWithDeps(t, CollectorDeps{
+					LookPath: func(name string) (string, error) {
+						switch name {
+						case "dmidecode", "sensors", "smartctl":
+							return "/usr/sbin/" + name, nil
+						default:
+							return "", os.ErrNotExist
+						}
+					},
+					RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+						if name == tc {
+							return nil, context.Canceled
+						}
+						return []byte(name + "\n"), nil
+					},
+				})
+				root := t.TempDir()
+				collector.config.SystemRootPrefix = root
+				writeRootFile(t, root, "sys/class/hwmon/hwmon0/name", "coretemp\n", 0o644)
+				writeRootFile(t, root, "usr/sbin/smartctl", "#!/bin/sh\n", 0o755)
+				if os.Geteuid() == 0 {
+					if err := os.MkdirAll(filepath.Join(root, "sys/firmware/dmi/tables"), 0o755); err != nil {
+						t.Fatalf("mkdir dmi tables: %v", err)
+					}
+				}
+				if err := collector.collectHardwareInfo(context.Background()); !errors.Is(err, context.Canceled) {
+					t.Fatalf("collectHardwareInfo %s cancellation=%v; want context.Canceled", tc, err)
+				}
+			})
+		}
+	})
+
+	t.Run("critical files copy error is logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/passwd", "root:x:0:0:root:/root:/bin/bash\n", 0o644)
+		if err := os.MkdirAll(filepath.Join(collector.tempDir, "etc/passwd"), 0o755); err != nil {
+			t.Fatalf("mkdir passwd blocker: %v", err)
+		}
+		if err := collector.collectCriticalFiles(context.Background()); err != nil {
+			t.Fatalf("collectCriticalFiles should log copy errors: %v", err)
+		}
+	})
+
+	t.Run("custom path copy errors are logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "opt/app/config.yml", "enabled: true\n", 0o644)
+		writeRootFile(t, root, "opt/appdir/file.txt", "data\n", 0o644)
+		collector.config.CustomBackupPaths = []string{"/opt/app/config.yml", "/opt/appdir"}
+		if err := os.MkdirAll(filepath.Join(collector.tempDir, "opt/app/config.yml"), 0o755); err != nil {
+			t.Fatalf("mkdir custom file blocker: %v", err)
+		}
+		writeFileAt(t, filepath.Join(collector.tempDir, "opt/appdir"), "dir blocker\n")
+		if err := collector.collectCustomPaths(context.Background()); err != nil {
+			t.Fatalf("collectCustomPaths should log copy errors: %v", err)
+		}
+	})
+
+	t.Run("script directory copy error is logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "usr/local/bin/tool", "#!/bin/sh\n", 0o755)
+		writeFileAt(t, filepath.Join(collector.tempDir, "usr/local/bin"), "bin blocker\n")
+		if err := collector.collectScriptDirectories(context.Background()); err != nil {
+			t.Fatalf("collectScriptDirectories should log copy errors: %v", err)
+		}
+	})
+
+	t.Run("ssh key copy errors are logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/ssh/sshd_config", "Port 22\n", 0o600)
+		writeRootFile(t, root, "root/.ssh/id_rsa", "root-key\n", 0o600)
+		writeRootFile(t, root, "home/alice/.ssh/id_ed25519", "alice-key\n", 0o600)
+		writeFileAt(t, filepath.Join(collector.tempDir, "etc/ssh"), "etc ssh blocker\n")
+		writeFileAt(t, filepath.Join(collector.tempDir, "root/.ssh"), "root ssh blocker\n")
+		writeFileAt(t, filepath.Join(collector.tempDir, "home/alice/.ssh"), "alice ssh blocker\n")
+		if err := collector.collectSSHKeys(context.Background()); err != nil {
+			t.Fatalf("collectSSHKeys should log copy errors: %v", err)
+		}
+	})
+
+	t.Run("script repository directory destination error", func(t *testing.T) {
+		collector := newTestCollector(t)
+		repo := t.TempDir()
+		collector.config.ScriptRepositoryPath = repo
+		if err := os.MkdirAll(filepath.Join(repo, "nested"), 0o755); err != nil {
+			t.Fatalf("mkdir repo nested: %v", err)
+		}
+		writeFileAt(t, filepath.Join(repo, "nested", "file.txt"), "data\n")
+		target := collector.proxsaveInfoDir("script-repository", filepath.Base(repo))
+		writeFileAt(t, filepath.Join(target, "nested"), "nested blocker\n")
+		if err := collector.collectScriptRepository(context.Background()); err == nil {
+			t.Fatalf("expected script repository destination error")
+		}
+	})
+
+	t.Run("root home copy errors are logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		collector.config.BackupSSHKeys = true
+		writeRootFile(t, root, "root/.bashrc", "alias ll='ls -l'\n", 0o644)
+		writeRootFile(t, root, "root/.bash_history", "history\n", 0o600)
+		writeRootFile(t, root, "root/.ssh/id_rsa", "key\n", 0o600)
+		writeRootFile(t, root, "root/.config/tool/config.json", "{}\n", 0o600)
+		writeRootFile(t, root, "root/.config/.wrangler/logs/wrangler.log", "log\n", 0o600)
+		if err := os.MkdirAll(filepath.Join(collector.tempDir, "root/.bashrc"), 0o755); err != nil {
+			t.Fatalf("mkdir root file blocker: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(collector.tempDir, "root/.bash_history"), 0o755); err != nil {
+			t.Fatalf("mkdir root history blocker: %v", err)
+		}
+		writeFileAt(t, filepath.Join(collector.tempDir, "root/.ssh"), "ssh blocker\n")
+		writeFileAt(t, filepath.Join(collector.tempDir, "root/.config"), "config blocker\n")
+		if err := collector.collectRootHome(context.Background()); err != nil {
+			t.Fatalf("collectRootHome should log copy errors: %v", err)
+		}
+	})
+
+	t.Run("user home copy errors are logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "home/alice/note.txt", "note\n", 0o644)
+		writeRootFile(t, root, "home/README", "top-level file\n", 0o644)
+		writeFileAt(t, filepath.Join(collector.tempDir, "home/alice"), "alice blocker\n")
+		if err := os.MkdirAll(filepath.Join(collector.tempDir, "home/README"), 0o755); err != nil {
+			t.Fatalf("mkdir readme blocker: %v", err)
+		}
+		if err := collector.collectUserHomes(context.Background()); err != nil {
+			t.Fatalf("collectUserHomes should log copy errors: %v", err)
+		}
+	})
+
+	t.Run("custom inaccessible path is logged", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "blocked", "not a directory\n", 0o644)
+		collector.config.CustomBackupPaths = []string{"/blocked/child"}
+		if err := collector.collectCustomPaths(context.Background()); err != nil {
+			t.Fatalf("collectCustomPaths should log inaccessible custom path: %v", err)
+		}
+	})
+
+	t.Run("network report includes globbed config files", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "etc/network/interfaces.d/vmbr0", "auto vmbr0\n", 0o644)
+		if err := collector.buildNetworkReport(context.Background(), t.TempDir()); err != nil {
+			t.Fatalf("buildNetworkReport with globbed config: %v", err)
+		}
+	})
+
+	t.Run("script repository skips backup and log files", func(t *testing.T) {
+		collector := newTestCollector(t)
+		repo := t.TempDir()
+		collector.config.ScriptRepositoryPath = repo
+		writeFileAt(t, filepath.Join(repo, "backup"), "backup file\n")
+		writeFileAt(t, filepath.Join(repo, "log"), "log file\n")
+		if err := collector.collectScriptRepository(context.Background()); err != nil {
+			t.Fatalf("collectScriptRepository backup/log files: %v", err)
+		}
+		target := collector.proxsaveInfoDir("script-repository", filepath.Base(repo))
+		if _, err := os.Stat(filepath.Join(target, "backup")); !os.IsNotExist(err) {
+			t.Fatalf("expected backup file skipped, stat err=%v", err)
+		}
+		if _, err := os.Stat(filepath.Join(target, "log")); !os.IsNotExist(err) {
+			t.Fatalf("expected log file skipped, stat err=%v", err)
+		}
+	})
+
+	t.Run("script repository mid walk cancellation", func(t *testing.T) {
+		collector := newTestCollector(t)
+		repo := t.TempDir()
+		collector.config.ScriptRepositoryPath = repo
+		writeFileAt(t, filepath.Join(repo, "file.txt"), "data\n")
+		ctx := &errAfterContext{Context: context.Background(), after: 2}
+		if err := collector.collectScriptRepository(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectScriptRepository mid-walk cancellation=%v; want context.Canceled", err)
+		}
+	})
+
+	t.Run("root home bad history glob is skipped", func(t *testing.T) {
+		collector := newTestCollector(t)
+		parent := t.TempDir()
+		root := filepath.Join(parent, "[bad")
+		if err := os.MkdirAll(filepath.Join(root, "root"), 0o755); err != nil {
+			t.Fatalf("mkdir root with glob metachar: %v", err)
+		}
+		collector.config.SystemRootPrefix = root
+		if err := collector.collectRootHome(context.Background()); err != nil {
+			t.Fatalf("collectRootHome bad history glob: %v", err)
+		}
+	})
+
+	t.Run("user homes mid-loop cancellation", func(t *testing.T) {
+		collector := newTestCollector(t)
+		root := t.TempDir()
+		collector.config.SystemRootPrefix = root
+		writeRootFile(t, root, "home/alice/note.txt", "note\n", 0o644)
+		ctx := &errAfterContext{Context: context.Background(), after: 1}
+		if err := collector.collectUserHomes(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectUserHomes mid-loop cancellation=%v; want context.Canceled", err)
+		}
+	})
+}
+
+func writeRootFile(t *testing.T, root, rel, content string, mode os.FileMode) {
+	t.Helper()
+	writeFileAt(t, filepath.Join(root, filepath.FromSlash(rel)), content)
+	if err := os.Chmod(filepath.Join(root, filepath.FromSlash(rel)), mode); err != nil {
+		t.Fatalf("chmod %s: %v", rel, err)
+	}
+}
+
+func writeFileAt(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file %s: %v", path, err)
+	}
+}
+
+func prepareStaticCopyErrorPath(t *testing.T, collector *Collector, root, rel string, dir bool) {
+	t.Helper()
+
+	src := filepath.Join(root, filepath.FromSlash(rel))
+	dest := filepath.Join(collector.tempDir, filepath.FromSlash(rel))
+	if dir {
+		writeFileAt(t, filepath.Join(src, "entry"), "data\n")
+		writeFileAt(t, dest, "dest blocker\n")
+		return
+	}
+
+	writeRootFile(t, root, rel, "data\n", 0o644)
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir destination blocker %s: %v", dest, err)
+	}
+}
+
+type errAfterContext struct {
+	context.Context
+	calls int
+	after int
+}
+
+func (c *errAfterContext) Err() error {
+	c.calls++
+	if c.calls > c.after {
+		return context.Canceled
+	}
+	return nil
+}
+
 func newTestCollector(t *testing.T) *Collector {
 	t.Helper()
 	return newTestCollectorWithDeps(t, CollectorDeps{})
@@ -716,6 +2843,9 @@ func newTestCollectorWithDeps(t *testing.T, override CollectorDeps) *Collector {
 	}
 	if override.Stat != nil {
 		deps.Stat = override.Stat
+	}
+	if override.DetectUnprivilegedContainer != nil {
+		deps.DetectUnprivilegedContainer = override.DetectUnprivilegedContainer
 	}
 	logger := logging.New(types.LogLevelDebug, false)
 	config := GetDefaultCollectorConfig()

--- a/internal/orchestrator/decrypt.go
+++ b/internal/orchestrator/decrypt.go
@@ -320,6 +320,33 @@ func inspectRcloneMetadataManifest(ctx context.Context, remoteMetadataPath, remo
 			}
 		case "PROXMOX_TYPE":
 			legacy.ProxmoxType = value
+		case "BACKUP_TARGETS", "PROXMOX_TARGETS":
+			targets := strings.Split(value, ",")
+			seenTargets := make(map[string]struct{}, len(legacy.ProxmoxTargets))
+			for _, target := range legacy.ProxmoxTargets {
+				target = strings.TrimSpace(target)
+				if target == "" {
+					continue
+				}
+				seenTargets[target] = struct{}{}
+			}
+			for _, target := range targets {
+				target = strings.TrimSpace(target)
+				if target == "" {
+					continue
+				}
+				if _, ok := seenTargets[target]; ok {
+					continue
+				}
+				seenTargets[target] = struct{}{}
+				legacy.ProxmoxTargets = append(legacy.ProxmoxTargets, target)
+			}
+		case "PROXMOX_VERSION":
+			legacy.ProxmoxVersion = value
+		case "PVE_VERSION":
+			legacy.PVEVersion = value
+		case "PBS_VERSION":
+			legacy.PBSVersion = value
 		case "HOSTNAME":
 			legacy.Hostname = value
 		case "SCRIPT_VERSION":

--- a/internal/orchestrator/decrypt_test.go
+++ b/internal/orchestrator/decrypt_test.go
@@ -2602,6 +2602,53 @@ func TestInspectRcloneMetadataManifest_LegacyWithComments(t *testing.T) {
 	}
 }
 
+func TestInspectRcloneMetadataManifest_LegacyIncludesTargetsAndVersions(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataPath := filepath.Join(tmpDir, "targets.metadata")
+
+	legacy := strings.Join([]string{
+		"PROXMOX_TARGETS=pve,pbs",
+		"BACKUP_TARGETS=pve,dual",
+		"PROXMOX_VERSION=8.2/3.4",
+		"PVE_VERSION=8.2-1",
+		"PBS_VERSION=3.4-2",
+		"",
+	}, "\n")
+	if err := os.WriteFile(metadataPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	scriptPath := filepath.Join(tmpDir, "rclone")
+	script := fmt.Sprintf("#!/bin/sh\ncat %q\n", metadataPath)
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake rclone: %v", err)
+	}
+
+	prependPathEnv(t, tmpDir)
+
+	logger := logging.New(types.LogLevelError, false)
+	logger.SetOutput(io.Discard)
+
+	got, err := inspectRcloneMetadataManifest(context.Background(), "gdrive:targets.metadata", "gdrive:backup.tar.zst", logger)
+	if err != nil {
+		t.Fatalf("inspectRcloneMetadataManifest error: %v", err)
+	}
+
+	if got.ProxmoxVersion != "8.2/3.4" || got.PVEVersion != "8.2-1" || got.PBSVersion != "3.4-2" {
+		t.Fatalf("unexpected versions: proxmox=%q pve=%q pbs=%q", got.ProxmoxVersion, got.PVEVersion, got.PBSVersion)
+	}
+
+	if len(got.ProxmoxTargets) != 3 {
+		t.Fatalf("ProxmoxTargets len=%d; want 3 (%v)", len(got.ProxmoxTargets), got.ProxmoxTargets)
+	}
+	wantTargets := []string{"pve", "pbs", "dual"}
+	for i, want := range wantTargets {
+		if got.ProxmoxTargets[i] != want {
+			t.Fatalf("ProxmoxTargets[%d]=%q; want %q (all=%v)", i, got.ProxmoxTargets[i], want, got.ProxmoxTargets)
+		}
+	}
+}
+
 func TestInspectRcloneMetadataManifest_RcloneFails(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/orchestrator/pve_staged_apply.go
+++ b/internal/orchestrator/pve_staged_apply.go
@@ -258,7 +258,7 @@ func maybeApplyPVEStorageMountGuardsFromStage(ctx context.Context, logger *loggi
 	if filepath.Clean(strings.TrimSpace(destRoot)) != string(os.PathSeparator) {
 		return nil
 	}
-	if !isRealRestoreFS(restoreFS) || os.Geteuid() != 0 {
+	if !isRealRestoreFS(restoreFS) || mountGuardGeteuid() != 0 {
 		return nil
 	}
 

--- a/internal/orchestrator/pve_staged_apply_additional_test.go
+++ b/internal/orchestrator/pve_staged_apply_additional_test.go
@@ -2,7 +2,10 @@ package orchestrator
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,13 +13,103 @@ import (
 	"testing"
 )
 
+const pveMountIntegrationStoragePrefix = "proxsave-it-"
+
+// requireWritablePveMountRoot skips integration tests unless /mnt/pve accepts a real write/remove probe.
 func requireWritablePveMountRoot(t *testing.T) {
 	t.Helper()
-	probe := filepath.Join("/mnt/pve", ".proxsave-mount-guard-probe")
-	if err := os.MkdirAll(filepath.Dir(probe), 0o755); err != nil {
-		t.Skipf("requires writable %s: %v", filepath.Dir(probe), err)
+	root := "/mnt/pve"
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Skipf("requires writable %s: %v", root, err)
 	}
-	_ = os.Remove(probe)
+	probe := filepath.Join(root, fmt.Sprintf(".%sprobe-%d", pveMountIntegrationStoragePrefix, os.Getpid()))
+	if err := os.WriteFile(probe, []byte("probe"), 0o600); err != nil {
+		t.Skipf("requires writable %s: %v", root, err)
+	}
+	if f, err := os.Open(probe); err == nil {
+		_ = f.Sync()
+		_ = f.Close()
+	}
+	if err := os.Remove(probe); err != nil {
+		t.Skipf("requires writable %s (remove probe): %v", root, err)
+	}
+}
+
+func uniquePveMountTestStorageID(t *testing.T, label string) string {
+	t.Helper()
+	label = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_':
+			return '-'
+		default:
+			return '-'
+		}
+	}, strings.ToLower(strings.TrimSpace(label)))
+	if label == "" {
+		label = "x"
+	}
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%d", t.Name(), label, os.Getpid())))
+	return pveMountIntegrationStoragePrefix + hex.EncodeToString(sum[:6]) + "-" + label
+}
+
+func pveMountTargetForStorageID(storageID string) string {
+	return filepath.Join("/mnt/pve", storageID)
+}
+
+func isPveMountIntegrationTestStorageID(storageID string) bool {
+	return strings.HasPrefix(storageID, pveMountIntegrationStoragePrefix)
+}
+
+func isPveMountIntegrationTestPath(path string) bool {
+	path = filepath.Clean(path)
+	if filepath.Dir(path) != "/mnt/pve" {
+		return false
+	}
+	return isPveMountIntegrationTestStorageID(filepath.Base(path))
+}
+
+func cleanupPveMountTestTarget(t *testing.T, target string) {
+	t.Helper()
+	if !isPveMountIntegrationTestPath(target) {
+		t.Fatalf("refusing cleanup of non-test mount target %q", target)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(target) })
+}
+
+func cleanupPveMountTestGuardDir(t *testing.T, target string) {
+	t.Helper()
+	if !isPveMountIntegrationTestPath(target) {
+		t.Fatalf("refusing cleanup of guard dir for non-test mount target %q", target)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(target)) })
+}
+
+func removePveMountTestPathIfExists(t *testing.T, path string) {
+	t.Helper()
+	if !isPveMountIntegrationTestPath(path) {
+		t.Fatalf("refusing remove of non-test mount path %q", path)
+	}
+	_ = os.Remove(path)
+}
+
+func TestPveMountIntegrationTestPathSafety(t *testing.T) {
+	id := uniquePveMountTestStorageID(t, "safety")
+	target := pveMountTargetForStorageID(id)
+	if !isPveMountIntegrationTestPath(target) {
+		t.Fatalf("expected owned test path %q", target)
+	}
+	for _, path := range []string{
+		"/mnt/pve/proxsave-offline",
+		"/mnt/pve/activate-ok",
+		"/mnt/pve",
+		"/mnt/pool/nas",
+	} {
+		if isPveMountIntegrationTestPath(path) {
+			t.Fatalf("path %q must not be treated as integration-test owned", path)
+		}
+	}
 }
 
 func pvePlan(needsClusterRestore bool, ids ...string) *RestorePlan {
@@ -617,13 +710,14 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_EarlyAndFallback(t *testing.T)
 	if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
 		t.Fatalf("mkdir staged storage.cfg dir: %v", err)
 	}
-	if err := os.WriteFile(stageCfgPath, []byte("nfs: proxsave-offline\n"), 0o644); err != nil {
+	offlineID := uniquePveMountTestStorageID(t, "offline")
+	if err := os.WriteFile(stageCfgPath, []byte("nfs: "+offlineID+"\n"), 0o644); err != nil {
 		t.Fatalf("write staged storage.cfg: %v", err)
 	}
 
-	target := "/mnt/pve/proxsave-offline"
-	t.Cleanup(func() { _ = os.RemoveAll(target) })
-	t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(target)) })
+	target := pveMountTargetForStorageID(offlineID)
+	cleanupPveMountTestTarget(t, target)
+	cleanupPveMountTestGuardDir(t, target)
 
 	fakeCmd := &FakeCommandRunner{
 		Errors: map[string]error{
@@ -744,13 +838,14 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 		if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
 			t.Fatalf("mkdir stage cfg dir: %v", err)
 		}
-		if err := os.WriteFile(stageCfgPath, []byte("nfs: activate-ok\n"), 0o644); err != nil {
+		activateID := uniquePveMountTestStorageID(t, "activate-ok")
+		if err := os.WriteFile(stageCfgPath, []byte("nfs: "+activateID+"\n"), 0o644); err != nil {
 			t.Fatalf("write staged storage.cfg: %v", err)
 		}
 
-		target := "/mnt/pve/activate-ok"
-		t.Cleanup(func() { _ = os.RemoveAll(target) })
-		t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(target)) })
+		target := pveMountTargetForStorageID(activateID)
+		cleanupPveMountTestTarget(t, target)
+		cleanupPveMountTestGuardDir(t, target)
 
 		fakeCmd := &FakeCommandRunner{}
 		restoreCmd = fakeCmd
@@ -782,7 +877,7 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 		if !strings.Contains(calls, "which pvesm") {
 			t.Fatalf("missing which pvesm call; calls=%v", fakeCmd.CallsList())
 		}
-		if !strings.Contains(calls, "pvesm activate activate-ok") {
+		if !strings.Contains(calls, "pvesm activate "+activateID) {
 			t.Fatalf("missing pvesm activate call; calls=%v", fakeCmd.CallsList())
 		}
 		if strings.Contains(calls, "chattr +i "+target) {
@@ -791,36 +886,34 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 	})
 
 	t.Run("mkdir failure and off-root symlink are skipped", func(t *testing.T) {
+		mkdirFailID := uniquePveMountTestStorageID(t, "mkdir-fail")
+		offrootID := uniquePveMountTestStorageID(t, "offroot-link")
 		stageRoot := t.TempDir()
 		stageCfgPath := filepath.Join(stageRoot, "etc/pve/storage.cfg")
 		if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
 			t.Fatalf("mkdir stage cfg dir: %v", err)
 		}
 		cfg := strings.Join([]string{
-			"nfs: mkdir-fail",
-			"nfs: offroot-link",
+			"nfs: " + mkdirFailID,
+			"nfs: " + offrootID,
 			"",
 		}, "\n")
 		if err := os.WriteFile(stageCfgPath, []byte(cfg), 0o644); err != nil {
 			t.Fatalf("write staged storage.cfg: %v", err)
 		}
 
-		if err := os.MkdirAll("/mnt/pve", 0o755); err != nil {
-			t.Fatalf("mkdir /mnt/pve: %v", err)
-		}
-
-		mkdirFailTarget := "/mnt/pve/mkdir-fail"
-		offrootTarget := "/mnt/pve/offroot-link"
+		mkdirFailTarget := pveMountTargetForStorageID(mkdirFailID)
+		offrootTarget := pveMountTargetForStorageID(offrootID)
 		if err := os.WriteFile(mkdirFailTarget, []byte("file blocks mkdir"), 0o644); err != nil {
 			t.Fatalf("seed mkdir-fail target file: %v", err)
 		}
-		t.Cleanup(func() { _ = os.Remove(mkdirFailTarget) })
+		t.Cleanup(func() { removePveMountTestPathIfExists(t, mkdirFailTarget) })
 
-		_ = os.Remove(offrootTarget)
+		removePveMountTestPathIfExists(t, offrootTarget)
 		if err := os.Symlink("/proc", offrootTarget); err != nil {
 			t.Fatalf("create offroot symlink: %v", err)
 		}
-		t.Cleanup(func() { _ = os.Remove(offrootTarget) })
+		t.Cleanup(func() { removePveMountTestPathIfExists(t, offrootTarget) })
 
 		fakeCmd := &FakeCommandRunner{
 			Errors: map[string]error{
@@ -845,7 +938,7 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 			t.Fatalf("expected skips for mkdir failure/off-root symlink, got %v", err)
 		}
 		calls := strings.Join(fakeCmd.CallsList(), "\n")
-		if strings.Contains(calls, "mount /mnt/pve/mkdir-fail") || strings.Contains(calls, "mount /mnt/pve/offroot-link") {
+		if strings.Contains(calls, "mount "+mkdirFailTarget) || strings.Contains(calls, "mount "+offrootTarget) {
 			t.Fatalf("mount attempts should not happen for skipped targets; calls=%v", fakeCmd.CallsList())
 		}
 	})
@@ -856,21 +949,23 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 		if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
 			t.Fatalf("mkdir stage cfg dir: %v", err)
 		}
+		chattrFailID := uniquePveMountTestStorageID(t, "chattr-fail")
+		guardOKID := uniquePveMountTestStorageID(t, "guard-ok")
 		cfg := strings.Join([]string{
-			"nfs: chattr-fail",
-			"nfs: guard-ok",
+			"nfs: " + chattrFailID,
+			"nfs: " + guardOKID,
 			"",
 		}, "\n")
 		if err := os.WriteFile(stageCfgPath, []byte(cfg), 0o644); err != nil {
 			t.Fatalf("write staged storage.cfg: %v", err)
 		}
 
-		chattrFailTarget := "/mnt/pve/chattr-fail"
-		guardOKTarget := "/mnt/pve/guard-ok"
-		t.Cleanup(func() { _ = os.RemoveAll(chattrFailTarget) })
-		t.Cleanup(func() { _ = os.RemoveAll(guardOKTarget) })
-		t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(chattrFailTarget)) })
-		t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(guardOKTarget)) })
+		chattrFailTarget := pveMountTargetForStorageID(chattrFailID)
+		guardOKTarget := pveMountTargetForStorageID(guardOKID)
+		cleanupPveMountTestTarget(t, chattrFailTarget)
+		cleanupPveMountTestTarget(t, guardOKTarget)
+		cleanupPveMountTestGuardDir(t, chattrFailTarget)
+		cleanupPveMountTestGuardDir(t, guardOKTarget)
 
 		fakeCmd := &FakeCommandRunner{
 			Errors: map[string]error{

--- a/internal/orchestrator/pve_staged_apply_additional_test.go
+++ b/internal/orchestrator/pve_staged_apply_additional_test.go
@@ -1,0 +1,890 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func pvePlan(needsClusterRestore bool, ids ...string) *RestorePlan {
+	cats := make([]Category, 0, len(ids))
+	for _, id := range ids {
+		cats = append(cats, Category{ID: id, Type: CategoryTypePVE})
+	}
+	return &RestorePlan{
+		SystemType:          SystemTypePVE,
+		NormalCategories:    cats,
+		NeedsClusterRestore: needsClusterRestore,
+	}
+}
+
+func TestMaybeApplyPVEConfigsFromStage_EarlyReturnsAndSafeFlow(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, nil, "/stage", "/", false); err != nil {
+		t.Fatalf("nil plan: expected nil error, got %v", err)
+	}
+
+	wrongSystem := &RestorePlan{
+		SystemType:       SystemTypePBS,
+		NormalCategories: []Category{{ID: "storage_pve", Type: CategoryTypePVE}},
+	}
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, wrongSystem, "/stage", "/", false); err != nil {
+		t.Fatalf("wrong system type: expected nil error, got %v", err)
+	}
+
+	noRelevantCategories := pvePlan(false, "unrelated")
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, noRelevantCategories, "/stage", "/", false); err != nil {
+		t.Fatalf("no relevant categories: expected nil error, got %v", err)
+	}
+
+	relevant := pvePlan(false, "storage_pve", "pve_jobs")
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, relevant, "   ", "/", false); err != nil {
+		t.Fatalf("blank stageRoot: expected nil error, got %v", err)
+	}
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, relevant, "/stage", "/tmp/not-root", false); err != nil {
+		t.Fatalf("non-root destination: expected nil error, got %v", err)
+	}
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, relevant, "/stage", "/", true); err != nil {
+		t.Fatalf("dry run: expected nil error, got %v", err)
+	}
+
+	origFS := restoreFS
+	origCmd := restoreCmd
+	t.Cleanup(func() {
+		restoreFS = origFS
+		restoreCmd = origCmd
+	})
+
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	restoreCmd = &FakeCommandRunner{}
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, relevant, "/stage", "/", false); err != nil {
+		t.Fatalf("non-real restoreFS: expected nil error, got %v", err)
+	}
+
+	restoreFS = osFS{}
+	restoreCmd = &FakeCommandRunner{}
+	stageRoot := t.TempDir()
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, relevant, stageRoot, "/", false); err != nil {
+		t.Fatalf("realFS safe flow: expected nil error, got %v", err)
+	}
+
+	restoreCmd = &FakeCommandRunner{}
+	clusterRecovery := pvePlan(true, "storage_pve", "pve_jobs")
+	if err := maybeApplyPVEConfigsFromStage(ctx, logger, clusterRecovery, stageRoot, "/", false); err != nil {
+		t.Fatalf("cluster recovery safe flow: expected nil error, got %v", err)
+	}
+}
+
+func TestApplyPVEVzdumpConfFromStage_Branches(t *testing.T) {
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+
+	logger := newTestLogger()
+	stageRoot := "/stage"
+
+	if err := applyPVEVzdumpConfFromStage(logger, stageRoot); err != nil {
+		t.Fatalf("missing staged file should be ignored: %v", err)
+	}
+
+	stagePath := filepath.Join(stageRoot, "etc/vzdump.conf")
+	restoreFS = readFileFailFS{FS: fakeFS, failPath: stagePath, err: errors.New("boom")}
+	if err := applyPVEVzdumpConfFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "read staged etc/vzdump.conf") {
+		t.Fatalf("expected staged read error, got %v", err)
+	}
+	restoreFS = fakeFS
+
+	if err := fakeFS.AddFile("/etc/vzdump.conf", []byte("old\n")); err != nil {
+		t.Fatalf("seed /etc/vzdump.conf: %v", err)
+	}
+	if err := fakeFS.AddFile(stagePath, []byte(" \n\t")); err != nil {
+		t.Fatalf("write staged empty vzdump.conf: %v", err)
+	}
+	if err := applyPVEVzdumpConfFromStage(logger, stageRoot); err != nil {
+		t.Fatalf("empty staged vzdump.conf: %v", err)
+	}
+	if _, err := fakeFS.Stat("/etc/vzdump.conf"); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected /etc/vzdump.conf removed; stat err=%v", err)
+	}
+
+	if err := fakeFS.AddFile(stagePath, []byte("  dumpdir /mnt/backup  \n\n")); err != nil {
+		t.Fatalf("write staged non-empty vzdump.conf: %v", err)
+	}
+	if err := applyPVEVzdumpConfFromStage(logger, stageRoot); err != nil {
+		t.Fatalf("non-empty staged vzdump.conf: %v", err)
+	}
+	got, err := fakeFS.ReadFile("/etc/vzdump.conf")
+	if err != nil {
+		t.Fatalf("read applied /etc/vzdump.conf: %v", err)
+	}
+	if string(got) != "dumpdir /mnt/backup\n" {
+		t.Fatalf("applied /etc/vzdump.conf=%q want %q", string(got), "dumpdir /mnt/backup\n")
+	}
+}
+
+func TestApplyPVEStorageCfgFromStage_Branches(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+
+	t.Run("pvesh missing", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		restoreCmd = &FakeCommandRunner{
+			Errors: map[string]error{
+				"which pvesh": errors.New("missing"),
+			},
+		}
+		if err := applyPVEStorageCfgFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("expected nil when pvesh missing, got %v", err)
+		}
+	})
+
+	t.Run("missing staged storage cfg", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+		restoreCmd = &FakeCommandRunner{}
+
+		if err := applyPVEStorageCfgFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("missing staged storage.cfg should be ignored: %v", err)
+		}
+	})
+
+	t.Run("staged read error", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		baseFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(baseFS.Root) })
+		stagePath := "/stage/etc/pve/storage.cfg"
+		restoreFS = readFileFailFS{FS: baseFS, failPath: stagePath, err: syscall.EPERM}
+		restoreCmd = &FakeCommandRunner{}
+
+		if err := applyPVEStorageCfgFromStage(ctx, logger, "/stage"); err == nil || !strings.Contains(err.Error(), "read staged storage.cfg") {
+			t.Fatalf("expected staged read error, got %v", err)
+		}
+	})
+
+	t.Run("empty staged cfg", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+		restoreCmd = &FakeCommandRunner{}
+		if err := fakeFS.AddFile("/stage/etc/pve/storage.cfg", []byte(" \n\t")); err != nil {
+			t.Fatalf("write staged storage.cfg: %v", err)
+		}
+
+		if err := applyPVEStorageCfgFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("empty storage.cfg should be ignored: %v", err)
+		}
+	})
+
+	t.Run("applies staged cfg via pvesh", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		fakeCmd := &FakeCommandRunner{}
+		restoreCmd = fakeCmd
+
+		content := strings.Join([]string{
+			"storage: local",
+			"    type dir",
+			"    path /var/lib/vz",
+			"",
+		}, "\n")
+		if err := fakeFS.AddFile("/stage/etc/pve/storage.cfg", []byte(content)); err != nil {
+			t.Fatalf("write staged storage.cfg: %v", err)
+		}
+
+		if err := applyPVEStorageCfgFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("applyPVEStorageCfgFromStage: %v", err)
+		}
+		calls := strings.Join(fakeCmd.CallsList(), "\n")
+		if !strings.Contains(calls, "which pvesh") {
+			t.Fatalf("missing which pvesh call; calls=%v", fakeCmd.CallsList())
+		}
+		if !strings.Contains(calls, "pvesh create /storage --storage=local --type=dir --path=/var/lib/vz") {
+			t.Fatalf("missing pvesh create storage call; calls=%v", fakeCmd.CallsList())
+		}
+	})
+}
+
+func TestApplyPVEDatacenterCfgFromStage_Branches(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+
+	t.Run("pvesh missing", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		restoreFS = NewFakeFS()
+		restoreCmd = &FakeCommandRunner{
+			Errors: map[string]error{
+				"which pvesh": errors.New("missing"),
+			},
+		}
+		if err := applyPVEDatacenterCfgFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("expected nil when pvesh missing, got %v", err)
+		}
+	})
+
+	t.Run("missing and empty staged datacenter cfg", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+		restoreCmd = &FakeCommandRunner{}
+
+		if err := applyPVEDatacenterCfgFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("missing staged datacenter.cfg should be ignored: %v", err)
+		}
+
+		if err := fakeFS.AddFile("/stage/etc/pve/datacenter.cfg", []byte(" \n\t")); err != nil {
+			t.Fatalf("write staged datacenter.cfg: %v", err)
+		}
+		if err := applyPVEDatacenterCfgFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("empty staged datacenter.cfg should be ignored: %v", err)
+		}
+	})
+
+	t.Run("runPvesh error and success", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		stagePath := "/stage/etc/pve/datacenter.cfg"
+		if err := fakeFS.AddFile(stagePath, []byte("keyboard: it\n")); err != nil {
+			t.Fatalf("write staged datacenter.cfg: %v", err)
+		}
+
+		failCmd := &FakeCommandRunner{
+			Errors: map[string]error{
+				"pvesh set /cluster/config -conf " + stagePath: errors.New("pvesh failed"),
+			},
+		}
+		restoreCmd = failCmd
+		if err := applyPVEDatacenterCfgFromStage(ctx, logger, "/stage"); err == nil || !strings.Contains(err.Error(), "pvesh [set /cluster/config -conf") {
+			t.Fatalf("expected pvesh failure, got %v", err)
+		}
+
+		okCmd := &FakeCommandRunner{}
+		restoreCmd = okCmd
+		if err := applyPVEDatacenterCfgFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		calls := strings.Join(okCmd.CallsList(), "\n")
+		if !strings.Contains(calls, "pvesh set /cluster/config -conf "+stagePath) {
+			t.Fatalf("missing datacenter apply call; calls=%v", okCmd.CallsList())
+		}
+	})
+}
+
+func TestApplyPVEBackupJobsFromStage_Branches(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+
+	t.Run("pvesh missing, stage missing, read error, empty, no jobs", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		restoreCmd = &FakeCommandRunner{
+			Errors: map[string]error{"which pvesh": errors.New("missing")},
+		}
+		if err := applyPVEBackupJobsFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("expected nil when pvesh missing, got %v", err)
+		}
+
+		restoreCmd = &FakeCommandRunner{}
+		if err := applyPVEBackupJobsFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("missing jobs.cfg should be ignored: %v", err)
+		}
+
+		stagePath := "/stage/etc/pve/jobs.cfg"
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: stagePath, err: syscall.EIO}
+		if err := applyPVEBackupJobsFromStage(ctx, logger, "/stage"); err == nil || !strings.Contains(err.Error(), "read staged jobs.cfg") {
+			t.Fatalf("expected staged read error, got %v", err)
+		}
+		restoreFS = fakeFS
+
+		if err := fakeFS.AddFile(stagePath, []byte(" \n\t")); err != nil {
+			t.Fatalf("write empty jobs.cfg: %v", err)
+		}
+		if err := applyPVEBackupJobsFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("empty jobs.cfg should be ignored: %v", err)
+		}
+
+		noJobs := "sendmail: relay\n    mailto root@example.com\n"
+		if err := fakeFS.AddFile(stagePath, []byte(noJobs)); err != nil {
+			t.Fatalf("write non-vzdump jobs.cfg: %v", err)
+		}
+		if err := applyPVEBackupJobsFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("non-vzdump jobs.cfg should be ignored: %v", err)
+		}
+	})
+
+	t.Run("create fails then update succeeds", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		cfg := strings.Join([]string{
+			"vzdump: job-update",
+			"    node pve1",
+			"    storage backup",
+			"",
+		}, "\n")
+		if err := fakeFS.AddFile("/stage/etc/pve/jobs.cfg", []byte(cfg)); err != nil {
+			t.Fatalf("write staged jobs.cfg: %v", err)
+		}
+
+		createCall := "pvesh create /cluster/backup --id job-update --node pve1 --storage backup"
+		fakeCmd := &FakeCommandRunner{
+			Errors: map[string]error{
+				createCall: errors.New("already exists"),
+			},
+		}
+		restoreCmd = fakeCmd
+		if err := applyPVEBackupJobsFromStage(ctx, logger, "/stage"); err != nil {
+			t.Fatalf("expected update fallback success, got %v", err)
+		}
+		calls := strings.Join(fakeCmd.CallsList(), "\n")
+		if !strings.Contains(calls, createCall) {
+			t.Fatalf("missing create call; calls=%v", fakeCmd.CallsList())
+		}
+		if !strings.Contains(calls, "pvesh set /cluster/backup/job-update --node pve1 --storage backup") {
+			t.Fatalf("missing update fallback call; calls=%v", fakeCmd.CallsList())
+		}
+	})
+
+	t.Run("create and update both fail", func(t *testing.T) {
+		origFS := restoreFS
+		origCmd := restoreCmd
+		t.Cleanup(func() {
+			restoreFS = origFS
+			restoreCmd = origCmd
+		})
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		cfg := strings.Join([]string{
+			"vzdump: job-fail",
+			"    node pve1",
+			"    storage backup",
+			"",
+		}, "\n")
+		if err := fakeFS.AddFile("/stage/etc/pve/jobs.cfg", []byte(cfg)); err != nil {
+			t.Fatalf("write staged jobs.cfg: %v", err)
+		}
+
+		fakeCmd := &FakeCommandRunner{
+			Errors: map[string]error{
+				"pvesh create /cluster/backup --id job-fail --node pve1 --storage backup": errors.New("create failed"),
+				"pvesh set /cluster/backup/job-fail --node pve1 --storage backup":         errors.New("set failed"),
+			},
+		}
+		restoreCmd = fakeCmd
+
+		err := applyPVEBackupJobsFromStage(ctx, logger, "/stage")
+		if err == nil || !strings.Contains(err.Error(), "applied=0 failed=1") {
+			t.Fatalf("expected aggregate apply error, got %v", err)
+		}
+	})
+}
+
+func TestPVEStorageMountGuardCandidatesFromSections_CoversDirAndNonDir(t *testing.T) {
+	sections := []proxmoxNotificationSection{
+		{
+			Type: "dir",
+			Name: "local-dir",
+			Entries: []proxmoxNotificationEntry{
+				{Key: "path", Value: " /mnt/storage/pve/local-dir "},
+			},
+		},
+		{
+			Type: "nfs",
+			Name: "nas01",
+		},
+		{
+			Type: "  ",
+			Name: "ignored",
+		},
+		{
+			Type: "dir",
+			Name: "",
+			Entries: []proxmoxNotificationEntry{
+				{Key: "path", Value: "/mnt/ignored"},
+			},
+		},
+	}
+
+	got := pveStorageMountGuardCandidatesFromSections(sections)
+	if len(got) != 2 {
+		t.Fatalf("candidates len=%d; want 2 (%v)", len(got), got)
+	}
+	if got[0].StorageID != "local-dir" || got[0].StorageType != "dir" || got[0].Path != "/mnt/storage/pve/local-dir" {
+		t.Fatalf("unexpected dir candidate: %+v", got[0])
+	}
+	if got[1].StorageID != "nas01" || got[1].StorageType != "nfs" || got[1].Path != "" {
+		t.Fatalf("unexpected non-dir candidate: %+v", got[1])
+	}
+}
+
+func TestPVEStorageMountGuardItems_CoversFilteringAndFallbacks(t *testing.T) {
+	candidates := []pveStorageMountGuardCandidate{
+		{StorageID: "local-ok", StorageType: "dir", Path: "/mnt/pool/datastore/local-ok"},
+		{StorageID: "local-no-fstab", StorageType: "dir", Path: "/mnt/other/datastore/nope"},
+		{StorageID: "invalid-root", StorageType: "dir", Path: "/"},
+		{StorageID: "nas-net", StorageType: "nfs"},
+	}
+
+	t.Run("with fstab map", func(t *testing.T) {
+		items := pveStorageMountGuardItems(
+			candidates,
+			[]string{"/mnt/pool", "/mnt/other"},
+			map[string]struct{}{
+				"/mnt/pool": {},
+			},
+		)
+		if len(items) != 2 {
+			t.Fatalf("items len=%d; want 2 (%v)", len(items), items)
+		}
+		targets := []string{items[0].GuardTarget, items[1].GuardTarget}
+		if !(containsGuardTarget(targets, "/mnt/pool") && containsGuardTarget(targets, "/mnt/pve/nas-net")) {
+			t.Fatalf("unexpected guard targets: %v", targets)
+		}
+	})
+
+	t.Run("without fstab map keeps only network", func(t *testing.T) {
+		items := pveStorageMountGuardItems(candidates, []string{"/mnt/pool", "/mnt/other"}, nil)
+		if len(items) != 1 || items[0].GuardTarget != "/mnt/pve/nas-net" {
+			t.Fatalf("items=%v; want only network guard target", items)
+		}
+	})
+}
+
+func containsGuardTarget(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMaybeApplyPVEStorageMountGuardsFromStage_EarlyAndFallback(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, nil, "/stage", "/"); err != nil {
+		t.Fatalf("nil plan: expected nil error, got %v", err)
+	}
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, &RestorePlan{SystemType: SystemTypePBS}, "/stage", "/"); err != nil {
+		t.Fatalf("wrong system type: expected nil error, got %v", err)
+	}
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, pvePlan(false, "pve_jobs"), "/stage", "/"); err != nil {
+		t.Fatalf("missing storage category: expected nil error, got %v", err)
+	}
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, pvePlan(false, "storage_pve"), "   ", "/"); err != nil {
+		t.Fatalf("blank stageRoot: expected nil error, got %v", err)
+	}
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, pvePlan(false, "storage_pve"), "/stage", "/tmp/not-root"); err != nil {
+		t.Fatalf("non-root destination: expected nil error, got %v", err)
+	}
+
+	origFS := restoreFS
+	origCmd := restoreCmd
+	origReadFile := mountGuardReadFile
+	origMkdirAll := mountGuardMkdirAll
+	origSysMount := mountGuardSysMount
+	origSysUnmount := mountGuardSysUnmount
+	t.Cleanup(func() {
+		restoreFS = origFS
+		restoreCmd = origCmd
+		mountGuardReadFile = origReadFile
+		mountGuardMkdirAll = origMkdirAll
+		mountGuardSysMount = origSysMount
+		mountGuardSysUnmount = origSysUnmount
+	})
+
+	nonRealFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(nonRealFS.Root) })
+	restoreFS = nonRealFS
+	restoreCmd = &FakeCommandRunner{}
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, pvePlan(false, "storage_pve"), "/stage", "/"); err != nil {
+		t.Fatalf("non-real FS: expected nil error, got %v", err)
+	}
+
+	restoreFS = osFS{}
+	stageRoot := t.TempDir()
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, pvePlan(false, "storage_pve"), stageRoot, "/"); err != nil {
+		t.Fatalf("missing staged storage.cfg should be ignored: %v", err)
+	}
+
+	stageCfgPath := filepath.Join(stageRoot, "etc/pve/storage.cfg")
+	if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir staged storage.cfg dir: %v", err)
+	}
+	if err := os.WriteFile(stageCfgPath, []byte("nfs: proxsave-offline\n"), 0o644); err != nil {
+		t.Fatalf("write staged storage.cfg: %v", err)
+	}
+
+	target := "/mnt/pve/proxsave-offline"
+	t.Cleanup(func() { _ = os.RemoveAll(target) })
+	t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(target)) })
+
+	fakeCmd := &FakeCommandRunner{
+		Errors: map[string]error{
+			"which pvesm":          errors.New("missing"),
+			"mount " + target:      errors.New("offline"),
+			"chattr +i " + target:  nil,
+		},
+	}
+	restoreCmd = fakeCmd
+
+	mountGuardReadFile = func(path string) ([]byte, error) {
+		switch path {
+		case "/proc/self/mountinfo", "/proc/mounts":
+			return []byte(""), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+	mountGuardMkdirAll = func(path string, perm os.FileMode) error { return nil }
+	mountGuardSysMount = func(source, target, fstype string, flags uintptr, data string) error {
+		return errors.New("blocked mount")
+	}
+	mountGuardSysUnmount = func(target string, flags int) error { return nil }
+
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, pvePlan(false, "storage_pve"), stageRoot, "/"); err != nil {
+		t.Fatalf("fallback guard path should not return fatal error, got %v", err)
+	}
+	calls := strings.Join(fakeCmd.CallsList(), "\n")
+	if !strings.Contains(calls, "mount "+target) {
+		t.Fatalf("missing offline mount attempt; calls=%v", fakeCmd.CallsList())
+	}
+	if !strings.Contains(calls, "chattr +i "+target) {
+		t.Fatalf("missing chattr fallback call; calls=%v", fakeCmd.CallsList())
+	}
+}
+
+func TestMaybeApplyPVEStorageMountGuardsFromStage_ReadAndNoopBranches(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+	plan := pvePlan(false, "storage_pve")
+
+	origFS := restoreFS
+	origCmd := restoreCmd
+	t.Cleanup(func() {
+		restoreFS = origFS
+		restoreCmd = origCmd
+	})
+
+	restoreFS = osFS{}
+	restoreCmd = &FakeCommandRunner{}
+
+	stageRoot := t.TempDir()
+	stageCfgPath := filepath.Join(stageRoot, "etc/pve/storage.cfg")
+	if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir stage cfg dir: %v", err)
+	}
+
+	if err := os.Mkdir(stageCfgPath, 0o755); err != nil {
+		t.Fatalf("mkdir stage cfg path as directory: %v", err)
+	}
+	err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, plan, stageRoot, "/")
+	if err == nil || !strings.Contains(err.Error(), "read staged storage.cfg") {
+		t.Fatalf("expected staged read error, got %v", err)
+	}
+
+	if err := os.Remove(stageCfgPath); err != nil {
+		t.Fatalf("remove stage cfg directory: %v", err)
+	}
+	if err := os.WriteFile(stageCfgPath, []byte(" \n\t"), 0o644); err != nil {
+		t.Fatalf("write empty staged storage.cfg: %v", err)
+	}
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, plan, stageRoot, "/"); err != nil {
+		t.Fatalf("empty staged storage.cfg should be ignored: %v", err)
+	}
+
+	if err := os.WriteFile(stageCfgPath, []byte("not_a_section_header line\nkey value\n"), 0o644); err != nil {
+		t.Fatalf("write invalid/no-section storage.cfg: %v", err)
+	}
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, plan, stageRoot, "/"); err != nil {
+		t.Fatalf("no section candidates should be ignored: %v", err)
+	}
+}
+
+func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+	plan := pvePlan(false, "storage_pve")
+
+	origFS := restoreFS
+	origCmd := restoreCmd
+	origReadFile := mountGuardReadFile
+	origMkdirAll := mountGuardMkdirAll
+	origSysMount := mountGuardSysMount
+	origSysUnmount := mountGuardSysUnmount
+	t.Cleanup(func() {
+		restoreFS = origFS
+		restoreCmd = origCmd
+		mountGuardReadFile = origReadFile
+		mountGuardMkdirAll = origMkdirAll
+		mountGuardSysMount = origSysMount
+		mountGuardSysUnmount = origSysUnmount
+	})
+
+	restoreFS = osFS{}
+	mountGuardMkdirAll = os.MkdirAll
+	mountGuardSysUnmount = func(target string, flags int) error { return nil }
+
+	t.Run("network activate succeeds and skips guard", func(t *testing.T) {
+		stageRoot := t.TempDir()
+		stageCfgPath := filepath.Join(stageRoot, "etc/pve/storage.cfg")
+		if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
+			t.Fatalf("mkdir stage cfg dir: %v", err)
+		}
+		if err := os.WriteFile(stageCfgPath, []byte("nfs: activate-ok\n"), 0o644); err != nil {
+			t.Fatalf("write staged storage.cfg: %v", err)
+		}
+
+		target := "/mnt/pve/activate-ok"
+		t.Cleanup(func() { _ = os.RemoveAll(target) })
+		t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(target)) })
+
+		fakeCmd := &FakeCommandRunner{}
+		restoreCmd = fakeCmd
+
+		readCalls := 0
+		mountGuardReadFile = func(path string) ([]byte, error) {
+			if path == "/proc/self/mountinfo" {
+				readCalls++
+				if readCalls >= 2 {
+					line := "24 33 0:20 / " + target + " rw,relatime - tmpfs tmpfs rw\n"
+					return []byte(line), nil
+				}
+				return []byte(""), nil
+			}
+			if path == "/proc/mounts" {
+				return []byte(""), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mountGuardSysMount = func(source, target, fstype string, flags uintptr, data string) error {
+			t.Fatalf("guard mount should not be attempted when activation makes target mounted")
+			return nil
+		}
+
+		if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, plan, stageRoot, "/"); err != nil {
+			t.Fatalf("expected successful activate path, got %v", err)
+		}
+		calls := strings.Join(fakeCmd.CallsList(), "\n")
+		if !strings.Contains(calls, "which pvesm") {
+			t.Fatalf("missing which pvesm call; calls=%v", fakeCmd.CallsList())
+		}
+		if !strings.Contains(calls, "pvesm activate activate-ok") {
+			t.Fatalf("missing pvesm activate call; calls=%v", fakeCmd.CallsList())
+		}
+		if strings.Contains(calls, "chattr +i "+target) {
+			t.Fatalf("chattr fallback should not run on activation success; calls=%v", fakeCmd.CallsList())
+		}
+	})
+
+	t.Run("mkdir failure and off-root symlink are skipped", func(t *testing.T) {
+		stageRoot := t.TempDir()
+		stageCfgPath := filepath.Join(stageRoot, "etc/pve/storage.cfg")
+		if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
+			t.Fatalf("mkdir stage cfg dir: %v", err)
+		}
+		cfg := strings.Join([]string{
+			"nfs: mkdir-fail",
+			"nfs: offroot-link",
+			"",
+		}, "\n")
+		if err := os.WriteFile(stageCfgPath, []byte(cfg), 0o644); err != nil {
+			t.Fatalf("write staged storage.cfg: %v", err)
+		}
+
+		if err := os.MkdirAll("/mnt/pve", 0o755); err != nil {
+			t.Fatalf("mkdir /mnt/pve: %v", err)
+		}
+
+		mkdirFailTarget := "/mnt/pve/mkdir-fail"
+		offrootTarget := "/mnt/pve/offroot-link"
+		if err := os.WriteFile(mkdirFailTarget, []byte("file blocks mkdir"), 0o644); err != nil {
+			t.Fatalf("seed mkdir-fail target file: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(mkdirFailTarget) })
+
+		_ = os.Remove(offrootTarget)
+		if err := os.Symlink("/proc", offrootTarget); err != nil {
+			t.Fatalf("create offroot symlink: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(offrootTarget) })
+
+		fakeCmd := &FakeCommandRunner{
+			Errors: map[string]error{
+				"which pvesm": errors.New("missing"),
+			},
+		}
+		restoreCmd = fakeCmd
+		mountGuardReadFile = func(path string) ([]byte, error) {
+			switch path {
+			case "/proc/self/mountinfo", "/proc/mounts":
+				return []byte(""), nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		}
+		mountGuardSysMount = func(source, target, fstype string, flags uintptr, data string) error {
+			t.Fatalf("guard mount should not be attempted for skipped targets")
+			return nil
+		}
+
+		if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, plan, stageRoot, "/"); err != nil {
+			t.Fatalf("expected skips for mkdir failure/off-root symlink, got %v", err)
+		}
+		calls := strings.Join(fakeCmd.CallsList(), "\n")
+		if strings.Contains(calls, "mount /mnt/pve/mkdir-fail") || strings.Contains(calls, "mount /mnt/pve/offroot-link") {
+			t.Fatalf("mount attempts should not happen for skipped targets; calls=%v", fakeCmd.CallsList())
+		}
+	})
+
+	t.Run("guard fallback chattr failure and guard bind success", func(t *testing.T) {
+		stageRoot := t.TempDir()
+		stageCfgPath := filepath.Join(stageRoot, "etc/pve/storage.cfg")
+		if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
+			t.Fatalf("mkdir stage cfg dir: %v", err)
+		}
+		cfg := strings.Join([]string{
+			"nfs: chattr-fail",
+			"nfs: guard-ok",
+			"",
+		}, "\n")
+		if err := os.WriteFile(stageCfgPath, []byte(cfg), 0o644); err != nil {
+			t.Fatalf("write staged storage.cfg: %v", err)
+		}
+
+		chattrFailTarget := "/mnt/pve/chattr-fail"
+		guardOKTarget := "/mnt/pve/guard-ok"
+		t.Cleanup(func() { _ = os.RemoveAll(chattrFailTarget) })
+		t.Cleanup(func() { _ = os.RemoveAll(guardOKTarget) })
+		t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(chattrFailTarget)) })
+		t.Cleanup(func() { _ = os.RemoveAll(guardDirForTarget(guardOKTarget)) })
+
+		fakeCmd := &FakeCommandRunner{
+			Errors: map[string]error{
+				"which pvesm":                  errors.New("missing"),
+				"mount " + chattrFailTarget:    errors.New("offline"),
+				"chattr +i " + chattrFailTarget: errors.New("chattr denied"),
+				"mount " + guardOKTarget:       errors.New("offline"),
+			},
+		}
+		restoreCmd = fakeCmd
+		mountGuardReadFile = func(path string) ([]byte, error) {
+			switch path {
+			case "/proc/self/mountinfo", "/proc/mounts":
+				return []byte(""), nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		}
+		mountGuardSysMount = func(source, target, fstype string, flags uintptr, data string) error {
+			if target == chattrFailTarget {
+				return errors.New("bind denied")
+			}
+			return nil
+		}
+
+		if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, plan, stageRoot, "/"); err != nil {
+			t.Fatalf("expected non-fatal guard fallback handling, got %v", err)
+		}
+		calls := strings.Join(fakeCmd.CallsList(), "\n")
+		if !strings.Contains(calls, "chattr +i "+chattrFailTarget) {
+			t.Fatalf("missing chattr fallback call for failing guard target; calls=%v", fakeCmd.CallsList())
+		}
+		if strings.Contains(calls, "chattr +i "+guardOKTarget) {
+			t.Fatalf("chattr should not run when guard bind succeeds; calls=%v", fakeCmd.CallsList())
+		}
+	})
+}

--- a/internal/orchestrator/pve_staged_apply_additional_test.go
+++ b/internal/orchestrator/pve_staged_apply_additional_test.go
@@ -10,6 +10,15 @@ import (
 	"testing"
 )
 
+func requireWritablePveMountRoot(t *testing.T) {
+	t.Helper()
+	probe := filepath.Join("/mnt/pve", ".proxsave-mount-guard-probe")
+	if err := os.MkdirAll(filepath.Dir(probe), 0o755); err != nil {
+		t.Skipf("requires writable %s: %v", filepath.Dir(probe), err)
+	}
+	_ = os.Remove(probe)
+}
+
 func pvePlan(needsClusterRestore bool, ids ...string) *RestorePlan {
 	cats := make([]Category, 0, len(ids))
 	for _, id := range ids {
@@ -570,6 +579,7 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_EarlyAndFallback(t *testing.T)
 	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, pvePlan(false, "storage_pve"), "/stage", "/tmp/not-root"); err != nil {
 		t.Fatalf("non-root destination: expected nil error, got %v", err)
 	}
+	requireWritablePveMountRoot(t)
 
 	origFS := restoreFS
 	origCmd := restoreCmd
@@ -577,6 +587,7 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_EarlyAndFallback(t *testing.T)
 	origMkdirAll := mountGuardMkdirAll
 	origSysMount := mountGuardSysMount
 	origSysUnmount := mountGuardSysUnmount
+	origGeteuid := mountGuardGeteuid
 	t.Cleanup(func() {
 		restoreFS = origFS
 		restoreCmd = origCmd
@@ -584,7 +595,9 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_EarlyAndFallback(t *testing.T)
 		mountGuardMkdirAll = origMkdirAll
 		mountGuardSysMount = origSysMount
 		mountGuardSysUnmount = origSysUnmount
+		mountGuardGeteuid = origGeteuid
 	})
+	mountGuardGeteuid = func() int { return 0 }
 
 	nonRealFS := NewFakeFS()
 	t.Cleanup(func() { _ = os.RemoveAll(nonRealFS.Root) })
@@ -654,12 +667,15 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ReadAndNoopBranches(t *testing
 
 	origFS := restoreFS
 	origCmd := restoreCmd
+	origGeteuid := mountGuardGeteuid
 	t.Cleanup(func() {
 		restoreFS = origFS
 		restoreCmd = origCmd
+		mountGuardGeteuid = origGeteuid
 	})
 
 	restoreFS = osFS{}
+	mountGuardGeteuid = func() int { return 0 }
 	restoreCmd = &FakeCommandRunner{}
 
 	stageRoot := t.TempDir()
@@ -698,6 +714,7 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 	ctx := context.Background()
 	logger := newTestLogger()
 	plan := pvePlan(false, "storage_pve")
+	requireWritablePveMountRoot(t)
 
 	origFS := restoreFS
 	origCmd := restoreCmd
@@ -705,6 +722,7 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 	origMkdirAll := mountGuardMkdirAll
 	origSysMount := mountGuardSysMount
 	origSysUnmount := mountGuardSysUnmount
+	origGeteuid := mountGuardGeteuid
 	t.Cleanup(func() {
 		restoreFS = origFS
 		restoreCmd = origCmd
@@ -712,9 +730,11 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 		mountGuardMkdirAll = origMkdirAll
 		mountGuardSysMount = origSysMount
 		mountGuardSysUnmount = origSysUnmount
+		mountGuardGeteuid = origGeteuid
 	})
 
 	restoreFS = osFS{}
+	mountGuardGeteuid = func() int { return 0 }
 	mountGuardMkdirAll = os.MkdirAll
 	mountGuardSysUnmount = func(target string, flags int) error { return nil }
 

--- a/internal/orchestrator/restore_access_control.go
+++ b/internal/orchestrator/restore_access_control.go
@@ -61,7 +61,7 @@ func maybeApplyAccessControlFromStage(ctx context.Context, logger *logging.Logge
 		logger.Debug("Skipping staged access control apply: non-system filesystem in use")
 		return nil
 	}
-	if os.Geteuid() != 0 {
+	if accessControlApplyGeteuid() != 0 {
 		logger.Warning("Skipping staged access control apply: requires root privileges")
 		return nil
 	}

--- a/internal/orchestrator/restore_access_control_additional_test.go
+++ b/internal/orchestrator/restore_access_control_additional_test.go
@@ -1,0 +1,1141 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestApplySensitiveFileFromStage_Branches(t *testing.T) {
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+
+	logger := newTestLogger()
+	stageRoot := "/stage"
+	rel := "etc/proxmox-backup/secret.cfg"
+	dest := "/etc/proxmox-backup/secret.cfg"
+	stagePath := filepath.Join(stageRoot, rel)
+
+	if err := applySensitiveFileFromStage(logger, stageRoot, rel, dest, 0o600); err != nil {
+		t.Fatalf("missing staged file should be ignored: %v", err)
+	}
+
+	restoreFS = readFileFailFS{FS: fakeFS, failPath: stagePath, err: errors.New("boom")}
+	if err := applySensitiveFileFromStage(logger, stageRoot, rel, dest, 0o600); err == nil || !strings.Contains(err.Error(), "read staged "+rel) {
+		t.Fatalf("expected staged read error, got %v", err)
+	}
+	restoreFS = fakeFS
+
+	if err := fakeFS.WriteFile(dest, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("seed destination file: %v", err)
+	}
+	if err := fakeFS.WriteFile(stagePath, []byte(" \n\t"), 0o600); err != nil {
+		t.Fatalf("write empty staged file: %v", err)
+	}
+	if err := applySensitiveFileFromStage(logger, stageRoot, rel, dest, 0o600); err != nil {
+		t.Fatalf("empty staged file should remove destination: %v", err)
+	}
+	if _, err := fakeFS.Stat(dest); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected destination removed, stat err=%v", err)
+	}
+
+	if err := fakeFS.WriteFile(stagePath, []byte("  token=abc123  \n"), 0o600); err != nil {
+		t.Fatalf("write staged non-empty file: %v", err)
+	}
+	if err := applySensitiveFileFromStage(logger, stageRoot, rel, dest, 0o600); err != nil {
+		t.Fatalf("apply non-empty staged file: %v", err)
+	}
+	got, err := fakeFS.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read applied destination: %v", err)
+	}
+	if string(got) != "token=abc123\n" {
+		t.Fatalf("destination=%q want %q", string(got), "token=abc123\n")
+	}
+}
+
+func TestMaybeApplyAccessControlFromStage_Branches(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+
+	if err := maybeApplyAccessControlFromStage(ctx, logger, nil, "/stage", false); err != nil {
+		t.Fatalf("nil plan should be ignored: %v", err)
+	}
+
+	planNoCategories := &RestorePlan{
+		SystemType:       SystemTypePVE,
+		NormalCategories: []Category{{ID: "unrelated", Type: CategoryTypePVE}},
+	}
+	if err := maybeApplyAccessControlFromStage(ctx, logger, planNoCategories, "/stage", false); err != nil {
+		t.Fatalf("plan without access-control categories should be ignored: %v", err)
+	}
+	if err := maybeApplyAccessControlFromStage(ctx, logger, planNoCategories, "   ", false); err != nil {
+		t.Fatalf("blank stage root should be ignored: %v", err)
+	}
+
+	pveClusterSafe := &RestorePlan{
+		SystemType:          SystemTypePVE,
+		ClusterBackup:       true,
+		NeedsClusterRestore: false,
+		NormalCategories:    []Category{{ID: "pve_access_control", Type: CategoryTypePVE}},
+	}
+	if err := maybeApplyAccessControlFromStage(ctx, logger, pveClusterSafe, "/stage", true); err != nil {
+		t.Fatalf("dry-run PVE cluster-safe plan should return nil: %v", err)
+	}
+
+	pbsDryRun := &RestorePlan{
+		SystemType:       SystemTypePBS,
+		NormalCategories: []Category{{ID: "pbs_access_control", Type: CategoryTypePBS}},
+	}
+	if err := maybeApplyAccessControlFromStage(ctx, logger, pbsDryRun, "/stage", true); err != nil {
+		t.Fatalf("dry-run PBS plan should return nil: %v", err)
+	}
+
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+
+	if err := maybeApplyAccessControlFromStage(ctx, logger, pbsDryRun, "/stage", false); err != nil {
+		t.Fatalf("non-real FS should skip staged access-control apply: %v", err)
+	}
+}
+
+func TestApplyPBSAccessControlFromStage_EarlyAndReadErrors(t *testing.T) {
+	logger := newTestLogger()
+
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := applyPBSAccessControlFromStage(canceled, logger, "/stage"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	if err := applyPBSAccessControlFromStage(nil, logger, "/stage"); err != nil {
+		t.Fatalf("nil context with missing staged files should be safe, got %v", err)
+	}
+
+	restoreFS = readFileFailFS{FS: fakeFS, failPath: "/stage/etc/proxmox-backup/user.cfg", err: syscall.EIO}
+	if err := applyPBSAccessControlFromStage(context.Background(), logger, "/stage"); err == nil || !strings.Contains(err.Error(), "read staged etc/proxmox-backup/user.cfg") {
+		t.Fatalf("expected staged user.cfg read error, got %v", err)
+	}
+}
+
+func TestPBSACLApplyAndHelpers_Branches(t *testing.T) {
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+
+	logger := newTestLogger()
+
+	if err := fakeFS.WriteFile(pbsACLCfgPath, []byte("old\n"), 0o640); err != nil {
+		t.Fatalf("seed old acl file: %v", err)
+	}
+	if err := applyPBSACLFromStage(logger, " \n\t"); err != nil {
+		t.Fatalf("empty ACL should remove current file: %v", err)
+	}
+	if _, err := fakeFS.Stat(pbsACLCfgPath); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected ACL removed, stat err=%v", err)
+	}
+
+	if err := fakeFS.WriteFile(pbsACLCfgPath, []byte("keep-me\n"), 0o640); err != nil {
+		t.Fatalf("seed acl file for unknown format: %v", err)
+	}
+	if err := applyPBSACLFromStage(logger, "this-is-not-known-format"); err != nil {
+		t.Fatalf("unknown ACL format should be ignored, got %v", err)
+	}
+	kept, err := fakeFS.ReadFile(pbsACLCfgPath)
+	if err != nil {
+		t.Fatalf("read acl after unknown format: %v", err)
+	}
+	if string(kept) != "keep-me\n" {
+		t.Fatalf("unknown format should keep previous acl content, got %q", string(kept))
+	}
+
+	sectionACL := strings.Join([]string{
+		"acl: backup-acl",
+		"  path /",
+		"  users root@pam alice@pbs",
+		"  roles Admin",
+		"",
+	}, "\n")
+	if err := applyPBSACLFromStage(logger, sectionACL); err != nil {
+		t.Fatalf("apply section ACL format: %v", err)
+	}
+	gotSection, err := fakeFS.ReadFile(pbsACLCfgPath)
+	if err != nil {
+		t.Fatalf("read section ACL output: %v", err)
+	}
+	if !strings.Contains(string(gotSection), "users alice@pbs") {
+		t.Fatalf("expected root user filtered from staged users, got:\n%s", string(gotSection))
+	}
+	if !strings.Contains(string(gotSection), "acl: proxsave-root-admin") {
+		t.Fatalf("expected root admin safety ACL injected, got:\n%s", string(gotSection))
+	}
+
+	lineACL := strings.Join([]string{
+		"acl:1:/:root@pam!old,alice@pbs:Admin",
+		"acl:0:/datastore:bob@pbs:DatastoreAdmin",
+		"keep-verbatim-line",
+		"",
+	}, "\n")
+	if err := applyPBSACLFromStage(logger, lineACL); err != nil {
+		t.Fatalf("apply line ACL format: %v", err)
+	}
+	gotLine, err := fakeFS.ReadFile(pbsACLCfgPath)
+	if err != nil {
+		t.Fatalf("read line ACL output: %v", err)
+	}
+	if !strings.Contains(string(gotLine), "acl:1:/:alice@pbs:Admin") {
+		t.Fatalf("expected root token filtered from ACL user list, got:\n%s", string(gotLine))
+	}
+	if !strings.Contains(string(gotLine), "keep-verbatim-line") {
+		t.Fatalf("expected unknown non-empty lines preserved, got:\n%s", string(gotLine))
+	}
+	if !strings.Contains(string(gotLine), "acl:1:/:root@pam:Admin") {
+		t.Fatalf("expected root admin ACL appended in line format, got:\n%s", string(gotLine))
+	}
+
+	if isPBSACLLineFormat("user: root@pam") {
+		t.Fatalf("expected false for non-acl line format")
+	}
+	if !isPBSACLLineFormat("acl:1:/:root@pam:Admin") {
+		t.Fatalf("expected true for valid acl line format")
+	}
+	if isPBSACLLineFormat("# comment only\n\n") {
+		t.Fatalf("expected false for comment-only content")
+	}
+
+	if _, ok := parsePBSACLLine("   "); ok {
+		t.Fatalf("empty line should return ok=false")
+	}
+	if entry, ok := parsePBSACLLine("custom line"); !ok || entry.Raw != "custom line" {
+		t.Fatalf("non-acl line parse mismatch: ok=%v entry=%+v", ok, entry)
+	}
+	if entry, ok := parsePBSACLLine("acl:1:/:missingparts"); !ok || entry.Raw == "" || entry.Path != "" {
+		t.Fatalf("invalid acl line should be preserved as raw: ok=%v entry=%+v", ok, entry)
+	}
+	if entry, ok := parsePBSACLLine("acl:1:/:alice@pbs:Admin"); !ok || entry.Path != "/" || entry.UserList != "alice@pbs" {
+		t.Fatalf("valid acl line parse mismatch: ok=%v entry=%+v", ok, entry)
+	}
+
+	if got, ok := filterPBSACLUsers("root@pam, root@pam!token"); ok || got != "" {
+		t.Fatalf("expected all-root ACL users to be filtered out, got=%q ok=%v", got, ok)
+	}
+
+	if err := applyPBSACLLineFormat("acl:1:/:root@pam:Admin\n"); err != nil {
+		t.Fatalf("applyPBSACLLineFormat with root already present: %v", err)
+	}
+	withRoot, err := fakeFS.ReadFile(pbsACLCfgPath)
+	if err != nil {
+		t.Fatalf("read ACL with preexisting root admin line: %v", err)
+	}
+	if strings.Count(string(withRoot), "acl:1:/:root@pam:Admin") != 1 {
+		t.Fatalf("root admin line should not be duplicated, got:\n%s", string(withRoot))
+	}
+
+	entries := []proxmoxNotificationEntry{
+		{Key: "users", Value: "old"},
+		{Key: "users", Value: "duplicate"},
+		{Key: "roles", Value: "Admin"},
+	}
+	replaced := setSectionEntryValue(entries, "users", "alice@pbs")
+	if findSectionEntryValue(replaced, "users") != "alice@pbs" {
+		t.Fatalf("setSectionEntryValue should replace first matching key")
+	}
+	countUsers := 0
+	for _, e := range replaced {
+		if strings.TrimSpace(e.Key) == "users" {
+			countUsers++
+		}
+	}
+	if countUsers != 1 {
+		t.Fatalf("setSectionEntryValue should collapse duplicate keys, count=%d", countUsers)
+	}
+	appended := setSectionEntryValue(replaced, "path", "/")
+	if findSectionEntryValue(appended, "path") != "/" {
+		t.Fatalf("setSectionEntryValue should append missing key")
+	}
+	unchanged := setSectionEntryValue(replaced, "   ", "ignored")
+	if len(unchanged) != len(replaced) {
+		t.Fatalf("empty key should not modify entries")
+	}
+
+	sectionsWithRoot := []proxmoxNotificationSection{
+		{
+			Type: "acl",
+			Name: "rule /",
+			Entries: []proxmoxNotificationEntry{
+				{Key: "users", Value: "root@pam"},
+				{Key: "roles", Value: "Admin"},
+			},
+		},
+	}
+	if !hasPBSRootAdminOnRootSectionFormat(sectionsWithRoot) {
+		t.Fatalf("expected root Admin ACL on / to be detected")
+	}
+	if hasPBSRootAdminOnRootSectionFormat([]proxmoxNotificationSection{{Type: "acl", Name: "rule /vms"}}) {
+		t.Fatalf("unexpected root Admin ACL detection")
+	}
+
+	if got := aclPathFromSectionName("rule-name /pool/one extra"); got != "/pool/one" {
+		t.Fatalf("aclPathFromSectionName=%q want %q", got, "/pool/one")
+	}
+	if got := aclPathFromSectionName("rule-name-without-path"); got != "" {
+		t.Fatalf("aclPathFromSectionName=%q want empty", got)
+	}
+}
+
+func TestPBSSecretFilesFromStage_Branches(t *testing.T) {
+	t.Run("shadow.json branches", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		logger := newTestLogger()
+		stageRoot := "/stage"
+		stagePath := filepath.Join(stageRoot, "etc/proxmox-backup/shadow.json")
+
+		if err := applyPBSShadowJSONFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("missing staged shadow.json should be ignored: %v", err)
+		}
+
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: stagePath, err: syscall.EIO}
+		if err := applyPBSShadowJSONFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "read staged shadow.json") {
+			t.Fatalf("expected staged read error, got %v", err)
+		}
+		restoreFS = fakeFS
+
+		if err := fakeFS.WriteFile(pbsShadowJSONPath, []byte(`{"old":"keep"}`), 0o600); err != nil {
+			t.Fatalf("seed current shadow.json: %v", err)
+		}
+		if err := fakeFS.WriteFile(stagePath, []byte(" \n\t"), 0o600); err != nil {
+			t.Fatalf("write empty staged shadow.json: %v", err)
+		}
+		if err := applyPBSShadowJSONFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("empty staged shadow.json should remove destination: %v", err)
+		}
+		if _, err := fakeFS.Stat(pbsShadowJSONPath); err == nil || !os.IsNotExist(err) {
+			t.Fatalf("expected %s removed, stat err=%v", pbsShadowJSONPath, err)
+		}
+
+		if err := fakeFS.WriteFile(stagePath, []byte(`{"broken"`), 0o600); err != nil {
+			t.Fatalf("write invalid staged shadow.json: %v", err)
+		}
+		if err := applyPBSShadowJSONFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "parse staged shadow.json") {
+			t.Fatalf("expected parse error, got %v", err)
+		}
+
+		if err := fakeFS.WriteFile(stagePath, []byte(`{"root@pbs":"old-root","alice@pbs":"alice-hash"}`), 0o600); err != nil {
+			t.Fatalf("write valid staged shadow.json: %v", err)
+		}
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: pbsShadowJSONPath, err: syscall.EPERM}
+		if err := applyPBSShadowJSONFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "read current shadow.json") {
+			t.Fatalf("expected current shadow read error, got %v", err)
+		}
+		restoreFS = fakeFS
+
+		if err := fakeFS.WriteFile(pbsShadowJSONPath, []byte(`{"root@pam":"fresh-root-hash","bob@pbs":"old-bob"}`), 0o600); err != nil {
+			t.Fatalf("seed current shadow.json with root: %v", err)
+		}
+		if err := applyPBSShadowJSONFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("apply valid shadow.json merge: %v", err)
+		}
+		got, err := fakeFS.ReadFile(pbsShadowJSONPath)
+		if err != nil {
+			t.Fatalf("read merged shadow.json: %v", err)
+		}
+		if strings.Contains(string(got), "root@pbs") {
+			t.Fatalf("root@pbs from staged backup should be filtered, got=%s", string(got))
+		}
+		if !strings.Contains(string(got), "root@pam") || !strings.Contains(string(got), "fresh-root-hash") {
+			t.Fatalf("current root@pam hash should be preserved, got=%s", string(got))
+		}
+		if !strings.Contains(string(got), "alice@pbs") {
+			t.Fatalf("non-root staged user should be restored, got=%s", string(got))
+		}
+	})
+
+	t.Run("token.shadow branches", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		logger := newTestLogger()
+		stageRoot := "/stage"
+		stagePath := filepath.Join(stageRoot, "etc/proxmox-backup/token.shadow")
+
+		if err := applyPBSTokenShadowFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("missing staged token.shadow should be ignored: %v", err)
+		}
+
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: stagePath, err: syscall.EIO}
+		if err := applyPBSTokenShadowFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "read staged token.shadow") {
+			t.Fatalf("expected staged read error, got %v", err)
+		}
+		restoreFS = fakeFS
+
+		if err := fakeFS.WriteFile(pbsTokenShadowPath, []byte(`{"old":"keep"}`), 0o600); err != nil {
+			t.Fatalf("seed token.shadow: %v", err)
+		}
+		if err := fakeFS.WriteFile(stagePath, []byte(" \n\t"), 0o600); err != nil {
+			t.Fatalf("write empty staged token.shadow: %v", err)
+		}
+		if err := applyPBSTokenShadowFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("empty staged token.shadow should remove destination: %v", err)
+		}
+		if _, err := fakeFS.Stat(pbsTokenShadowPath); err == nil || !os.IsNotExist(err) {
+			t.Fatalf("expected %s removed, stat err=%v", pbsTokenShadowPath, err)
+		}
+
+		if err := fakeFS.WriteFile(stagePath, []byte(`{"broken"`), 0o600); err != nil {
+			t.Fatalf("write invalid staged token.shadow: %v", err)
+		}
+		if err := applyPBSTokenShadowFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "parse staged token.shadow") {
+			t.Fatalf("expected parse error, got %v", err)
+		}
+
+		if err := fakeFS.WriteFile(stagePath, []byte(`{"root@pam!old":"old-secret","alice@pbs!tok":"alice-secret"}`), 0o600); err != nil {
+			t.Fatalf("write valid staged token.shadow: %v", err)
+		}
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: pbsTokenShadowPath, err: syscall.EPERM}
+		if err := applyPBSTokenShadowFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "read current token.shadow") {
+			t.Fatalf("expected current token.shadow read error, got %v", err)
+		}
+		restoreFS = fakeFS
+
+		if err := fakeFS.WriteFile(pbsTokenShadowPath, []byte(`{"root@pam!fresh":"fresh-secret","bob@pbs!old":"old"}`), 0o600); err != nil {
+			t.Fatalf("seed current token.shadow: %v", err)
+		}
+		if err := applyPBSTokenShadowFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("apply valid token.shadow merge: %v", err)
+		}
+		got, err := fakeFS.ReadFile(pbsTokenShadowPath)
+		if err != nil {
+			t.Fatalf("read merged token.shadow: %v", err)
+		}
+		if strings.Contains(string(got), "root@pam!old") {
+			t.Fatalf("staged root token should be filtered, got=%s", string(got))
+		}
+		if !strings.Contains(string(got), "root@pam!fresh") {
+			t.Fatalf("current root token should be preserved, got=%s", string(got))
+		}
+		if !strings.Contains(string(got), "alice@pbs!tok") {
+			t.Fatalf("non-root staged token should be restored, got=%s", string(got))
+		}
+	})
+
+	t.Run("tfa.json branches", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		logger := newTestLogger()
+		stageRoot := "/stage"
+		stagePath := filepath.Join(stageRoot, "etc/proxmox-backup/tfa.json")
+
+		if err := applyPBSTFAJSONFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("missing staged tfa.json should be ignored: %v", err)
+		}
+
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: stagePath, err: syscall.EIO}
+		if err := applyPBSTFAJSONFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "read staged tfa.json") {
+			t.Fatalf("expected staged read error, got %v", err)
+		}
+		restoreFS = fakeFS
+
+		if err := fakeFS.WriteFile(pbsTFAJSONPath, []byte(`{"users":{}}`), 0o600); err != nil {
+			t.Fatalf("seed tfa.json: %v", err)
+		}
+		if err := fakeFS.WriteFile(stagePath, []byte(" \n\t"), 0o600); err != nil {
+			t.Fatalf("write empty staged tfa.json: %v", err)
+		}
+		if err := applyPBSTFAJSONFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("empty staged tfa.json should remove destination: %v", err)
+		}
+		if _, err := fakeFS.Stat(pbsTFAJSONPath); err == nil || !os.IsNotExist(err) {
+			t.Fatalf("expected %s removed, stat err=%v", pbsTFAJSONPath, err)
+		}
+
+		if err := fakeFS.WriteFile(stagePath, []byte(`{"broken"`), 0o600); err != nil {
+			t.Fatalf("write invalid staged tfa.json: %v", err)
+		}
+		if err := applyPBSTFAJSONFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "parse staged tfa.json") {
+			t.Fatalf("expected parse error, got %v", err)
+		}
+
+		stageTFA := `{"users":{"root@pam":{"totp":[1]},"alice@pbs":{"webauthn":[{"id":"x"}]}},"webauthn":{"rp":"backup"}}`
+		if err := fakeFS.WriteFile(stagePath, []byte(stageTFA), 0o600); err != nil {
+			t.Fatalf("write valid staged tfa.json: %v", err)
+		}
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: pbsTFAJSONPath, err: syscall.EPERM}
+		if err := applyPBSTFAJSONFromStage(logger, stageRoot); err == nil || !strings.Contains(err.Error(), "read current tfa.json") {
+			t.Fatalf("expected current tfa.json read error, got %v", err)
+		}
+		restoreFS = fakeFS
+
+		currentTFA := `{"users":{"root@pam":{"totp":[9]},"keep@pbs":{"totp":[7]}},"totp":{"digits":6}}`
+		if err := fakeFS.WriteFile(pbsTFAJSONPath, []byte(currentTFA), 0o600); err != nil {
+			t.Fatalf("seed current tfa.json: %v", err)
+		}
+		if err := applyPBSTFAJSONFromStage(logger, stageRoot); err != nil {
+			t.Fatalf("apply valid tfa.json merge: %v", err)
+		}
+		got, err := fakeFS.ReadFile(pbsTFAJSONPath)
+		if err != nil {
+			t.Fatalf("read merged tfa.json: %v", err)
+		}
+		if strings.Contains(string(got), `"root@pam":{"totp":[1]}`) {
+			t.Fatalf("staged root@pam TFA should be replaced by current one, got=%s", string(got))
+		}
+		if !strings.Contains(string(got), `"root@pam":{"totp":[9]}`) {
+			t.Fatalf("current root@pam TFA should be preserved, got=%s", string(got))
+		}
+		if !strings.Contains(string(got), `"alice@pbs"`) {
+			t.Fatalf("non-root staged user should be restored, got=%s", string(got))
+		}
+	})
+}
+
+func TestApplyPVEAccessControlFromStage_AdditionalBranches(t *testing.T) {
+	t.Run("context handling and no staged files", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		canceled, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := applyPVEAccessControlFromStage(canceled, newTestLogger(), "/stage"); !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+
+		if err := applyPVEAccessControlFromStage(nil, newTestLogger(), "/stage"); err != nil {
+			t.Fatalf("nil context with no staged files should be safe, got %v", err)
+		}
+	})
+
+	t.Run("staged read error surfaces", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+		base := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(base.Root) })
+		restoreFS = readFileFailFS{FS: base, failPath: "/stage/etc/pve/user.cfg", err: syscall.EIO}
+
+		if err := applyPVEAccessControlFromStage(context.Background(), newTestLogger(), "/stage"); err == nil || !strings.Contains(err.Error(), "read staged etc/pve/user.cfg") {
+			t.Fatalf("expected staged read error, got %v", err)
+		}
+	})
+
+	t.Run("root bootstrap and realm merge with pve user", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		stageRoot := "/stage"
+		stagedUser := strings.Join([]string{
+			"user: alice@pve",
+			"  enable 1",
+			"",
+		}, "\n")
+		stagedDomains := strings.Join([]string{
+			"pam: pam",
+			"  comment backup-pam",
+			"",
+		}, "\n")
+		stagedTFA := strings.Join([]string{
+			"webauthn: alice-key",
+			"  user alice@pve",
+			"",
+		}, "\n")
+
+		if err := fakeFS.WriteFile(stageRoot+"/etc/pve/user.cfg", []byte(stagedUser), 0o640); err != nil {
+			t.Fatalf("write staged user.cfg: %v", err)
+		}
+		if err := fakeFS.WriteFile(stageRoot+"/etc/pve/domains.cfg", []byte(stagedDomains), 0o640); err != nil {
+			t.Fatalf("write staged domains.cfg: %v", err)
+		}
+		if err := fakeFS.WriteFile(stageRoot+"/etc/pve/priv/tfa.cfg", []byte(stagedTFA), 0o600); err != nil {
+			t.Fatalf("write staged tfa.cfg: %v", err)
+		}
+
+		if err := applyPVEAccessControlFromStage(context.Background(), newTestLogger(), stageRoot); err != nil {
+			t.Fatalf("applyPVEAccessControlFromStage: %v", err)
+		}
+
+		gotUser, err := fakeFS.ReadFile(pveUserCfgPath)
+		if err != nil {
+			t.Fatalf("read merged user.cfg: %v", err)
+		}
+		if !strings.Contains(string(gotUser), "user: root@pam") || !strings.Contains(string(gotUser), "enable 1") {
+			t.Fatalf("expected root@pam bootstrap user to be present, got:\n%s", string(gotUser))
+		}
+		if !strings.Contains(string(gotUser), "acl: proxsave-root-admin") {
+			t.Fatalf("expected root admin ACL to be injected, got:\n%s", string(gotUser))
+		}
+
+		gotDomains, err := fakeFS.ReadFile(pveDomainsCfgPath)
+		if err != nil {
+			t.Fatalf("read merged domains.cfg: %v", err)
+		}
+		if !strings.Contains(string(gotDomains), "pam: pam") || !strings.Contains(string(gotDomains), "pve: pve") {
+			t.Fatalf("expected required pam/pve realms, got:\n%s", string(gotDomains))
+		}
+	})
+}
+
+func TestAccessControlUtilityFunctions_Branches(t *testing.T) {
+	t.Run("stage/read helpers and renderer", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+
+		fakeFS := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+		restoreFS = fakeFS
+
+		if content, present, err := readStageFileOptional("/stage", "etc/pve/user.cfg"); err != nil || present || content != "" {
+			t.Fatalf("missing staged file mismatch: content=%q present=%v err=%v", content, present, err)
+		}
+
+		stagePath := "/stage/etc/pve/user.cfg"
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: stagePath, err: syscall.EPERM}
+		if _, _, err := readStageFileOptional("/stage", "etc/pve/user.cfg"); err == nil || !strings.Contains(err.Error(), "read staged etc/pve/user.cfg") {
+			t.Fatalf("expected staged read error, got %v", err)
+		}
+		restoreFS = fakeFS
+
+		if err := fakeFS.WriteFile(stagePath, []byte(" \n\t"), 0o640); err != nil {
+			t.Fatalf("write empty staged user.cfg: %v", err)
+		}
+		if content, present, err := readStageFileOptional("/stage", "etc/pve/user.cfg"); err != nil || !present || content != "" {
+			t.Fatalf("empty staged file mismatch: content=%q present=%v err=%v", content, present, err)
+		}
+
+		if err := fakeFS.WriteFile(stagePath, []byte(" user: alice@pve \n"), 0o640); err != nil {
+			t.Fatalf("write non-empty staged user.cfg: %v", err)
+		}
+		if content, present, err := readStageFileOptional("/stage", "etc/pve/user.cfg"); err != nil || !present || content != "user: alice@pve" {
+			t.Fatalf("trimmed staged file mismatch: content=%q present=%v err=%v", content, present, err)
+		}
+
+		if sections, err := readProxmoxConfigSectionsOptional("/missing.cfg"); err != nil || len(sections) != 0 {
+			t.Fatalf("missing proxmox cfg mismatch: sections=%v err=%v", sections, err)
+		}
+
+		restoreFS = readFileFailFS{FS: fakeFS, failPath: "/etc/pve/user.cfg", err: syscall.EIO}
+		if _, err := readProxmoxConfigSectionsOptional("/etc/pve/user.cfg"); err == nil {
+			t.Fatalf("expected read error from readProxmoxConfigSectionsOptional")
+		}
+		restoreFS = fakeFS
+
+		if err := fakeFS.WriteFile("/etc/pve/user.cfg", []byte(" \n\t"), 0o640); err != nil {
+			t.Fatalf("write empty /etc/pve/user.cfg: %v", err)
+		}
+		if sections, err := readProxmoxConfigSectionsOptional("/etc/pve/user.cfg"); err != nil || len(sections) != 0 {
+			t.Fatalf("empty proxmox cfg mismatch: sections=%v err=%v", sections, err)
+		}
+
+		if err := fakeFS.WriteFile("/etc/pve/user.cfg", []byte("user: alice@pve\n  enable 1\n"), 0o640); err != nil {
+			t.Fatalf("write valid /etc/pve/user.cfg: %v", err)
+		}
+		if sections, err := readProxmoxConfigSectionsOptional("/etc/pve/user.cfg"); err != nil || len(sections) != 1 {
+			t.Fatalf("valid proxmox cfg parse mismatch: sections=%v err=%v", sections, err)
+		}
+
+		rendered := renderProxmoxConfig([]proxmoxNotificationSection{
+			{Type: " ", Name: "ignored"},
+			{
+				Type: "user",
+				Name: "alice@pve",
+				Entries: []proxmoxNotificationEntry{
+					{Key: "enable", Value: "1"},
+					{Key: "comment", Value: ""},
+					{Key: " ", Value: "ignored"},
+				},
+			},
+		})
+		if !strings.Contains(rendered, "user: alice@pve") || !strings.Contains(rendered, "  enable 1") || !strings.Contains(rendered, "  comment") {
+			t.Fatalf("renderProxmoxConfig output unexpected:\n%s", rendered)
+		}
+		if !strings.HasSuffix(rendered, "\n") {
+			t.Fatalf("renderProxmoxConfig should end with newline")
+		}
+		if renderProxmoxConfig(nil) != "" {
+			t.Fatalf("renderProxmoxConfig(nil) should be empty")
+		}
+	})
+
+	t.Run("ids, realms and ACL predicates", func(t *testing.T) {
+		if !isRootPBSUserID(" root@pbs ") {
+			t.Fatalf("isRootPBSUserID should detect root regardless of realm/spacing")
+		}
+		if isRootPBSUserID("   ") {
+			t.Fatalf("isRootPBSUserID should reject empty ids")
+		}
+		if !isRootPBSAuthID(" root@pam!tok ") {
+			t.Fatalf("isRootPBSAuthID should detect root-bound auth ids")
+		}
+		if isRootPBSAuthID("   ") {
+			t.Fatalf("isRootPBSAuthID should reject empty auth ids")
+		}
+
+		withRoot := []proxmoxNotificationSection{
+			{Type: "role", Name: "Admin"},
+			{Type: "user", Name: "root@pam"},
+			{Type: "user", Name: "alice@pbs"},
+		}
+		if root := findPBSRootUserSection(withRoot); root == nil || root.Name != "root@pam" {
+			t.Fatalf("findPBSRootUserSection should find root user, got %+v", root)
+		}
+		if root := findPBSRootUserSection([]proxmoxNotificationSection{{Type: "user", Name: "alice@pbs"}}); root != nil {
+			t.Fatalf("findPBSRootUserSection should return nil when root is missing, got %+v", root)
+		}
+
+		if realm := userRealm("alice@pve"); realm != "pve" {
+			t.Fatalf("userRealm=%q want pve", realm)
+		}
+		if realm := userRealm("alice"); realm != "" {
+			t.Fatalf("userRealm without @ should be empty, got %q", realm)
+		}
+
+		sections := []proxmoxNotificationSection{
+			{Type: "user", Name: "alice@pve"},
+			{Type: "role", Name: "Admin"},
+		}
+		if !anyUserInRealm(sections, "pve") {
+			t.Fatalf("expected anyUserInRealm to detect pve user")
+		}
+		if anyUserInRealm(sections, "pbs") {
+			t.Fatalf("did not expect pbs realm match")
+		}
+		if anyUserInRealm(sections, "   ") {
+			t.Fatalf("empty realm should never match")
+		}
+
+		backup := []proxmoxNotificationSection{{Type: "pam", Name: "pam", Entries: []proxmoxNotificationEntry{{Key: "comment", Value: "backup"}}}}
+		current := []proxmoxNotificationSection{
+			{Type: "pam", Name: "pam", Entries: []proxmoxNotificationEntry{{Key: "comment", Value: "current"}}},
+			{Type: "pve", Name: "pve", Entries: []proxmoxNotificationEntry{{Key: "comment", Value: "current-pve"}}},
+		}
+		merged := mergeRequiredRealms(backup, current, []string{"pam", "pve"})
+		if got := findSectionEntryValue(findSection(merged, "pam", "pam").Entries, "comment"); got != "current" {
+			t.Fatalf("required pam realm should be overridden by current safety config, got %q", got)
+		}
+		if findSection(merged, "pve", "pve") == nil {
+			t.Fatalf("required pve realm should be present")
+		}
+
+		if !listContains("root@pam,alice@pve", "alice@pve") {
+			t.Fatalf("listContains should parse comma-separated lists")
+		}
+		if listContains("root@pam alice@pve", "bob@pve") {
+			t.Fatalf("listContains returned true for missing entry")
+		}
+		if listContains("root@pam alice@pve", "   ") {
+			t.Fatalf("listContains should reject empty needle")
+		}
+		if listContains("   ", "root@pam") {
+			t.Fatalf("listContains should reject empty haystack")
+		}
+
+		if !hasRootAdminOnRoot([]proxmoxNotificationSection{
+			{
+				Type: "acl",
+				Name: "rule /",
+				Entries: []proxmoxNotificationEntry{
+					{Key: "users", Value: "root@pam"},
+					{Key: "roles", Value: "Administrator"},
+				},
+			},
+		}) {
+			t.Fatalf("hasRootAdminOnRoot should detect root Administrator ACL on /")
+		}
+	})
+
+	t.Run("token/tfa/shadow identity helpers", func(t *testing.T) {
+		if user := tokenSectionUserID(proxmoxNotificationSection{Type: "role", Name: "x"}); user != "" {
+			t.Fatalf("tokenSectionUserID for non-token should be empty, got %q", user)
+		}
+		if user := tokenSectionUserID(proxmoxNotificationSection{Type: "token", Name: "broken-name"}); user != "" {
+			t.Fatalf("tokenSectionUserID for invalid token names should be empty, got %q", user)
+		}
+		if user := tokenSectionUserID(proxmoxNotificationSection{Type: "token", Name: "alice@pve!tok1"}); user != "alice@pve" {
+			t.Fatalf("tokenSectionUserID=%q want alice@pve", user)
+		}
+
+		if user := tfaSectionUserID(proxmoxNotificationSection{Name: "alice@pve"}); user != "alice@pve" {
+			t.Fatalf("tfaSectionUserID by name=%q want alice@pve", user)
+		}
+		if user := tfaSectionUserID(proxmoxNotificationSection{
+			Name: "entry-only",
+			Entries: []proxmoxNotificationEntry{
+				{Key: "user", Value: "bob@pve"},
+			},
+		}); user != "bob@pve" {
+			t.Fatalf("tfaSectionUserID by entry=%q want bob@pve", user)
+		}
+		if user := tfaSectionUserID(proxmoxNotificationSection{Name: "no-user"}); user != "" {
+			t.Fatalf("tfaSectionUserID expected empty, got %q", user)
+		}
+
+		if user := shadowSectionUserID(proxmoxNotificationSection{Type: "user", Name: "alice@pve"}); user != "alice@pve" {
+			t.Fatalf("shadowSectionUserID by user type=%q want alice@pve", user)
+		}
+		if user := shadowSectionUserID(proxmoxNotificationSection{Type: "hash", Name: "bob@pve"}); user != "bob@pve" {
+			t.Fatalf("shadowSectionUserID by name=%q want bob@pve", user)
+		}
+		if user := shadowSectionUserID(proxmoxNotificationSection{
+			Type: "hash",
+			Name: "fallback",
+			Entries: []proxmoxNotificationEntry{
+				{Key: "userid", Value: "carol@pve"},
+			},
+		}); user != "carol@pve" {
+			t.Fatalf("shadowSectionUserID by userid entry=%q want carol@pve", user)
+		}
+		if user := shadowSectionUserID(proxmoxNotificationSection{Name: "nobody"}); user != "" {
+			t.Fatalf("shadowSectionUserID expected empty, got %q", user)
+		}
+
+		if _, _, ok := splitPVETokenSectionName("invalid"); ok {
+			t.Fatalf("splitPVETokenSectionName should reject invalid token name")
+		}
+		if _, _, ok := splitPVETokenSectionName("   "); ok {
+			t.Fatalf("splitPVETokenSectionName should reject empty token name")
+		}
+		if _, _, ok := splitPVETokenSectionName("!tok"); ok {
+			t.Fatalf("splitPVETokenSectionName should reject missing user part")
+		}
+		if _, _, ok := splitPVETokenSectionName("alice@pve!"); ok {
+			t.Fatalf("splitPVETokenSectionName should reject missing token part")
+		}
+		userID, tokenID, ok := splitPVETokenSectionName("alice@pve!tok")
+		if !ok || userID != "alice@pve" || tokenID != "tok" {
+			t.Fatalf("splitPVETokenSectionName parse mismatch: user=%q token=%q ok=%v", userID, tokenID, ok)
+		}
+	})
+
+	t.Run("webauthn extractors and misc helpers", func(t *testing.T) {
+		pveUsers := extractWebAuthnUsersFromPVETFA([]proxmoxNotificationSection{
+			{Type: "webauthn", Name: "k1", Entries: []proxmoxNotificationEntry{{Key: "user", Value: "alice@pve"}}},
+			{Type: "u2f", Name: "k2", Entries: []proxmoxNotificationEntry{{Key: "user", Value: "alice@pve"}}},
+			{Type: "webauthn", Name: "k3", Entries: []proxmoxNotificationEntry{{Key: "user", Value: "root@pam"}}},
+			{Type: "totp", Name: "k4", Entries: []proxmoxNotificationEntry{{Key: "user", Value: "bob@pve"}}},
+			{Type: "u2f", Name: "k5", Entries: []proxmoxNotificationEntry{{Key: "user", Value: "carol@pve"}}},
+		})
+		if len(pveUsers) != 2 || pveUsers[0] != "alice@pve" || pveUsers[1] != "carol@pve" {
+			t.Fatalf("extractWebAuthnUsersFromPVETFA unexpected users: %v", pveUsers)
+		}
+
+		pbsUsers := map[string]json.RawMessage{
+			"root@pam":  json.RawMessage(`{"webauthn":[{}]}`),
+			"alice@pbs": json.RawMessage(`{"webauthn":[{"id":"a"}]}`),
+			"bob@pbs":   json.RawMessage(`{"u2f":[{"id":"b"}]}`),
+			"bad@pbs":   json.RawMessage(`{"broken"`),
+			"none@pbs":  json.RawMessage(`{"totp":[1]}`),
+		}
+		extracted := extractWebAuthnUsersFromPBSTFAUsers(pbsUsers)
+		if len(extracted) != 2 || extracted[0] != "alice@pbs" || extracted[1] != "bob@pbs" {
+			t.Fatalf("extractWebAuthnUsersFromPBSTFAUsers unexpected users: %v", extracted)
+		}
+
+		if jsonRawNonNull(json.RawMessage(`null`)) {
+			t.Fatalf("jsonRawNonNull should be false for null")
+		}
+		if jsonRawNonNull(json.RawMessage(`{}`)) {
+			t.Fatalf("jsonRawNonNull should be false for empty object")
+		}
+		if !jsonRawNonNull(json.RawMessage(`{"x":1}`)) {
+			t.Fatalf("jsonRawNonNull should be true for non-empty object")
+		}
+
+		if s := summarizeUserIDs([]string{"a", "b"}, 0); s != "a, b" {
+			t.Fatalf("summarizeUserIDs with max<=0 should keep full list when small, got %q", s)
+		}
+		if s := summarizeUserIDs([]string{"a", "b", "c"}, 2); s != "a, b (+1 more)" {
+			t.Fatalf("summarizeUserIDs truncation mismatch, got %q", s)
+		}
+		if s := summarizeUserIDs(nil, 3); s != "" {
+			t.Fatalf("summarizeUserIDs(nil) should be empty, got %q", s)
+		}
+
+		if got := mustMarshalRaw(func() {}); string(got) != "{}" {
+			t.Fatalf("mustMarshalRaw fallback mismatch, got %q", string(got))
+		}
+		if users := parseTFAUsersMap(nil); len(users) != 0 {
+			t.Fatalf("parseTFAUsersMap(nil) should be empty, got %v", users)
+		}
+		if users := parseTFAUsersMap(map[string]json.RawMessage{"users": json.RawMessage(`{"alice@pbs":{"totp":[1]}}`)}); len(users) != 1 {
+			t.Fatalf("parseTFAUsersMap valid payload mismatch, got %v", users)
+		}
+		if users := parseTFAUsersMap(map[string]json.RawMessage{"users": json.RawMessage(`{"broken"`)}); len(users) != 0 {
+			t.Fatalf("parseTFAUsersMap invalid payload should be empty, got %v", users)
+		}
+	})
+}
+
+func TestMaybeApplyAccessControlFromStage_RealFSPaths(t *testing.T) {
+	origFS := restoreFS
+	origReadFile := mountGuardReadFile
+	t.Cleanup(func() {
+		restoreFS = origFS
+		mountGuardReadFile = origReadFile
+	})
+	restoreFS = osFS{}
+
+	logger := newTestLogger()
+	ctx := context.Background()
+
+	t.Run("pbs read failure bubbles", func(t *testing.T) {
+		stageRoot := t.TempDir()
+		userPath := filepath.Join(stageRoot, "etc/proxmox-backup/user.cfg")
+		if err := os.MkdirAll(userPath, 0o755); err != nil {
+			t.Fatalf("create directory at staged user.cfg path: %v", err)
+		}
+
+		plan := &RestorePlan{
+			SystemType:       SystemTypePBS,
+			NormalCategories: []Category{{ID: "pbs_access_control", Type: CategoryTypePBS}},
+		}
+		err := maybeApplyAccessControlFromStage(ctx, logger, plan, stageRoot, false)
+		if err == nil || !strings.Contains(err.Error(), "read staged etc/proxmox-backup/user.cfg") {
+			t.Fatalf("expected staged user.cfg read error, got %v", err)
+		}
+	})
+
+	t.Run("dual cluster-safe path returns after pbs apply", func(t *testing.T) {
+		stageRoot := t.TempDir()
+		plan := &RestorePlan{
+			SystemType:          SystemTypeDual,
+			ClusterBackup:       true,
+			NeedsClusterRestore: false,
+			NormalCategories: []Category{
+				{ID: "pbs_access_control", Type: CategoryTypePBS},
+				{ID: "pve_access_control", Type: CategoryTypePVE},
+			},
+		}
+		if err := maybeApplyAccessControlFromStage(ctx, logger, plan, stageRoot, false); err != nil {
+			t.Fatalf("expected dual cluster-safe branch to return nil, got %v", err)
+		}
+	})
+
+	t.Run("pve cluster recovery skip", func(t *testing.T) {
+		stageRoot := t.TempDir()
+		plan := &RestorePlan{
+			SystemType:          SystemTypePVE,
+			ClusterBackup:       true,
+			NeedsClusterRestore: true,
+			NormalCategories:    []Category{{ID: "pve_access_control", Type: CategoryTypePVE}},
+		}
+		if err := maybeApplyAccessControlFromStage(ctx, logger, plan, stageRoot, false); err != nil {
+			t.Fatalf("expected cluster recovery skip path, got %v", err)
+		}
+	})
+
+	t.Run("pve apply failure bubbles when pmxcfs missing", func(t *testing.T) {
+		stageRoot := t.TempDir()
+		plan := &RestorePlan{
+			SystemType:       SystemTypePVE,
+			NormalCategories: []Category{{ID: "pve_access_control", Type: CategoryTypePVE}},
+		}
+
+		mountGuardReadFile = func(path string) ([]byte, error) {
+			if path == "/proc/self/mountinfo" || path == "/proc/mounts" {
+				return []byte(""), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		err := maybeApplyAccessControlFromStage(ctx, logger, plan, stageRoot, false)
+		if err == nil || !strings.Contains(err.Error(), "/etc/pve is not mounted") {
+			t.Fatalf("expected /etc/pve mount protection error, got %v", err)
+		}
+	})
+}
+
+func TestApplyPBSAccessControlFromStage_WriteErrorBranches(t *testing.T) {
+	logger := newTestLogger()
+
+	t.Run("token.cfg write failure", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+
+		base := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(base.Root) })
+
+		stageRoot := "/stage"
+		tokenCfg := strings.Join([]string{
+			"token: alice@pbs!tok",
+			"  comment demo",
+			"",
+		}, "\n")
+		if err := base.WriteFile(stageRoot+"/etc/proxmox-backup/token.cfg", []byte(tokenCfg), 0o640); err != nil {
+			t.Fatalf("write staged token.cfg: %v", err)
+		}
+
+		restoreFS = &ErrorInjectingFS{
+			base:        base,
+			openFileErr: errors.New("open failed"),
+		}
+		err := applyPBSAccessControlFromStage(context.Background(), logger, stageRoot)
+		if err == nil || !strings.Contains(err.Error(), "write /etc/proxmox-backup/token.cfg") {
+			t.Fatalf("expected token.cfg write error, got %v", err)
+		}
+	})
+
+	t.Run("acl.cfg write failure via ACL apply", func(t *testing.T) {
+		origFS := restoreFS
+		t.Cleanup(func() { restoreFS = origFS })
+
+		base := NewFakeFS()
+		t.Cleanup(func() { _ = os.RemoveAll(base.Root) })
+
+		stageRoot := "/stage"
+		aclCfg := strings.Join([]string{
+			"acl: staged-acl",
+			"  path /",
+			"  users alice@pbs",
+			"  roles Admin",
+			"",
+		}, "\n")
+		if err := base.WriteFile(stageRoot+"/etc/proxmox-backup/acl.cfg", []byte(aclCfg), 0o640); err != nil {
+			t.Fatalf("write staged acl.cfg: %v", err)
+		}
+
+		restoreFS = &ErrorInjectingFS{
+			base:        base,
+			openFileErr: errors.New("open failed"),
+		}
+		err := applyPBSAccessControlFromStage(context.Background(), logger, stageRoot)
+		if err == nil || !strings.Contains(err.Error(), "write /etc/proxmox-backup/acl.cfg") {
+			t.Fatalf("expected acl.cfg write error, got %v", err)
+		}
+	})
+}
+
+func TestApplyPVEAccessControlFromStage_MountProbeBranches(t *testing.T) {
+	origFS := restoreFS
+	origReadFile := mountGuardReadFile
+	t.Cleanup(func() {
+		restoreFS = origFS
+		mountGuardReadFile = origReadFile
+	})
+	restoreFS = osFS{}
+
+	logger := newTestLogger()
+
+	t.Run("mount probe error only warns and continues", func(t *testing.T) {
+		mountGuardReadFile = func(path string) ([]byte, error) {
+			if path == "/proc/self/mountinfo" || path == "/proc/mounts" {
+				return nil, errors.New("probe failed")
+			}
+			return nil, os.ErrNotExist
+		}
+		if err := applyPVEAccessControlFromStage(context.Background(), logger, t.TempDir()); err != nil {
+			t.Fatalf("mount probe warning path should continue, got %v", err)
+		}
+	})
+
+	t.Run("pmxcfs not mounted returns explicit refusal", func(t *testing.T) {
+		mountGuardReadFile = func(path string) ([]byte, error) {
+			if path == "/proc/self/mountinfo" || path == "/proc/mounts" {
+				return []byte(""), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		err := applyPVEAccessControlFromStage(context.Background(), logger, t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "/etc/pve is not mounted") {
+			t.Fatalf("expected mount refusal error, got %v", err)
+		}
+	})
+}
+
+func TestApplyPVEAccessControlFromStage_WriteErrorBranches(t *testing.T) {
+	cases := []struct {
+		name     string
+		stageRel string
+		content  string
+		wantPath string
+	}{
+		{
+			name:     "domains write failure",
+			stageRel: "etc/pve/domains.cfg",
+			content:  "pam: pam\n  comment builtin\n",
+			wantPath: pveDomainsCfgPath,
+		},
+		{
+			name:     "user write failure",
+			stageRel: "etc/pve/user.cfg",
+			content:  "user: alice@pve\n  enable 1\n",
+			wantPath: pveUserCfgPath,
+		},
+		{
+			name:     "shadow write failure",
+			stageRel: "etc/pve/priv/shadow.cfg",
+			content:  "user: alice@pve\n  hash abc\n",
+			wantPath: pveShadowCfgPath,
+		},
+		{
+			name:     "token write failure",
+			stageRel: "etc/pve/priv/token.cfg",
+			content:  "token: alice@pve!tok\n  comment x\n",
+			wantPath: pveTokenCfgPath,
+		},
+		{
+			name:     "tfa write failure",
+			stageRel: "etc/pve/priv/tfa.cfg",
+			content:  "totp: alice@pve\n  user alice@pve\n",
+			wantPath: pveTFACfgPath,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origFS := restoreFS
+			t.Cleanup(func() { restoreFS = origFS })
+
+			base := NewFakeFS()
+			t.Cleanup(func() { _ = os.RemoveAll(base.Root) })
+
+			stageRoot := "/stage"
+			stagePath := filepath.Join(stageRoot, tc.stageRel)
+			if err := base.WriteFile(stagePath, []byte(tc.content), 0o640); err != nil {
+				t.Fatalf("write staged file %s: %v", tc.stageRel, err)
+			}
+
+			restoreFS = &ErrorInjectingFS{
+				base:        base,
+				openFileErr: errors.New("open failed"),
+			}
+			err := applyPVEAccessControlFromStage(context.Background(), newTestLogger(), stageRoot)
+			if err == nil || !strings.Contains(err.Error(), "write "+tc.wantPath) {
+				t.Fatalf("expected write error for %s, got %v", tc.wantPath, err)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/restore_access_control_additional_test.go
+++ b/internal/orchestrator/restore_access_control_additional_test.go
@@ -903,11 +903,14 @@ func TestAccessControlUtilityFunctions_Branches(t *testing.T) {
 func TestMaybeApplyAccessControlFromStage_RealFSPaths(t *testing.T) {
 	origFS := restoreFS
 	origReadFile := mountGuardReadFile
+	origGeteuid := accessControlApplyGeteuid
 	t.Cleanup(func() {
 		restoreFS = origFS
 		mountGuardReadFile = origReadFile
+		accessControlApplyGeteuid = origGeteuid
 	})
 	restoreFS = osFS{}
+	accessControlApplyGeteuid = func() int { return 0 }
 
 	logger := newTestLogger()
 	ctx := context.Background()

--- a/internal/safeexec/safeexec_test.go
+++ b/internal/safeexec/safeexec_test.go
@@ -5,33 +5,92 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 )
 
 func TestCommandContextAllowlist(t *testing.T) {
-	allowedCommands := []string{
-		"rclone",
-		"tar",
-		"xz",
-		"zstd",
-		"systemctl",
-		"mailq",
-		"tail",
-		"journalctl",
-		"pvesh",
-		"pveum",
-		"proxmox-backup-manager",
+	ctx := context.Background()
+	allowedCommands := make([]string, 0, len(allowedCommandFactories))
+	for name := range allowedCommandFactories {
+		allowedCommands = append(allowedCommands, name)
 	}
+	sort.Strings(allowedCommands)
+
 	for _, command := range allowedCommands {
-		if _, err := CommandContext(context.Background(), command); err != nil {
+		cmd, err := CommandContext(ctx, command, "--version")
+		if err != nil {
 			t.Fatalf("CommandContext(%q) allowed command error: %v", command, err)
 		}
+		if got, want := cmd.Args[0], command; got != want {
+			t.Fatalf("CommandContext(%q) cmd.Args[0]=%q; want %q", command, got, want)
+		}
 	}
-	if _, err := CommandContext(context.Background(), "not-a-proxsave-command"); !errors.Is(err, ErrCommandNotAllowed) {
+	if _, err := CommandContext(ctx, "not-a-proxsave-command"); !errors.Is(err, ErrCommandNotAllowed) {
 		t.Fatalf("CommandContext unknown command error = %v, want ErrCommandNotAllowed", err)
 	}
-	if _, err := CommandContext(context.Background(), "/bin/sh"); !errors.Is(err, ErrCommandNotAllowed) {
+	if _, err := CommandContext(ctx, "/bin/sh"); !errors.Is(err, ErrCommandNotAllowed) {
 		t.Fatalf("CommandContext path command error = %v, want ErrCommandNotAllowed", err)
+	}
+	invalidNames := []string{"", " echo", "echo ", `bad\name`}
+	for _, name := range invalidNames {
+		if _, err := CommandContext(ctx, name); !errors.Is(err, ErrCommandNotAllowed) {
+			t.Fatalf("CommandContext(%q) malformed-name error = %v, want ErrCommandNotAllowed", name, err)
+		}
+	}
+}
+
+func TestCommandWrappers(t *testing.T) {
+	ctx := context.Background()
+
+	out, err := Output(ctx, "echo", "safeexec-output")
+	if err != nil {
+		t.Fatalf("Output valid command error: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "safeexec-output" {
+		t.Fatalf("Output()=%q; want %q", got, "safeexec-output")
+	}
+
+	combined, err := CombinedOutput(ctx, "echo", "safeexec-combined")
+	if err != nil {
+		t.Fatalf("CombinedOutput valid command error: %v", err)
+	}
+	if got := strings.TrimSpace(string(combined)); got != "safeexec-combined" {
+		t.Fatalf("CombinedOutput()=%q; want %q", got, "safeexec-combined")
+	}
+
+	if _, err := Output(ctx, "false"); err == nil {
+		t.Fatalf("Output(false) expected exit error")
+	}
+	if _, err := Output(ctx, "not-allowed-command"); !errors.Is(err, ErrCommandNotAllowed) {
+		t.Fatalf("Output disallowed command error = %v, want ErrCommandNotAllowed", err)
+	}
+	if _, err := CombinedOutput(ctx, "not-allowed-command"); !errors.Is(err, ErrCommandNotAllowed) {
+		t.Fatalf("CombinedOutput disallowed command error = %v, want ErrCommandNotAllowed", err)
+	}
+}
+
+func TestTrustedCommandContext(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "trusted")
+	if err := os.WriteFile(execPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, err := TrustedCommandContext(context.Background(), execPath, "arg1", "arg2")
+	if err != nil {
+		t.Fatalf("TrustedCommandContext valid path error: %v", err)
+	}
+	if got, want := cmd.Path, execPath; got != want {
+		t.Fatalf("TrustedCommandContext Path=%q; want %q", got, want)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "arg1" || cmd.Args[2] != "arg2" {
+		t.Fatalf("TrustedCommandContext Args=%v; want [trusted arg1 arg2]", cmd.Args)
+	}
+
+	if _, err := TrustedCommandContext(context.Background(), "relative/path"); err == nil {
+		t.Fatalf("TrustedCommandContext(relative) expected error")
 	}
 }
 
@@ -45,8 +104,28 @@ func TestValidateTrustedExecutablePath(t *testing.T) {
 		t.Fatalf("ValidateTrustedExecutablePath valid error: %v", err)
 	}
 
+	if err := ValidateTrustedExecutablePath("   "); err == nil {
+		t.Fatalf("expected empty path to be rejected")
+	}
+
 	if err := ValidateTrustedExecutablePath("relative"); err == nil {
 		t.Fatalf("expected relative path to be rejected")
+	}
+
+	if err := ValidateTrustedExecutablePath(filepath.Join(dir, "missing")); err == nil {
+		t.Fatalf("expected missing executable to be rejected")
+	}
+
+	if err := ValidateTrustedExecutablePath(dir); err == nil {
+		t.Fatalf("expected directory path to be rejected")
+	}
+
+	notExecutable := filepath.Join(dir, "not-exec")
+	if err := os.WriteFile(notExecutable, []byte("no exec"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateTrustedExecutablePath(notExecutable); err == nil {
+		t.Fatalf("expected non-executable file to be rejected")
 	}
 
 	worldWritable := filepath.Join(dir, "ww")
@@ -78,14 +157,14 @@ func TestValidateRcloneRemoteName(t *testing.T) {
 }
 
 func TestValidateRemoteRelativePath(t *testing.T) {
-	valid := []string{"", "tenant/a", "/tenant/a/", "tenant with spaces/a"}
+	valid := []string{"", "/", "tenant/a", "/tenant/a/", "tenant with spaces/a"}
 	for _, value := range valid {
 		if err := ValidateRemoteRelativePath(value, "path"); err != nil {
 			t.Fatalf("ValidateRemoteRelativePath(%q) error: %v", value, err)
 		}
 	}
 
-	invalid := []string{"../escape", "tenant/../../escape", "bad\npath"}
+	invalid := []string{"..", "../escape", "tenant/../../escape", "bad\npath"}
 	for _, value := range invalid {
 		if err := ValidateRemoteRelativePath(value, "path"); err == nil {
 			t.Fatalf("ValidateRemoteRelativePath(%q) expected error", value)
@@ -94,12 +173,19 @@ func TestValidateRemoteRelativePath(t *testing.T) {
 }
 
 func TestProcPath(t *testing.T) {
-	got, err := ProcPath(123, "status")
-	if err != nil {
-		t.Fatalf("ProcPath valid error: %v", err)
+	valid := map[string]string{
+		"status": "/proc/123/status",
+		"comm":   "/proc/123/comm",
+		"exe":    "/proc/123/exe",
 	}
-	if got != "/proc/123/status" {
-		t.Fatalf("ProcPath = %q", got)
+	for leaf, want := range valid {
+		got, err := ProcPath(123, leaf)
+		if err != nil {
+			t.Fatalf("ProcPath(%s) valid error: %v", leaf, err)
+		}
+		if got != want {
+			t.Fatalf("ProcPath(%s) = %q; want %q", leaf, got, want)
+		}
 	}
 	if _, err := ProcPath(0, "status"); err == nil {
 		t.Fatalf("expected pid 0 to be rejected")


### PR DESCRIPTION
- **Bump x/crypto to v0.52.0**
- **ci: download modules before govulncheck**
- **Preserve legacy manifest parse causes**
- **Align remote legacy manifest parsing**
- **Propagate legacy scanner failures**
- **Expand test coverage**
- **Fix staged apply tests to use injectable root checks.**
- **test: expand PVE collector coverage**
- **fix(backup): isolate PXAR per-datastore errors in parallel step**
- **test: expand system collector probe and collection coverage**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manifest loading now reports combined causes and surfaces legacy parsing/scan failures.
  * Backup collection better propagates cancellations/deadlines and avoids swallowing parent-context errors.
  * Legacy metadata targets and version fields are now recognized and merged into manifests.

* **Tests**
  * Expanded unit/integration test coverage across collectors, restore/apply flows, and edge/error branches.

* **Chores**
  * Updated module dependencies and CI workflow action pins.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tis24dev/proxsave/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses PXAR parallel collection isolation, improves manifest error reporting, expands test coverage, and hardens the CI pipeline. It touches three functional areas: the backup collection layer, the orchestrator's legacy metadata parsing, and GitHub Actions workflow hardening.

- **PXAR parallel isolation**: `runPBSPXARStep` no longer cancels the shared context on the first per-datastore error; it now collects all per-datastore failures with `errors.Join` and the new `handlePBSPXARStepError` helper treats datastore errors as best-effort warnings unless the parent context itself is done.
- **Manifest error improvements**: `LoadManifest` now surfaces both the JSON parse cause and the legacy parse cause in its combined error message; `parseLegacyMetadata` now propagates `bufio.Scanner` errors instead of silently succeeding.
- **Legacy remote manifest parsing**: `inspectRcloneMetadataManifest` in `decrypt.go` now handles `BACKUP_TARGETS`, `PROXMOX_TARGETS`, `PROXMOX_VERSION`, `PVE_VERSION`, and `PBS_VERSION` fields with deduplication logic for targets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed production paths are well-covered by new tests and the behavior changes are intentional and consistent with the PR description.

The core PXAR concurrency fix (collecting all per-datastore errors instead of canceling on first failure) is thoroughly exercised across six new targeted test cases. The manifest error-reporting changes are backwards-compatible (callers only check err != nil). The orchestrator's legacy metadata parsing additions are additive and tested. No existing contract is broken.

No files require special attention; the test coverage for collector_pbs_datastore.go is particularly thorough.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/backup/collector_pbs_datastore.go | Rewrites runPBSPXARStep to collect all per-datastore errors instead of canceling on first failure; uses errors.Join for the final result and respects parent context cancellation. |
| internal/backup/collector_bricks_pbs_features.go | Adds handlePBSPXARStepError to uniformly treat per-datastore errors as best-effort warnings unless the parent context is done; replaces ad-hoc log+return-nil patterns across all PXAR brick functions. |
| internal/backup/collector_bricks.go | Adds isParentContextError — a stricter variant of isContextCancellationError that only matches when the error equals the parent context's current error. |
| internal/backup/checksum.go | LoadManifest now reports both JSON and legacy parse causes in the error message; parseLegacyMetadata now returns an error and propagates bufio.Scanner failures instead of silently succeeding. |
| internal/orchestrator/decrypt.go | inspectRcloneMetadataManifest now parses BACKUP_TARGETS, PROXMOX_TARGETS, PROXMOX_VERSION, PVE_VERSION, and PBS_VERSION from legacy manifests with target deduplication. |
| .github/workflows/security-ultimate.yml | Adds go mod download before govulncheck and updates pinned SHA hashes for codeql-action actions. |
| internal/backup/collector_pxar_datastore_test.go | Replaces old cancel-on-first-error test with six new tests covering: all-datastores-continue, partial failure, pre-canceled context, deadline exceeded, local cancellation kept, and parent+datastore error joining. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runPBSPXARStep] -->|pre-check| B{ctx.Err?}
    B -->|yes| C[return ctxErr]
    B -->|no| D[launch goroutines per datastore]
    D --> E{acquire semaphore}
    E -->|ctx.Done| F[goroutine exits]
    E -->|acquired| G[fn ctx ds state]
    G -->|err = nil| H[no-op]
    G -->|err != nil| I{isParentContextError?}
    I -->|yes| J[goroutine exits silently]
    I -->|no| K[Debug log + append to errs]
    H & J & K --> L[wg.Wait]
    L --> M{ctx.Err after wait?}
    M -->|ctxErr + errs| N[errors.Join both]
    M -->|ctxErr only| O[return ctxErr]
    M -->|no ctxErr| P[errors.Join errs or nil]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/backup/checksum.go`, line 116-120 ([link](https://github.com/tis24dev/proxsave/blob/2a42192f98b44d88c8b969c117aa046848789c0b/internal/backup/checksum.go#L116-L120)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **JSON parse error is no longer wrapped**

   The previous message used `%w` to wrap `err`, so callers could do `errors.As(returnedErr, &*json.SyntaxError{})` or similar. The new format uses `%v` for both `err` and `legacyErr`, so neither is reachable via `errors.Is`/`errors.As`. The existing callers in `backup_sources.go` and `storage/local.go` only check `err != nil`, so there is no current breakage, but the semantic change is worth calling out if future callers ever need to distinguish parse failure causes.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(orchestrator): use unique per-run s..."](https://github.com/tis24dev/proxsave/commit/66a41424cafb696e49d100e266b81d0e24222789) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33941302)</sub>

<!-- /greptile_comment -->