### PR TITLE
Fix 26 correctness bugs found by the pre-test audit

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0  # necessario per leggere commit + tag
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -35,7 +35,7 @@ jobs:
           go test $(go list ./... | grep -v -E '/cmd/|/pbs$|/bech32$|^github.com/tis24dev/proxsave$') -coverprofile=coverage.out
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
 
@@ -36,7 +36,7 @@ jobs:
           cache: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
           languages: go
 
@@ -45,6 +45,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
           category: "/language:go"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # pinned from actions/dependency-review-action@v5.0.0

--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       # CHECKOUT (fetch-depth 0 for changelog and GoReleaser)
       ########################################
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security-ultimate.yml
+++ b/.github/workflows/security-ultimate.yml
@@ -21,7 +21,7 @@ jobs:
       # CHECKOUT
       ########################################
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       ########################################
       # GO 1.25 — MAIN TOOLCHAIN
@@ -89,7 +89,7 @@ jobs:
       # UPLOAD SARIF
       ########################################
       - name: Upload GoSec SARIF
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
           sarif_file: gosec.sarif
 

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 

--- a/cmd/proxsave/cron_bootstrap_nil_logging_audited_test.go
+++ b/cmd/proxsave/cron_bootstrap_nil_logging_audited_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// Regression for cron-failure-warnings-lost-when-bootstrap-nil (2026-06-09 audit):
+// migrateLegacyCronEntries mixed nil-safe logBootstrap* helpers with direct
+// bootstrap.Warning/Debug calls. BootstrapLogger methods are nil-receiver safe but
+// silently early-return, so with a nil bootstrap the key failure warnings ("Unable
+// to inspect existing cron entries", "Failed to update cron entries") were dropped
+// instead of falling back to the global logger. All those calls were converted to the
+// nil-safe helpers; this pins that a nil bootstrap still emits via the global logger.
+func TestLogBootstrapHelpers_FallBackToGlobalLoggerWhenNil(t *testing.T) {
+	orig := logging.GetDefaultLogger()
+	t.Cleanup(func() { logging.SetDefaultLogger(orig) })
+
+	var buf bytes.Buffer
+	custom := logging.New(types.LogLevelDebug, false)
+	custom.SetOutput(&buf)
+	logging.SetDefaultLogger(custom)
+
+	logBootstrapWarning(nil, "sentinel-warning-%d", 42)
+	logBootstrapInfo(nil, "sentinel-info")
+	logBootstrapDebug(nil, "sentinel-debug")
+
+	out := buf.String()
+	for _, want := range []string{"sentinel-warning-42", "sentinel-info", "sentinel-debug"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("a nil bootstrap dropped %q instead of routing to the global logger; output:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/proxsave/cron_migration_test.go
+++ b/cmd/proxsave/cron_migration_test.go
@@ -6,18 +6,21 @@ import (
 	"github.com/tis24dev/proxsave/internal/logging"
 )
 
+// audited: 2026-06-09 — filterCronLines now returns []string (all distinct removed
+// schedules) instead of a single string, so multiple legacy entries with different
+// schedules no longer collapse into one. Cases updated to the slice signature.
 func TestFilterCronLines(t *testing.T) {
 	// Define the user's specific lines that must be preserved
 	userLine1 := "0 12 * * * /mnt/pve/nas/scripts/proxmox/proxmox-backup-client/backup_folders-nightly.sh 192.168.1.5 htpc-1 /mnt/pve/nas"
 	userLine2 := "0 2 * * * /mnt/pve/nas/scripts/proxmox/proxmox-backup-client/backup_folders-nightly.sh pbs.miodominio.com pbs1-test /mnt/pve/nas"
 
 	tests := []struct {
-		name         string
-		inputLines   []string
-		correctPaths []string
-		wantLines    []string
-		wantHasEntry bool
-		wantSchedule string
+		name          string
+		inputLines    []string
+		correctPaths  []string
+		wantLines     []string
+		wantHasEntry  bool
+		wantSchedules []string
 	}{
 		{
 			name: "Preserve proxmox-backup-client lines",
@@ -48,8 +51,8 @@ func TestFilterCronLines(t *testing.T) {
 			wantLines: []string{
 				userLine1,
 			},
-			wantHasEntry: false,
-			wantSchedule: "0 5 * * *",
+			wantHasEntry:  false,
+			wantSchedules: []string{"0 5 * * *"},
 		},
 		{
 			name: "Remove outdated binary reference",
@@ -61,8 +64,8 @@ func TestFilterCronLines(t *testing.T) {
 			wantLines: []string{
 				userLine1,
 			},
-			wantHasEntry: false,
-			wantSchedule: "0 2 * * *",
+			wantHasEntry:  false,
+			wantSchedules: []string{"0 2 * * *"},
 		},
 		{
 			name: "Preserve custom binary name proxmox-backup-new",
@@ -113,8 +116,8 @@ func TestFilterCronLines(t *testing.T) {
 				userLine2,
 				"0 5 * * * /usr/local/bin/proxsave",
 			},
-			wantHasEntry: true,
-			wantSchedule: "0 4 * * *",
+			wantHasEntry:  true,
+			wantSchedules: []string{"0 4 * * *"},
 		},
 		{
 			// Regression: a different binary whose name merely shares the
@@ -153,14 +156,20 @@ func TestFilterCronLines(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLines, gotHasEntry, gotSchedule := filterCronLines(tt.inputLines, tt.correctPaths)
+			gotLines, gotHasEntry, gotSchedules := filterCronLines(tt.inputLines, tt.correctPaths)
 
 			if gotHasEntry != tt.wantHasEntry {
 				t.Errorf("hasCurrentEntry = %v, want %v", gotHasEntry, tt.wantHasEntry)
 			}
 
-			if gotSchedule != tt.wantSchedule {
-				t.Errorf("replacedSchedule = %q, want %q", gotSchedule, tt.wantSchedule)
+			if len(gotSchedules) != len(tt.wantSchedules) {
+				t.Errorf("replacedSchedules = %q, want %q", gotSchedules, tt.wantSchedules)
+			} else {
+				for i := range gotSchedules {
+					if gotSchedules[i] != tt.wantSchedules[i] {
+						t.Errorf("replacedSchedules[%d] = %q, want %q", i, gotSchedules[i], tt.wantSchedules[i])
+					}
+				}
 			}
 
 			if len(gotLines) != len(tt.wantLines) {

--- a/cmd/proxsave/cron_multi_schedule_audited_test.go
+++ b/cmd/proxsave/cron_multi_schedule_audited_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+// Regression for cron-multi-entry-schedule-collapse (2026-06-09 audit): when the
+// crontab had two or more outdated proxsave/proxmox-backup entries with DIFFERENT
+// schedules and no current entry, filterCronLines remembered only the first
+// schedule, so migrateLegacyCronEntries rewrote a single entry and silently
+// discarded the others. Written after changing filterCronLines to collect every
+// distinct removed schedule.
+
+func TestFilterCronLines_MultipleDistinctSchedulesPreserved(t *testing.T) {
+	input := []string{
+		"0 2 * * * /usr/bin/proxmox-backup",        // outdated, schedule A
+		"30 5 * * 0 /usr/local/bin/proxmox-backup", // outdated, schedule B (weekly)
+		"# a comment",
+		"0 1 * * * /some/other/job",
+	}
+
+	lines, hasCurrent, schedules := filterCronLines(input, []string{"/usr/local/bin/proxsave"})
+
+	if hasCurrent {
+		t.Fatalf("hasCurrentEntry = true, want false")
+	}
+	want := []string{"0 2 * * *", "30 5 * * 0"}
+	if len(schedules) != len(want) {
+		t.Fatalf("schedules = %q, want %q (distinct schedules must not collapse into one)", schedules, want)
+	}
+	for i := range want {
+		if schedules[i] != want[i] {
+			t.Errorf("schedules[%d] = %q, want %q", i, schedules[i], want[i])
+		}
+	}
+
+	// Both outdated lines removed; the comment and unrelated job stay.
+	wantLines := []string{"# a comment", "0 1 * * * /some/other/job"}
+	if len(lines) != len(wantLines) {
+		t.Fatalf("lines = %q, want %q", lines, wantLines)
+	}
+	for i := range wantLines {
+		if lines[i] != wantLines[i] {
+			t.Errorf("line[%d] = %q, want %q", i, lines[i], wantLines[i])
+		}
+	}
+}
+
+func TestFilterCronLines_DuplicateScheduleDeduped(t *testing.T) {
+	input := []string{
+		"0 2 * * * /usr/bin/proxmox-backup",
+		"0 2 * * * /usr/local/bin/proxmox-backup",
+	}
+	_, _, schedules := filterCronLines(input, []string{"/usr/local/bin/proxsave"})
+	if len(schedules) != 1 || schedules[0] != "0 2 * * *" {
+		t.Fatalf("schedules = %q, want exactly [\"0 2 * * *\"] (identical schedules deduped)", schedules)
+	}
+}

--- a/cmd/proxsave/entrypoint_symlink_audited_test.go
+++ b/cmd/proxsave/entrypoint_symlink_audited_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+// Regression for symlink-delete-then-recreate-no-rollback (2026-06-09 audit):
+// ensureGoSymlink removed an existing /usr/local/bin/proxsave and only then created
+// the new symlink, so a failed os.Symlink left the host with NO proxsave entrypoint.
+// installEntrypointSymlink now replaces atomically (symlink to a temp path + rename
+// over dest), so dest is never left missing. Written after that change.
+
+func writeFakeExec(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "proxsave-bin")
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake exec: %v", err)
+	}
+	return p
+}
+
+func assertSymlinkTo(t *testing.T, dest, target string) {
+	t.Helper()
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatalf("dest %s missing: %v", dest, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dest %s is not a symlink (mode %v)", dest, info.Mode())
+	}
+	got, err := os.Readlink(dest)
+	if err != nil {
+		t.Fatalf("readlink %s: %v", dest, err)
+	}
+	if got != target {
+		t.Fatalf("symlink %s -> %s, want -> %s", dest, got, target)
+	}
+}
+
+func TestInstallEntrypointSymlink_CreatesWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	exec := writeFakeExec(t, dir)
+	dest := filepath.Join(dir, "proxsave")
+
+	installEntrypointSymlink(exec, dest, logging.NewBootstrapLogger())
+	assertSymlinkTo(t, dest, exec)
+}
+
+func TestInstallEntrypointSymlink_ReplacesWrongSymlinkAndFile(t *testing.T) {
+	dir := t.TempDir()
+	exec := writeFakeExec(t, dir)
+
+	// Wrong symlink.
+	destA := filepath.Join(dir, "a")
+	if err := os.Symlink("/some/other/target", destA); err != nil {
+		t.Fatal(err)
+	}
+	installEntrypointSymlink(exec, destA, logging.NewBootstrapLogger())
+	assertSymlinkTo(t, destA, exec)
+
+	// Real file occupying the entrypoint path.
+	destB := filepath.Join(dir, "b")
+	if err := os.WriteFile(destB, []byte("stale"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	installEntrypointSymlink(exec, destB, logging.NewBootstrapLogger())
+	assertSymlinkTo(t, destB, exec)
+}
+
+func TestInstallEntrypointSymlink_KeepsCorrectSymlink(t *testing.T) {
+	dir := t.TempDir()
+	exec := writeFakeExec(t, dir)
+	dest := filepath.Join(dir, "proxsave")
+	if err := os.Symlink(exec, dest); err != nil {
+		t.Fatal(err)
+	}
+	installEntrypointSymlink(exec, dest, logging.NewBootstrapLogger())
+	assertSymlinkTo(t, dest, exec)
+}
+
+// The regression guard: when the install cannot complete, the existing entrypoint
+// must be preserved (never deleted-then-not-recreated). A directory at dest makes
+// the final rename fail; dest must survive and the temp symlink must be cleaned up.
+func TestInstallEntrypointSymlink_FailurePreservesExistingDest(t *testing.T) {
+	dir := t.TempDir()
+	exec := writeFakeExec(t, dir)
+	dest := filepath.Join(dir, "proxsave")
+	if err := os.Mkdir(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(dest, "keep")
+	if err := os.WriteFile(marker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	installEntrypointSymlink(exec, dest, logging.NewBootstrapLogger())
+
+	// dest still exists (rename over a directory fails) and its contents survive.
+	if info, err := os.Lstat(dest); err != nil || !info.IsDir() {
+		t.Fatalf("dest should still be the original directory, got info=%v err=%v", info, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("existing dest contents were lost: %v", err)
+	}
+	// The temp symlink must not be left behind.
+	if _, err := os.Lstat(dest + ".proxsave-new"); !os.IsNotExist(err) {
+		t.Fatalf("temp symlink should have been cleaned up, err=%v", err)
+	}
+}

--- a/cmd/proxsave/permissions.go
+++ b/cmd/proxsave/permissions.go
@@ -127,22 +127,32 @@ func applyDirOwnershipRecursive(root string, uid, gid int, logger *logging.Logge
 	logger.Debug("Walking directory tree for permissions: %s (uid=%d,gid=%d)", root, uid, gid)
 
 	return filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-
-		if err := os.Chown(path, uid, gid); err != nil {
-			// Do not stop on chown errors; just log at debug level.
-			logger.Debug("chown failed on %s: %v", path, err)
-		}
-
-		if d.IsDir() {
-			if err := os.Chmod(path, 0o750); err != nil {
-				logger.Debug("chmod failed on %s: %v", path, err)
-			}
-		}
-		return nil
+		return applyOwnershipWalkEntry(path, d, walkErr, uid, gid, logger)
 	})
+}
+
+// applyOwnershipWalkEntry applies ownership/permissions to a single walked entry.
+// A traversal error (walkErr) is logged and SKIPPED (return nil) rather than
+// propagated: returning it would abort filepath.WalkDir, leaving every not-yet-
+// visited entry with its old ownership. One unreadable subtree must not block
+// fixing the rest of the backup tree.
+func applyOwnershipWalkEntry(path string, d os.DirEntry, walkErr error, uid, gid int, logger *logging.Logger) error {
+	if walkErr != nil {
+		logger.Debug("permission walk: skipping %s: %v", path, walkErr)
+		return nil
+	}
+
+	if err := os.Chown(path, uid, gid); err != nil {
+		// Do not stop on chown errors; just log at debug level.
+		logger.Debug("chown failed on %s: %v", path, err)
+	}
+
+	if d.IsDir() {
+		if err := os.Chmod(path, 0o750); err != nil {
+			logger.Debug("chmod failed on %s: %v", path, err)
+		}
+	}
+	return nil
 }
 
 // fixPermissionsAfterInstall runs a best-effort permission and ownership

--- a/cmd/proxsave/permissions_walk_audited_test.go
+++ b/cmd/proxsave/permissions_walk_audited_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// Regression for chown-walk-aborts-partial (2026-06-09 audit): the WalkDir callback
+// in applyDirOwnershipRecursive returned the traversal error on the first unreadable
+// entry, which aborts filepath.WalkDir, so every not-yet-visited entry kept its old
+// ownership/permissions while applyBackupPermissions still returned nil. The per-entry
+// logic now lives in applyOwnershipWalkEntry, which skips a traversal error instead of
+// aborting. Written after that change.
+
+func permWalkTestLogger() *logging.Logger {
+	l := logging.New(types.LogLevelDebug, false)
+	l.SetOutput(io.Discard)
+	return l
+}
+
+func TestApplyOwnershipWalkEntry_TraversalErrorIsSkippedNotAborted(t *testing.T) {
+	// A non-nil walkErr (with a nil DirEntry, as WalkDir passes on read failures)
+	// must return nil so the walk continues to the rest of the tree.
+	if err := applyOwnershipWalkEntry("/some/unreadable/subdir", nil, errors.New("permission denied"), 0, 0, permWalkTestLogger()); err != nil {
+		t.Fatalf("a traversal error must be skipped (return nil) so the walk continues, got %v", err)
+	}
+}
+
+func TestApplyOwnershipWalkEntry_NormalEntryReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("read dir: %v", err)
+	}
+
+	// chown to our own uid/gid is a harmless no-op; the entry must process cleanly.
+	if err := applyOwnershipWalkEntry(file, entries[0], nil, os.Getuid(), os.Getgid(), permWalkTestLogger()); err != nil {
+		t.Fatalf("a normal entry must return nil, got %v", err)
+	}
+}

--- a/cmd/proxsave/runtime_helpers.go
+++ b/cmd/proxsave/runtime_helpers.go
@@ -675,10 +675,10 @@ func migrateLegacyCronEntries(ctx context.Context, baseDir, execPath string, boo
 		// PBS binary and we must never schedule that as root in cron.
 		fallback := strings.TrimSpace(execPath)
 		if fallback == "" {
-			bootstrap.Warning("WARNING: Unable to locate Go binary for cron migration")
+			logBootstrapWarning(bootstrap, "WARNING: Unable to locate Go binary for cron migration")
 			return
 		}
-		bootstrap.Info("proxsave symlink not found; falling back to %s for cron entries", fallback)
+		logBootstrapInfo(bootstrap, "proxsave symlink not found; falling back to %s for cron entries", fallback)
 		newCommandToken = fallback
 	}
 
@@ -713,7 +713,7 @@ func migrateLegacyCronEntries(ctx context.Context, baseDir, execPath string, boo
 
 	current, err := readCron()
 	if err != nil {
-		bootstrap.Warning("WARNING: Unable to inspect existing cron entries: %v", err)
+		logBootstrapWarning(bootstrap, "WARNING: Unable to inspect existing cron entries: %v", err)
 		return
 	}
 
@@ -758,14 +758,14 @@ func migrateLegacyCronEntries(ctx context.Context, baseDir, execPath string, boo
 
 	newCron := strings.Join(updatedLines, "\n") + "\n"
 	if err := writeCron(newCron); err != nil {
-		bootstrap.Warning("WARNING: Failed to update cron entries: %v", err)
+		logBootstrapWarning(bootstrap, "WARNING: Failed to update cron entries: %v", err)
 		return
 	}
 
 	if hasCurrentEntry {
-		bootstrap.Debug("Existing cron entry already targets %s; no changes made.", newCommandToken)
+		logBootstrapDebug(bootstrap, "Existing cron entry already targets %s; no changes made.", newCommandToken)
 	} else {
-		bootstrap.Debug("Recreated cron entry for proxsave at schedule %s: %s", schedule, newCommandToken)
+		logBootstrapDebug(bootstrap, "Recreated cron entry for proxsave at schedule %s: %s", schedule, newCommandToken)
 	}
 }
 
@@ -884,6 +884,14 @@ func logBootstrapInfo(bootstrap *logging.BootstrapLogger, format string, args ..
 		return
 	}
 	logging.Info(format, args...)
+}
+
+func logBootstrapDebug(bootstrap *logging.BootstrapLogger, format string, args ...interface{}) {
+	if bootstrap != nil {
+		bootstrap.Debug(format, args...)
+		return
+	}
+	logging.Debug(format, args...)
 }
 
 // containsBinaryReference reports whether the cron line's COMMAND is a

--- a/cmd/proxsave/runtime_helpers.go
+++ b/cmd/proxsave/runtime_helpers.go
@@ -598,32 +598,7 @@ func ensureGoSymlink(execPath string, bootstrap *logging.BootstrapLogger) {
 		return
 	}
 
-	create := func(dest string) {
-		if info, err := os.Lstat(dest); err == nil {
-			if info.Mode()&os.ModeSymlink != 0 {
-				if resolved, err := filepath.EvalSymlinks(dest); err == nil && resolved == execPath {
-					logBootstrapInfo(bootstrap, "Keeping existing symlink %s -> %s", dest, resolved)
-					return
-				}
-			}
-			if rmErr := os.Remove(dest); rmErr != nil {
-				logBootstrapWarning(bootstrap, "WARNING: Failed to replace %s: remove failed: %v", dest, rmErr)
-				return
-			}
-			logBootstrapInfo(bootstrap, "Removed existing entrypoint at %s", dest)
-		} else if !os.IsNotExist(err) {
-			logBootstrapWarning(bootstrap, "WARNING: Unable to inspect %s: %v", dest, err)
-			return
-		}
-
-		if err := os.Symlink(execPath, dest); err != nil {
-			logBootstrapWarning(bootstrap, "WARNING: Failed to create symlink %s -> %s: %v", dest, execPath, err)
-			return
-		}
-		logBootstrapInfo(bootstrap, "Created symlink: %s -> %s", dest, execPath)
-	}
-
-	create("/usr/local/bin/proxsave")
+	installEntrypointSymlink(execPath, "/usr/local/bin/proxsave", bootstrap)
 	// The legacy "proxmox-backup" command name is no longer a supported entrypoint:
 	// drop its symlink instead of recreating it. proxsave is the only entrypoint.
 	removeLegacyEntrypoint("/usr/local/bin/proxmox-backup", bootstrap)
@@ -635,6 +610,38 @@ func ensureGoSymlink(execPath string, bootstrap *logging.BootstrapLogger) {
 // script) is never deleted. Proxmox Backup Server ships its tools as
 // proxmox-backup-client/-proxy/-manager under /usr/sbin and /usr/bin, never a bare
 // "proxmox-backup" symlink in /usr/local/bin, so PBS is unaffected.
+// installEntrypointSymlink points dest at execPath as a symlink, replacing any
+// existing file/symlink ATOMICALLY: it creates the new symlink at a temp path in
+// the same directory and renames it over dest. A bare remove-then-symlink would
+// leave the host with NO entrypoint if the symlink step failed after the remove
+// succeeded; the atomic rename never leaves dest missing.
+func installEntrypointSymlink(execPath, dest string, bootstrap *logging.BootstrapLogger) {
+	if info, err := os.Lstat(dest); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			if resolved, err := filepath.EvalSymlinks(dest); err == nil && resolved == execPath {
+				logBootstrapInfo(bootstrap, "Keeping existing symlink %s -> %s", dest, resolved)
+				return
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		logBootstrapWarning(bootstrap, "WARNING: Unable to inspect %s: %v", dest, err)
+		return
+	}
+
+	tmp := dest + ".proxsave-new"
+	_ = os.Remove(tmp) // clear any leftover from a previous interrupted run
+	if err := os.Symlink(execPath, tmp); err != nil {
+		logBootstrapWarning(bootstrap, "WARNING: Failed to create symlink %s -> %s: %v", dest, execPath, err)
+		return
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		_ = os.Remove(tmp)
+		logBootstrapWarning(bootstrap, "WARNING: Failed to install symlink %s -> %s: %v", dest, execPath, err)
+		return
+	}
+	logBootstrapInfo(bootstrap, "Created symlink: %s -> %s", dest, execPath)
+}
+
 func removeLegacyEntrypoint(dest string, bootstrap *logging.BootstrapLogger) {
 	info, err := os.Lstat(dest)
 	if err != nil {

--- a/cmd/proxsave/runtime_helpers.go
+++ b/cmd/proxsave/runtime_helpers.go
@@ -725,23 +725,28 @@ func migrateLegacyCronEntries(ctx context.Context, baseDir, execPath string, boo
 	}
 
 	lines = dropLegacyBashCronLines(lines, baseDir, bootstrap)
-	updatedLines, hasCurrentEntry, replacedSchedule := filterCronLines(lines, correctPaths)
+	updatedLines, hasCurrentEntry, replacedSchedules := filterCronLines(lines, correctPaths)
 
 	schedule := strings.TrimSpace(cronSchedule)
 	if schedule == "" {
 		schedule = "0 2 * * *"
 	}
-	// Add an entry pointing to the Go binary if none already targets it. If we
-	// removed an entry that pointed to an outdated proxsave/proxmox-backup binary,
-	// keep the operator's existing schedule instead of resetting to the default,
-	// and warn that the entry was rewritten.
+	// Add entries pointing to the Go binary if none already targets it. If we
+	// removed entries that pointed to outdated proxsave/proxmox-backup binaries,
+	// recreate ONE entry per distinct removed schedule (keeping each operator
+	// schedule) instead of resetting to the default or collapsing several distinct
+	// schedules into a single rewritten entry.
 	if !hasCurrentEntry {
-		if replacedSchedule != "" {
-			schedule = replacedSchedule
-			logBootstrapWarning(bootstrap, "Cron entry pointed to an outdated binary path; rewriting it to %s and keeping the existing schedule %q", newCommandToken, schedule)
+		schedules := replacedSchedules
+		if len(schedules) == 0 {
+			schedules = []string{schedule}
+		} else {
+			logBootstrapWarning(bootstrap, "Cron entries pointed to outdated binary paths; rewriting %d to %s and keeping the existing schedule(s) %q", len(schedules), newCommandToken, schedules)
 		}
-		defaultLine := fmt.Sprintf("%s %s", schedule, newCommandToken)
-		updatedLines = append(updatedLines, defaultLine)
+		for _, s := range schedules {
+			updatedLines = append(updatedLines, fmt.Sprintf("%s %s", s, newCommandToken))
+		}
+		schedule = strings.Join(schedules, ", ")
 	}
 
 	newCron := strings.Join(updatedLines, "\n") + "\n"
@@ -786,10 +791,11 @@ func dropLegacyBashCronLines(lines []string, baseDir string, bootstrap *logging.
 	return kept
 }
 
-func filterCronLines(lines []string, correctPaths []string) ([]string, bool, string) {
+func filterCronLines(lines []string, correctPaths []string) ([]string, bool, []string) {
 	updatedLines := make([]string, 0, len(lines))
 	hasCurrentEntry := false
-	replacedSchedule := ""
+	var replacedSchedules []string
+	seenSchedules := make(map[string]bool)
 
 	containsCorrectPath := func(line string) bool {
 		// Match the cron command token exactly, not as a substring: otherwise a
@@ -821,16 +827,19 @@ func filterCronLines(lines []string, correctPaths []string) ([]string, bool, str
 		}
 		if containsBinaryReference(line) {
 			// Remove proxsave/proxmox-backup entries that point to outdated binaries,
-			// remembering the operator's schedule so the rewritten entry can keep it.
-			if replacedSchedule == "" {
-				replacedSchedule = cronScheduleField(line)
+			// remembering EACH distinct schedule so every rewritten entry can keep its
+			// own. Multiple legacy entries with different schedules must not collapse
+			// into a single rewritten entry (which would silently drop the others).
+			if sched := cronScheduleField(line); sched != "" && !seenSchedules[sched] {
+				seenSchedules[sched] = true
+				replacedSchedules = append(replacedSchedules, sched)
 			}
 			continue
 		}
 		updatedLines = append(updatedLines, line)
 	}
 
-	return updatedLines, hasCurrentEntry, replacedSchedule
+	return updatedLines, hasCurrentEntry, replacedSchedules
 }
 
 // cronScheduleField returns the schedule portion of a cron line — the first five

--- a/cmd/proxsave/upgrade.go
+++ b/cmd/proxsave/upgrade.go
@@ -212,9 +212,12 @@ func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.Bootstra
 
 // downloadAndInstallLatest downloads the specified release archive from GitHub,
 // verifies the checksum, extracts the proxsave binary, and installs it to execPath.
-func downloadAndInstallLatest(ctx context.Context, execPath string, bootstrap *logging.BootstrapLogger, tag, version string) (string, error) {
-	var err error
+func downloadAndInstallLatest(ctx context.Context, execPath string, bootstrap *logging.BootstrapLogger, tag, version string) (versionInstalled string, err error) {
 	done := logging.DebugStartBootstrap(bootstrap, "upgrade download/install", "tag=%s version=%s", tag, version)
+	// Named return so the deferred trace reflects the ACTUAL returned error. The
+	// per-step `if err := <call>; err != nil { return "", ... }` blocks shadow a
+	// local err, but a `return` assigns this named err on the way out, so done(err)
+	// no longer logs the span as "ok" when a download/verify/install step failed.
 	defer func() { done(err) }()
 
 	osName, arch, err := detectOSArch()

--- a/cmd/proxsave/upgrade.go
+++ b/cmd/proxsave/upgrade.go
@@ -340,13 +340,17 @@ func fetchLatestRelease(ctx context.Context) (string, string, error) {
 // returns -1 if current < latest, 0 if equal, 1 if current > latest.
 // Pre-release/build suffixes are ignored for comparison purposes.
 func compareVersions(current, latest string) int {
-	normalize := func(v string) []int {
+	normalize := func(v string) ([]int, bool) {
 		v = strings.TrimSpace(v)
 		if v == "" {
-			return []int{0}
+			return []int{0}, false
 		}
-		// Strip common pre-release/build suffixes (e.g. "-rc1")
+		// A "-" suffix marks a semver pre-release (e.g. "-rc1"); "+" marks build
+		// metadata. Record whether this is a pre-release and strip the suffix so
+		// the numeric core can be compared; the flag breaks numeric ties below.
+		prerelease := false
 		if idx := strings.IndexAny(v, "-+"); idx >= 0 {
+			prerelease = v[idx] == '-'
 			v = v[:idx]
 		}
 		parts := strings.Split(v, ".")
@@ -364,13 +368,13 @@ func compareVersions(current, latest string) int {
 			}
 		}
 		if len(out) == 0 {
-			return []int{0}
+			return []int{0}, prerelease
 		}
-		return out
+		return out, prerelease
 	}
 
-	a := normalize(current)
-	b := normalize(latest)
+	a, aPre := normalize(current)
+	b, bPre := normalize(latest)
 
 	maxLen := len(a)
 	if len(b) > maxLen {
@@ -392,7 +396,19 @@ func compareVersions(current, latest string) int {
 			return 1
 		}
 	}
-	return 0
+
+	// Numeric cores are equal: a stable release outranks the same-numeric
+	// pre-release, matching isNewerVersion (the update check) so the upgrade gate
+	// and the update nag agree on the rc -> stable transition instead of leaving
+	// rc users stranded ("already running the latest version").
+	switch {
+	case aPre && !bPre:
+		return -1
+	case !aPre && bPre:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func downloadFile(ctx context.Context, url string, root *os.Root, name string, bootstrap *logging.BootstrapLogger) (err error) {

--- a/cmd/proxsave/upgrade.go
+++ b/cmd/proxsave/upgrade.go
@@ -204,7 +204,19 @@ func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.Bootstra
 
 	printUpgradeFooter(upgradeErr, versionInstalled, args.ConfigPath, baseDir, telegramCode, permStatus, permMessage, cfgUpgradeResult, cfgUpgradeErr)
 
-	if upgradeErr != nil {
+	// A configuration-upgrade failure after a successful binary install must also be
+	// reflected in the exit code (the footer already shows "Configuration: ERROR"),
+	// so automation does not treat the run as fully successful.
+	if upgradeErr == nil && cfgUpgradeErr != nil {
+		workflowErr = cfgUpgradeErr
+	}
+	return upgradeExitCode(upgradeErr, cfgUpgradeErr)
+}
+
+// upgradeExitCode maps the binary-install and config-upgrade outcomes to a process
+// exit code: any failure on either yields a non-zero exit.
+func upgradeExitCode(upgradeErr, cfgUpgradeErr error) int {
+	if upgradeErr != nil || cfgUpgradeErr != nil {
 		return types.ExitGenericError.Int()
 	}
 	return types.ExitSuccess.Int()

--- a/cmd/proxsave/upgrade.go
+++ b/cmd/proxsave/upgrade.go
@@ -288,21 +288,23 @@ func downloadAndInstallLatest(ctx context.Context, execPath string, bootstrap *l
 }
 
 func detectOSArch() (string, string, error) {
-	osName := strings.ToLower(runtime.GOOS)
+	return resolveReleaseTarget(runtime.GOOS, runtime.GOARCH)
+}
+
+// resolveReleaseTarget maps the running platform to the OS/arch of a published
+// release archive. Releases are built for linux/amd64 ONLY (see
+// .github/.goreleaser.yml), so any other architecture is rejected up front:
+// advertising it would build a download URL for an archive that does not exist and
+// fail later with a confusing 404.
+func resolveReleaseTarget(goos, goarch string) (string, string, error) {
+	osName := strings.ToLower(goos)
 	if osName != "linux" {
 		return "", "", fmt.Errorf("unsupported OS: %s (only linux is supported)", osName)
 	}
-
-	var arch string
-	switch runtime.GOARCH {
-	case "amd64":
-		arch = "amd64"
-	case "arm64":
-		arch = "arm64"
-	default:
-		return "", "", fmt.Errorf("unsupported architecture: %s (supported: amd64, arm64)", runtime.GOARCH)
+	if goarch != "amd64" {
+		return "", "", fmt.Errorf("no prebuilt release for architecture %s: only linux/amd64 binaries are published; build from source to upgrade on this host", goarch)
 	}
-	return osName, arch, nil
+	return osName, "amd64", nil
 }
 
 func fetchLatestRelease(ctx context.Context) (string, string, error) {

--- a/cmd/proxsave/upgrade_exit_code_audited_test.go
+++ b/cmd/proxsave/upgrade_exit_code_audited_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// Regression for cfg-upgrade-err-zero-exit (2026-06-09 audit): after a successful
+// binary install, a failed upgradeConfigWithBinary (cfgUpgradeErr) was logged and
+// shown as "Configuration: ERROR" in the footer, but runUpgrade's terminal return
+// inspected only upgradeErr, so it still returned ExitSuccess (0). The exit-code
+// decision now lives in upgradeExitCode and accounts for both errors.
+func TestUpgradeExitCode(t *testing.T) {
+	boom := errors.New("boom")
+	cases := []struct {
+		name                      string
+		upgradeErr, cfgUpgradeErr error
+		want                      int
+	}{
+		{"both ok", nil, nil, types.ExitSuccess.Int()},
+		{"binary install failed", boom, nil, types.ExitGenericError.Int()},
+		{"config upgrade failed after good install", nil, boom, types.ExitGenericError.Int()},
+		{"both failed", boom, boom, types.ExitGenericError.Int()},
+	}
+	for _, c := range cases {
+		if got := upgradeExitCode(c.upgradeErr, c.cfgUpgradeErr); got != c.want {
+			t.Errorf("%s: upgradeExitCode = %d, want %d", c.name, got, c.want)
+		}
+	}
+}

--- a/cmd/proxsave/upgrade_helpers_test.go
+++ b/cmd/proxsave/upgrade_helpers_test.go
@@ -202,6 +202,9 @@ func TestInstallBinary(t *testing.T) {
 	}
 }
 
+// audited: 2026-06-09 — only linux/amd64 releases are published, so arm64 is no
+// longer accepted (the old test treated arm64 as supported, documenting an arch the
+// release pipeline never builds).
 func TestDetectOSArch(t *testing.T) {
 	osName, arch, err := detectOSArch()
 
@@ -212,7 +215,7 @@ func TestDetectOSArch(t *testing.T) {
 		return
 	}
 
-	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+	if runtime.GOARCH != "amd64" {
 		if err == nil {
 			t.Fatalf("expected error for unsupported architecture %q, got os=%q arch=%q", runtime.GOARCH, osName, arch)
 		}
@@ -225,7 +228,7 @@ func TestDetectOSArch(t *testing.T) {
 	if osName != "linux" {
 		t.Fatalf("detectOSArch() os=%q, want %q", osName, "linux")
 	}
-	if arch != runtime.GOARCH {
-		t.Fatalf("detectOSArch() arch=%q, want %q", arch, runtime.GOARCH)
+	if arch != "amd64" {
+		t.Fatalf("detectOSArch() arch=%q, want %q", arch, "amd64")
 	}
 }

--- a/cmd/proxsave/upgrade_release_target_audited_test.go
+++ b/cmd/proxsave/upgrade_release_target_audited_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression for arch-advertised-not-built (2026-06-09 audit): detectOSArch accepted
+// runtime.GOARCH == "arm64", so on an arm64 host downloadAndInstallLatest built a URL
+// for proxsave_<v>_linux_arm64.tar.gz, which the release pipeline never publishes
+// (goreleaser builds amd64 only) - failing later with a confusing 404. The platform
+// mapping now lives in the pure resolveReleaseTarget so the rejection is testable
+// without depending on the host's GOARCH.
+func TestResolveReleaseTarget(t *testing.T) {
+	cases := []struct {
+		goos, goarch     string
+		wantOS, wantArch string
+		wantErr          string // substring; "" means no error
+	}{
+		{"linux", "amd64", "linux", "amd64", ""},
+		{"Linux", "amd64", "linux", "amd64", ""}, // OS is lower-cased
+		{"linux", "arm64", "", "", "no prebuilt release for architecture arm64"},
+		{"linux", "386", "", "", "no prebuilt release for architecture 386"},
+		{"darwin", "amd64", "", "", "unsupported OS: darwin"},
+		{"windows", "amd64", "", "", "unsupported OS: windows"},
+	}
+	for _, c := range cases {
+		os, arch, err := resolveReleaseTarget(c.goos, c.goarch)
+		if c.wantErr == "" {
+			if err != nil {
+				t.Errorf("resolveReleaseTarget(%q,%q) error = %v, want nil", c.goos, c.goarch, err)
+				continue
+			}
+			if os != c.wantOS || arch != c.wantArch {
+				t.Errorf("resolveReleaseTarget(%q,%q) = (%q,%q), want (%q,%q)", c.goos, c.goarch, os, arch, c.wantOS, c.wantArch)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+			t.Errorf("resolveReleaseTarget(%q,%q) error = %v, want substring %q", c.goos, c.goarch, err, c.wantErr)
+		}
+	}
+}

--- a/cmd/proxsave/upgrade_trace_audited_test.go
+++ b/cmd/proxsave/upgrade_trace_audited_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// Regression for deferred-trace-err-shadowed (2026-06-09 audit): downloadAndInstallLatest
+// declared `var err error` for its deferred trace, but each download/verify/install step
+// used `if err := <call>; err != nil { return ... }`, shadowing a local err. On failure the
+// outer err stayed nil (last set by a successful os.OpenRoot), so the deferred trace logged
+// the span as "ok" even though the function returned an error. Written after switching to a
+// named return so the trace reflects the real outcome.
+func TestDownloadAndInstallLatest_TraceReportsErrorOnFailure(t *testing.T) {
+	bootstrap := logging.NewBootstrapLogger()
+	bootstrap.SetLevel(types.LogLevelDebug)
+
+	var mirrorBuf bytes.Buffer
+	mirror := logging.New(types.LogLevelDebug, false)
+	mirror.SetOutput(&mirrorBuf)
+	bootstrap.SetMirrorLogger(mirror)
+
+	// A cancelled context makes the first (shadowed) step, downloadFile, fail fast
+	// via http.NewRequestWithContext/client.Do without any real network call.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := downloadAndInstallLatest(ctx, filepath.Join(t.TempDir(), "proxsave"), bootstrap, "v9.9.9", "9.9.9")
+	if err == nil {
+		t.Fatal("expected downloadAndInstallLatest to fail with a cancelled context")
+	}
+
+	out := mirrorBuf.String()
+	if !strings.Contains(out, "End upgrade download/install (error=") {
+		t.Errorf("deferred trace should report the span as failed; trace:\n%s", out)
+	}
+	if strings.Contains(out, "End upgrade download/install (ok") {
+		t.Errorf("deferred trace must NOT report the span as ok when a step failed; trace:\n%s", out)
+	}
+}

--- a/cmd/proxsave/version_compare_prerelease_audited_test.go
+++ b/cmd/proxsave/version_compare_prerelease_audited_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+// Regression for version-comparator-divergence-prerelease (2026-06-09 audit):
+// the upgrade gate (compareVersions) stripped any "-"/"+" suffix and so treated
+// "1.2.3-rc1" as EQUAL to "1.2.3", while the update nag (isNewerVersion) correctly
+// treats a stable release as newer than the same-numeric pre-release. The two gave
+// opposite answers on the rc -> stable transition, so an rc user was told an update
+// existed yet runUpgrade refused it ("already running the latest version").
+// Written after aligning compareVersions with isNewerVersion.
+
+func TestCompareVersions_PrereleaseTieBreak(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            int
+	}{
+		{"1.2.3-rc1", "1.2.3", -1},    // rc -> stable is an upgrade
+		{"1.2.3", "1.2.3-rc1", 1},     // stable -> rc is not a downgrade target
+		{"1.2.3-rc1", "1.2.3-rc2", 0}, // both pre-release, same numeric core
+		{"1.2.3", "1.2.3", 0},         // both stable
+		{"1.2.3+build", "1.2.3", 0},   // build metadata is not a pre-release
+		{"1.2.3", "1.2.3+build", 0},   // build metadata is not a pre-release
+		{"1.2.3-rc1", "1.2.4", -1},    // numeric core still dominates
+	}
+	for _, c := range cases {
+		if got := compareVersions(c.current, c.latest); got != c.want {
+			t.Errorf("compareVersions(%q,%q) = %d, want %d", c.current, c.latest, got, c.want)
+		}
+	}
+}
+
+// The upgrade gate and the update nag must agree: whenever isNewerVersion says an
+// update exists, compareVersions must report current < latest (-1), and vice versa.
+func TestCompareVersions_AgreesWithIsNewerVersion(t *testing.T) {
+	pairs := [][2]string{
+		{"1.2.3-rc1", "1.2.3"},
+		{"1.2.2", "1.2.3"},
+		{"1.2.3", "1.3.0"},
+		{"1.2.3", "1.2.3"},
+		{"1.2.3", "1.2.3-rc1"},
+		{"2.0.0", "1.9.9"},
+	}
+	for _, p := range pairs {
+		cur, lat := p[0], p[1]
+		newer := isNewerVersion(cur, lat)
+		cmp := compareVersions(cur, lat)
+		if newer && cmp >= 0 {
+			t.Errorf("isNewerVersion(%q,%q)=true but compareVersions=%d (want <0)", cur, lat, cmp)
+		}
+		if !newer && cmp < 0 {
+			t.Errorf("isNewerVersion(%q,%q)=false but compareVersions=%d (want >=0)", cur, lat, cmp)
+		}
+	}
+}

--- a/cmd/proxsave/version_helpers_test.go
+++ b/cmd/proxsave/version_helpers_test.go
@@ -2,6 +2,11 @@ package main
 
 import "testing"
 
+// audited: 2026-06-09 — corrected the "1.2.3-rc1" vs "1.2.3" case from 0 to -1.
+// The old expectation encoded the bug where compareVersions stripped the
+// pre-release suffix entirely and treated an rc as equal to its stable release,
+// diverging from isNewerVersion and stranding rc users on "already running the
+// latest version".
 func TestCompareVersions(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -14,7 +19,7 @@ func TestCompareVersions(t *testing.T) {
 		{"patch newer", "0.11.10", "0.11.2", 1},
 		{"minor newer", "0.10.9", "0.11.0", -1},
 		{"major newer", "1.0.0", "0.99.0", 1},
-		{"ignore suffix", "1.2.3-rc1", "1.2.3", 0},
+		{"prerelease older than stable", "1.2.3-rc1", "1.2.3", -1},
 		{"different length", "1.2", "1.2.1", -1},
 		{"empty current", "", "1", -1},
 		{"empty latest", "1", "", 1},

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -1,0 +1,59 @@
+# Test strategy — proxsave
+
+## Revisione progressiva della suite + convenzione `*_audited_test.go`
+
+È in corso una revisione progressiva dell'intera test suite esistente per verificare
+che nessun test cristallizzi un bug (cioè asserisca come "corretto" un comportamento
+in realtà difettoso del codice non testato). Per distinguere a colpo d'occhio i test
+già vagliati da quelli ancora da rivedere si usa il **suffisso del nome file**:
+
+- **`*_test.go`** (senza marcatore) = test **legacy, ancora da rivedere**.
+- **`*_audited_test.go`** = test **vagliato**, in uno di questi due casi:
+  - è **nato dopo la baseline** (scritto sapendo già che il codice sotto è corretto), oppure
+  - è un file legacy che è stato **riletto e approvato** (nessun bug cristallizzato).
+
+Go richiede solo che il file finisca in `_test.go`, quindi `*_audited_test.go` viene
+raccolto normalmente da `go test`: la convenzione non ha alcun costo a runtime.
+
+### Regole operative
+
+- Quando scrivi **nuovi** test, nominali direttamente `<qualcosa>_audited_test.go`.
+- Quando **finisci di rivedere** un file legacy, rinominalo con `git mv`:
+  `git mv foo_test.go foo_audited_test.go` (la history viene preservata; il rename è
+  di per sé il log della revisione, fai un commit atomico per file/area).
+- Per i file enormi rivisti a pezzi, granularità **per funzione** con un tag-commento
+  datato sopra la `func Test...`:
+  `// audited: 2026-06-09 — verificato che non cristallizza bug`
+- **Non** rinominare in blocco i 238 file legacy: il rename avviene solo a revisione
+  effettivamente completata.
+
+### Avanzamento
+
+```bash
+# quanti restano da rivedere
+find . -name '*_test.go' -not -name '*_audited_test.go' -not -path './vendor/*' | wc -l
+# quanti già vagliati
+find . -name '*_audited_test.go' -not -path './vendor/*' | wc -l
+# prossimi da fare in un package
+find internal/orchestrator -name '*_test.go' -not -name '*_audited_test.go'
+```
+
+### Baseline git
+
+Il tag **`tests-audit-baseline`** (su `3222a30`, 2026-06-09) marca lo stato della suite
+all'avvio della revisione. Per sapere *cosa* è cambiato nei test rispetto a quel punto:
+
+```bash
+git diff --name-only tests-audit-baseline -- '*_test.go'
+```
+
+Il suffisso `_audited_` risponde a "rivisto / da rivedere"; il tag risponde a
+"creato prima/dopo la baseline". Insieme coprono entrambe le domande.
+
+## Contesto
+
+La revisione nasce dall'audit di correttezza pre-test del 2026-06-09
+(`diagnostics/precoverage-bughunt-2026-06-09.md`), che ha confermato 26 bug nel codice
+non coperto che stavamo per testare: la prova che scrivere test su codice non vagliato
+rischia di cristallizzare i difetti. Da qui la regola: prima si verifica la correttezza
+del codice, poi si scrive il test, che nasce `_audited`.

--- a/internal/backup/archiver.go
+++ b/internal/backup/archiver.go
@@ -995,12 +995,17 @@ func (a *Archiver) VerifyArchive(ctx context.Context, archivePath string) error 
 		return a.verifyXZArchive(ctx, archivePath)
 	case types.CompressionZstd:
 		return a.verifyZstdArchive(ctx, archivePath)
-	case types.CompressionGzip:
+	case types.CompressionGzip, types.CompressionPigz:
+		// pigz emits standard gzip-format output, so the gzip verifier applies.
 		return a.verifyGzipArchive(ctx, archivePath)
+	case types.CompressionBzip2:
+		return a.verifyBzip2Archive(ctx, archivePath)
+	case types.CompressionLZMA:
+		return a.verifyLzmaArchive(ctx, archivePath)
 	case types.CompressionNone:
 		return a.verifyTarArchive(ctx, archivePath)
 	default:
-		a.logger.Warning("Unknown compression type, skipping detailed verification")
+		a.logger.Warning("Unknown compression type %q, skipping detailed verification", a.compression)
 		return nil
 	}
 }
@@ -1078,6 +1083,42 @@ func (a *Archiver) verifyGzipArchive(ctx context.Context, archivePath string) er
 	}
 
 	a.logger.Debug("Archive verification passed: Gzip compression and tar structure are valid")
+	return nil
+}
+
+// verifyBzip2Archive tests bzip2 compression and tar integrity
+func (a *Archiver) verifyBzip2Archive(ctx context.Context, archivePath string) error {
+	a.logger.Debug("Testing Bzip2 compression integrity")
+
+	// tar -tjf decompresses through bzip2 and lists, exercising both layers.
+	cmd, err := a.cmd(ctx, "tar", "-tjf", archivePath)
+	if err != nil {
+		return err
+	}
+	cmd.Stdout = nil // Discard output
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tar/bzip2 verification failed: %w (output: %s)", err, string(output))
+	}
+
+	a.logger.Debug("Archive verification passed: Bzip2 compression and tar structure are valid")
+	return nil
+}
+
+// verifyLzmaArchive tests lzma compression and tar integrity
+func (a *Archiver) verifyLzmaArchive(ctx context.Context, archivePath string) error {
+	a.logger.Debug("Testing LZMA compression integrity")
+
+	// tar --lzma -tf decompresses through lzma and lists, exercising both layers.
+	cmd, err := a.cmd(ctx, "tar", "--lzma", "-tf", archivePath)
+	if err != nil {
+		return err
+	}
+	cmd.Stdout = nil // Discard output
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tar/lzma verification failed: %w (output: %s)", err, string(output))
+	}
+
+	a.logger.Debug("Archive verification passed: LZMA compression and tar structure are valid")
 	return nil
 }
 

--- a/internal/backup/archiver.go
+++ b/internal/backup/archiver.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -438,6 +439,17 @@ func (a *Archiver) CreateArchive(ctx context.Context, sourceDir, outputPath stri
 }
 
 // createGzipArchive creates a gzip-compressed tar archive using Go's stdlib
+// finalizeEncryptionInto runs the encryption finalizer and folds any error into
+// *errp. A failed age Close means the encrypted archive's final chunk was not
+// written - a truncated, undecryptable archive - so it must never be demoted to a
+// warning behind an earlier close error (e.g. a compressor Close that ran first via
+// the LIFO defer order). errors.Join preserves both errors.
+func finalizeEncryptionInto(errp *error, finalize func() error) {
+	if cerr := finalize(); cerr != nil {
+		*errp = errors.Join(*errp, fmt.Errorf("finalize encrypted archive: %w", cerr))
+	}
+}
+
 func (a *Archiver) createGzipArchive(ctx context.Context, sourceDir, outputPath string) (err error) {
 	a.logger.Debug("Creating gzip archive with level %d (mode %s)", a.compressionLevel, a.CompressionMode())
 
@@ -452,15 +464,7 @@ func (a *Archiver) createGzipArchive(ctx context.Context, sourceDir, outputPath 
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if cerr := finalizeEncryption(); cerr != nil {
-			if err == nil {
-				err = fmt.Errorf("finalize encrypted archive: %w", cerr)
-			} else {
-				a.logger.Warning("Failed to finalize encrypted archive: %v", cerr)
-			}
-		}
-	}()
+	defer finalizeEncryptionInto(&err, finalizeEncryption)
 
 	// Create gzip writer targeting final writer (possibly encrypted)
 	gzWriter, err := gzip.NewWriterLevel(writer, a.compressionLevel)
@@ -502,15 +506,7 @@ func (a *Archiver) createTarArchive(ctx context.Context, sourceDir, outputPath s
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if cerr := finalizeEncryption(); cerr != nil {
-			if err == nil {
-				err = fmt.Errorf("finalize encrypted archive: %w", cerr)
-			} else {
-				a.logger.Warning("Failed to finalize encrypted archive: %v", cerr)
-			}
-		}
-	}()
+	defer finalizeEncryptionInto(&err, finalizeEncryption)
 
 	if err := a.writeTar(ctx, sourceDir, writer); err != nil {
 		return fmt.Errorf("failed to write tar archive: %w", err)
@@ -587,15 +583,7 @@ func (a *Archiver) createXZArchive(ctx context.Context, sourceDir, outputPath st
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if cerr := finalizeEncryption(); cerr != nil {
-			if err == nil {
-				err = fmt.Errorf("finalize encrypted archive: %w", cerr)
-			} else {
-				a.logger.Warning("Failed to finalize encrypted archive: %v", cerr)
-			}
-		}
-	}()
+	defer finalizeEncryptionInto(&err, finalizeEncryption)
 	cmd.Stdout = writer
 
 	errChan := make(chan error, 1)
@@ -658,15 +646,7 @@ func (a *Archiver) createZstdArchive(ctx context.Context, sourceDir, outputPath 
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if cerr := finalizeEncryption(); cerr != nil {
-			if err == nil {
-				err = fmt.Errorf("finalize encrypted archive: %w", cerr)
-			} else {
-				a.logger.Warning("Failed to finalize encrypted archive: %v", cerr)
-			}
-		}
-	}()
+	defer finalizeEncryptionInto(&err, finalizeEncryption)
 	cmd.Stdout = writer
 
 	errChan := make(chan error, 1)
@@ -742,15 +722,7 @@ func (a *Archiver) pipeTarThroughCommand(ctx context.Context, sourceDir, outputP
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if cerr := finalizeEncryption(); cerr != nil {
-			if err == nil {
-				err = fmt.Errorf("finalize encrypted archive: %w", cerr)
-			} else {
-				a.logger.Warning("Failed to finalize encrypted archive: %v", cerr)
-			}
-		}
-	}()
+	defer finalizeEncryptionInto(&err, finalizeEncryption)
 	cmd.Stdout = writer
 	if err := a.attachStderrLogger(cmd, algo); err != nil {
 		return fmt.Errorf("capture %s output: %w", algo, err)

--- a/internal/backup/archiver_finalize_encryption_audited_test.go
+++ b/internal/backup/archiver_finalize_encryption_audited_test.go
@@ -1,0 +1,47 @@
+package backup
+
+import (
+	"errors"
+	"testing"
+)
+
+// Regression for age-close-demoted-on-prior-error (2026-06-09 audit): each
+// create*Archive registered a finalizeEncryption defer that only promoted the age
+// Close error when the named err was still nil; otherwise it logged a warning and
+// discarded it. Because the compressor's closeIntoErr defer runs FIRST (LIFO) and
+// can set err, a real age Close failure (final-chunk flush -> truncated/undecryptable
+// archive) was downgraded to a warning. The shared finalizeEncryptionInto now folds
+// the age error in via errors.Join so it is never lost.
+
+func TestFinalizeEncryptionInto_DoesNotDemoteAgeErrorBehindPriorError(t *testing.T) {
+	prior := errors.New("close gzip writer: boom") // e.g. compressor Close ran first
+	ageErr := errors.New("age final chunk flush failed")
+
+	err := prior
+	finalizeEncryptionInto(&err, func() error { return ageErr })
+
+	if !errors.Is(err, ageErr) {
+		t.Errorf("age finalize error was dropped behind a prior error; err=%v", err)
+	}
+	if !errors.Is(err, prior) {
+		t.Errorf("prior error was dropped; err=%v", err)
+	}
+}
+
+func TestFinalizeEncryptionInto_SurfacesAgeErrorWhenNoPrior(t *testing.T) {
+	ageErr := errors.New("age final chunk flush failed")
+	var err error
+	finalizeEncryptionInto(&err, func() error { return ageErr })
+	if !errors.Is(err, ageErr) {
+		t.Errorf("age finalize error not surfaced; err=%v", err)
+	}
+}
+
+func TestFinalizeEncryptionInto_LeavesPriorErrorUntouchedOnSuccess(t *testing.T) {
+	prior := errors.New("prior")
+	err := prior
+	finalizeEncryptionInto(&err, func() error { return nil })
+	if !errors.Is(err, prior) {
+		t.Errorf("prior error must be preserved when finalize succeeds; err=%v", err)
+	}
+}

--- a/internal/backup/archiver_verify_audited_test.go
+++ b/internal/backup/archiver_verify_audited_test.go
@@ -1,0 +1,100 @@
+package backup
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// Regression for the 2026-06-09 audit finding verify-skips-pigz-bzip2-lzma:
+// VerifyArchive routed pigz/bzip2/lzma into the "Unknown compression type" default
+// branch and returned nil, so a corrupt archive of those (supported) types passed
+// verification and only failed at restore. These tests assert a corrupt archive is
+// now rejected. Written after the fix, hence the _audited suffix.
+
+// writeCompressibleTree drops one sizeable, low-compressibility file so the
+// compressed body spans well past any header, making mid-stream truncation a
+// reliable way to corrupt the stream.
+func writeAuditPayload(t *testing.T, dir string) {
+	t.Helper()
+	buf := make([]byte, 256*1024)
+	for i := range buf {
+		buf[i] = byte((i*31 + i/7) % 251)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "payload.bin"), buf, 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+}
+
+func TestVerifyArchive_DetectsCorruption_PigzBzip2Lzma(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not available")
+	}
+
+	cases := []struct {
+		name string
+		comp types.CompressionType
+		tool string // underlying compressor; if missing, skip (or create falls back)
+		ext  string
+	}{
+		{"pigz", types.CompressionPigz, "pigz", ".tar.gz"},
+		{"bzip2", types.CompressionBzip2, "bzip2", ".tar.bz2"},
+		{"lzma", types.CompressionLZMA, "lzma", ".tar.lzma"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := exec.LookPath(tc.tool); err != nil {
+				// Without the tool, CreateArchive falls back to gzip and this
+				// would no longer exercise the target type.
+				t.Skipf("%s not available", tc.tool)
+			}
+
+			src := t.TempDir()
+			writeAuditPayload(t, src)
+			archivePath := filepath.Join(t.TempDir(), "backup"+tc.ext)
+
+			logger := logging.New(types.LogLevelInfo, false)
+			logger.SetOutput(io.Discard)
+			ar := NewArchiver(logger, &ArchiverConfig{
+				Compression:        tc.comp,
+				CompressionLevel:   6,
+				CompressionThreads: 2,
+				DryRun:             false,
+			})
+
+			ctx := context.Background()
+			if err := ar.CreateArchive(ctx, src, archivePath); err != nil {
+				t.Fatalf("CreateArchive(%s): %v", tc.name, err)
+			}
+
+			// A valid archive must verify clean (also proves the verify command
+			// is compatible with the create command for this type).
+			if err := ar.VerifyArchive(ctx, archivePath); err != nil {
+				t.Fatalf("VerifyArchive on a good %s archive returned error: %v", tc.name, err)
+			}
+
+			// Corrupt the compressed body: truncate to 60% so the decompressor
+			// hits an unexpected end mid-stream.
+			info, err := os.Stat(archivePath)
+			if err != nil {
+				t.Fatalf("stat archive: %v", err)
+			}
+			if err := os.Truncate(archivePath, info.Size()*6/10); err != nil {
+				t.Fatalf("truncate archive: %v", err)
+			}
+
+			// The regression: before routing these types to a real verifier,
+			// VerifyArchive returned nil for a corrupt archive.
+			if err := ar.VerifyArchive(ctx, archivePath); err == nil {
+				t.Fatalf("VerifyArchive accepted a CORRUPT %s archive (integrity check was skipped)", tc.name)
+			}
+		})
+	}
+}

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -41,6 +41,14 @@ var (
 type Checker struct {
 	logger *logging.Logger
 	config *CheckerConfig
+
+	// lockAcquired is true only after THIS checker successfully created the lock
+	// file. ReleaseLock is a no-op unless this flag is set, so a checker that did
+	// not win the lock (another backup held it, or a deferred release fired after
+	// an early error before acquisition) never deletes the holder's lock file.
+	lockAcquired bool
+	// lockPath records the exact path of the lock file this checker created.
+	lockPath string
 }
 
 // DisableCloud globally disables cloud-related checks for this checker.
@@ -397,6 +405,11 @@ func (c *Checker) CheckLockFile() CheckResult {
 			result.Message = result.Error.Error()
 			return result
 		}
+
+		// Record ownership: only now does this checker truly hold the lock, so a
+		// later ReleaseLock is allowed to remove it.
+		c.lockAcquired = true
+		c.lockPath = lockPath
 	} else {
 		c.logger.Info("[DRY RUN] Would create lock file: %s", lockPath)
 	}
@@ -653,15 +666,33 @@ func (c *Checker) CheckTempDirectory() CheckResult {
 	return result
 }
 
-// ReleaseLock removes the lock file
+// ReleaseLock removes the lock file, but ONLY if this checker actually acquired
+// it. A checker that never won the lock must not delete the shared lock file:
+// doing so would remove the holder's lock and break mutual exclusion (e.g. a
+// second backup that failed the "another backup is in progress" check, or a
+// deferred release that fired after an early error before acquisition).
 func (c *Checker) ReleaseLock() error {
-	lockPath := c.config.LockFilePath
-	if lockPath == "" {
-		lockPath = filepath.Join(c.config.LockDirPath, ".backup.lock")
+	if c.config.DryRun {
+		c.logger.Info("[DRY RUN] Would release lock file: %s", c.resolveLockPath())
+		return nil
 	}
 
-	if c.config.DryRun {
-		c.logger.Info("[DRY RUN] Would release lock file: %s", lockPath)
+	if !c.lockAcquired {
+		c.logger.Debug("Lock not acquired by this checker; nothing to release")
+		return nil
+	}
+
+	lockPath := c.lockPath
+	if lockPath == "" {
+		lockPath = c.resolveLockPath()
+	}
+
+	// Defense in depth: only remove the lock if it still belongs to this process.
+	// Guards against the rare case where our lock was reaped as stale and another
+	// process re-created it between acquisition and release.
+	if !c.ownsLockFile(lockPath) {
+		c.logger.Warning("Lock file %s no longer owned by this process (pid=%d); not removing", lockPath, os.Getpid())
+		c.lockAcquired = false
 		return nil
 	}
 
@@ -669,8 +700,35 @@ func (c *Checker) ReleaseLock() error {
 		return fmt.Errorf("failed to release lock: %w", err)
 	}
 
+	c.lockAcquired = false
 	c.logger.Debug("Lock file released: %s", lockPath)
 	return nil
+}
+
+// resolveLockPath returns the configured lock file path, defaulting to
+// <LockDirPath>/.backup.lock when no explicit path is set.
+func (c *Checker) resolveLockPath() string {
+	if c.config.LockFilePath != "" {
+		return c.config.LockFilePath
+	}
+	return filepath.Join(c.config.LockDirPath, ".backup.lock")
+}
+
+// ownsLockFile reports whether the lock file at lockPath was written by this
+// process (matching pid and host). A missing or unreadable file, or one without
+// a parseable pid, is treated as owned so the subsequent remove is a harmless
+// no-op rather than a leak.
+func (c *Checker) ownsLockFile(lockPath string) bool {
+	content, err := os.ReadFile(lockPath)
+	if err != nil {
+		return true
+	}
+	meta := parseLockFileMetadata(content)
+	if meta.PID == 0 {
+		return true
+	}
+	hostname, _ := os.Hostname()
+	return meta.PID == os.Getpid() && sameHost(meta.Host, hostname)
 }
 
 // GetDefaultCheckerConfig returns a default checker configuration

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -1691,24 +1691,30 @@ func TestReleaseLock_DryRunUsesDefaultPath(t *testing.T) {
 	}
 }
 
+// audited: 2026-06-09 — corrected setup: ReleaseLock is now ownership-aware, so
+// the remove-failure path is only reachable after a real acquisition. The old
+// setup (write lock file by hand, never acquire, expect removal) encoded the
+// pre-fix bug where a non-owner deleted the shared lock.
 func TestReleaseLock_RemoveFails(t *testing.T) {
 	logger := logging.New(types.LogLevelInfo, false)
 	logger.SetOutput(io.Discard)
 
 	tmpDir := t.TempDir()
 	lockPath := filepath.Join(tmpDir, ".backup.lock")
-	if err := os.WriteFile(lockPath, []byte("lock"), 0o600); err != nil {
-		t.Fatalf("write lock file: %v", err)
-	}
 
 	cfg := GetDefaultCheckerConfig(tmpDir, tmpDir, tmpDir)
 	cfg.LockFilePath = lockPath
+
+	checker := NewChecker(logger, cfg)
+	// Acquire the lock for real so this checker owns it.
+	if res := checker.CheckLockFile(); !res.Passed {
+		t.Fatalf("CheckLockFile should acquire the lock: %s", res.Message)
+	}
 
 	origRemove := osRemove
 	t.Cleanup(func() { osRemove = origRemove })
 	osRemove = func(name string) error { return syscall.EPERM }
 
-	checker := NewChecker(logger, cfg)
 	err := checker.ReleaseLock()
 	if err == nil || !strings.Contains(err.Error(), "failed to release lock") {
 		t.Fatalf("expected failed to release lock error, got: %v", err)

--- a/internal/checks/lock_ownership_audited_test.go
+++ b/internal/checks/lock_ownership_audited_test.go
@@ -1,0 +1,150 @@
+package checks
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// These tests guard the backup-lock mutual exclusion against the regression
+// confirmed by the 2026-06-09 pre-test audit (deferred-release-deletes-foreign-lock
+// / release-runs-on-unacquired-lock-path): a checker that never acquired the lock
+// must never delete the holder's lock file. They are written AFTER fixing
+// ReleaseLock to be ownership-aware, hence the _audited suffix.
+
+func newLockChecker(t *testing.T, lockPath string) (*Checker, *CheckerConfig) {
+	t.Helper()
+	logger := logging.New(types.LogLevelInfo, false)
+	logger.SetOutput(io.Discard)
+	cfg := &CheckerConfig{
+		BackupPath:   filepath.Dir(lockPath),
+		LogPath:      filepath.Dir(lockPath),
+		LockDirPath:  filepath.Dir(lockPath),
+		LockFilePath: lockPath,
+		MaxLockAge:   time.Hour,
+		DryRun:       false,
+	}
+	return NewChecker(logger, cfg), cfg
+}
+
+// TestReleaseLock_NonOwnerDoesNotDeleteForeignLock is the core regression: a
+// second backup that loses the lock check must not delete the winner's lock when
+// its own deferred ReleaseLock fires.
+func TestReleaseLock_NonOwnerDoesNotDeleteForeignLock(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), ".backup.lock")
+
+	// Backup A acquires the lock.
+	checkerA, _ := newLockChecker(t, lockPath)
+	if res := checkerA.CheckLockFile(); !res.Passed {
+		t.Fatalf("backup A should acquire the lock, got: %s", res.Message)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock file should exist after A acquired it: %v", err)
+	}
+
+	// Backup B (separate checker, same path) loses: A's pid is alive (this very
+	// process), so CheckLockFile reports "another backup in progress" and does
+	// NOT create a lock for B.
+	checkerB, _ := newLockChecker(t, lockPath)
+	if res := checkerB.CheckLockFile(); res.Passed {
+		t.Fatalf("backup B must NOT acquire the lock while A holds it")
+	}
+
+	// B's deferred release must be a no-op: A's lock must survive.
+	if err := checkerB.ReleaseLock(); err != nil {
+		t.Fatalf("B.ReleaseLock returned error: %v", err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("A's lock file was deleted by non-owner B's ReleaseLock (mutual exclusion broken): %v", err)
+	}
+
+	// A still owns it and can release it cleanly.
+	if err := checkerA.ReleaseLock(); err != nil {
+		t.Fatalf("A.ReleaseLock returned error: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("A's lock file should be removed after the owner releases it")
+	}
+}
+
+// TestReleaseLock_NoOpWhenNeverAcquired covers the early-error path: a checker
+// whose deferred ReleaseLock fires before it ever acquired the lock (e.g. a
+// storage-init failure) must not delete a pre-existing foreign lock.
+func TestReleaseLock_NoOpWhenNeverAcquired(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), ".backup.lock")
+
+	// A foreign lock file already on disk (held by some other backup).
+	if err := os.WriteFile(lockPath, []byte("pid=999999\nhost=otherhost\ntime=2026-06-09T00:00:00Z\n"), 0o640); err != nil {
+		t.Fatalf("seeding foreign lock: %v", err)
+	}
+
+	// This checker never called CheckLockFile, so it never acquired anything.
+	checker, _ := newLockChecker(t, lockPath)
+	if err := checker.ReleaseLock(); err != nil {
+		t.Fatalf("ReleaseLock returned error: %v", err)
+	}
+
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("foreign lock was deleted by a checker that never acquired it: %v", err)
+	}
+}
+
+// TestReleaseLock_OwnerReleaseIsIdempotent ensures the owner can release, and a
+// second release after the file is gone does not error or touch a lock another
+// process may have created in the meantime.
+func TestReleaseLock_OwnerReleaseIsIdempotent(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), ".backup.lock")
+
+	checker, _ := newLockChecker(t, lockPath)
+	if res := checker.CheckLockFile(); !res.Passed {
+		t.Fatalf("checker should acquire the lock, got: %s", res.Message)
+	}
+	if err := checker.ReleaseLock(); err != nil {
+		t.Fatalf("first ReleaseLock failed: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock should be gone after owner release")
+	}
+
+	// A different process now holds the lock.
+	if err := os.WriteFile(lockPath, []byte("pid=999999\nhost=otherhost\ntime=2026-06-09T00:00:00Z\n"), 0o640); err != nil {
+		t.Fatalf("seeding new foreign lock: %v", err)
+	}
+	// A stray second release from the original owner must not delete it.
+	if err := checker.ReleaseLock(); err != nil {
+		t.Fatalf("second ReleaseLock failed: %v", err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("second release wrongly deleted another process's lock: %v", err)
+	}
+}
+
+// TestReleaseLock_SkipsRemovalWhenLockReplacedByAnotherProcess exercises the
+// defense-in-depth content check: even when this checker believes it holds the
+// lock (lockAcquired==true), it must not remove a lock whose on-disk pid/host
+// now belong to a different process (our lock was reaped as stale and recreated).
+func TestReleaseLock_SkipsRemovalWhenLockReplacedByAnotherProcess(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), ".backup.lock")
+
+	checker, _ := newLockChecker(t, lockPath)
+	if res := checker.CheckLockFile(); !res.Passed {
+		t.Fatalf("checker should acquire the lock, got: %s", res.Message)
+	}
+
+	// Simulate our lock being reaped and re-created by another process.
+	if err := os.WriteFile(lockPath, []byte("pid=999999\nhost=otherhost\ntime=2026-06-09T00:00:00Z\n"), 0o640); err != nil {
+		t.Fatalf("replacing lock content: %v", err)
+	}
+
+	if err := checker.ReleaseLock(); err != nil {
+		t.Fatalf("ReleaseLock returned error: %v", err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("release deleted a lock now owned by another process: %v", err)
+	}
+}

--- a/internal/orchestrator/network_apply.go
+++ b/internal/orchestrator/network_apply.go
@@ -196,6 +196,23 @@ func buildNetworkApplyNotCommittedError(ctx context.Context, logger *logging.Log
 	}
 }
 
+// rollbackAlreadyExecuted reports whether the rollback has already run to
+// completion. The rollback script removes the marker file as its final step (and
+// disarmNetworkRollback removes it too), so while the timer is armed and before
+// we disarm, a missing marker means the revert already happened. This catches the
+// case rollbackAlreadyRunning misses: a finished systemd unit is no longer
+// 'active', so `systemctl is-active` reports it as not running.
+func rollbackAlreadyExecuted(logger *logging.Logger, handle *networkRollbackHandle) bool {
+	if handle == nil || strings.TrimSpace(handle.markerPath) == "" {
+		return false
+	}
+	if _, err := restoreFS.Stat(handle.markerPath); err != nil {
+		logging.DebugStep(logger, "rollback already executed", "Marker missing (%s): rollback already ran", handle.markerPath)
+		return true
+	}
+	return false
+}
+
 func rollbackAlreadyRunning(ctx context.Context, logger *logging.Logger, handle *networkRollbackHandle) bool {
 	if handle == nil || strings.TrimSpace(handle.unitName) == "" {
 		logging.DebugStep(logger, "rollback already running", "Skip check: handle=%v unitName=%q", handle != nil, "")

--- a/internal/orchestrator/network_apply.go
+++ b/internal/orchestrator/network_apply.go
@@ -214,8 +214,24 @@ func rollbackAlreadyExecuted(logger *logging.Logger, handle *networkRollbackHand
 }
 
 func rollbackAlreadyRunning(ctx context.Context, logger *logging.Logger, handle *networkRollbackHandle) bool {
-	if handle == nil || strings.TrimSpace(handle.unitName) == "" {
-		logging.DebugStep(logger, "rollback already running", "Skip check: handle=%v unitName=%q", handle != nil, "")
+	if handle == nil {
+		logging.DebugStep(logger, "rollback already running", "Skip check: nil handle")
+		return false
+	}
+
+	// The rollback script writes "<marker>.running" before it starts the revert and
+	// removes it when finished. Statting that sentinel detects an in-progress
+	// rollback even in the nohup fallback, where there is no systemd unit to query
+	// (this is what closes the commit-during-revert race in that mode).
+	if mp := strings.TrimSpace(handle.markerPath); mp != "" {
+		if _, err := restoreFS.Stat(mp + ".running"); err == nil {
+			logging.DebugStep(logger, "rollback already running", "Running sentinel present (%s.running)", mp)
+			return true
+		}
+	}
+
+	if strings.TrimSpace(handle.unitName) == "" {
+		logging.DebugStep(logger, "rollback already running", "Skip systemd check: no unit (nohup fallback)")
 		return false
 	}
 	if !commandAvailable("systemctl") {
@@ -677,6 +693,11 @@ func buildRollbackScript(markerPath, backupPath, logPath string, restartNetworki
 		fmt.Sprintf("LOG=%s", shellQuote(logPath)),
 		fmt.Sprintf("MARKER=%s", shellQuote(markerPath)),
 		fmt.Sprintf("BACKUP=%s", shellQuote(backupPath)),
+		// RUNNING signals that the revert is actually in progress: it is written
+		// AFTER the marker guard passes and removed when the script finishes, so an
+		// in-flight rollback is detectable even in the nohup fallback, where there is
+		// no systemd unit to query (rollbackAlreadyRunning stats "<marker>.running").
+		`RUNNING="$MARKER.running"`,
 		// Header
 		`echo "[INFO] ========================================" >> "$LOG"`,
 		`echo "[INFO] NETWORK ROLLBACK SCRIPT STARTED" >> "$LOG"`,
@@ -694,6 +715,9 @@ func buildRollbackScript(markerPath, backupPath, logPath string, restartNetworki
 		`  exit 0`,
 		`fi`,
 		`echo "[DEBUG] Marker exists, proceeding with rollback" >> "$LOG"`,
+		// Signal that the revert is now in progress (before any filesystem change).
+		`echo "[DEBUG] Signalling rollback in progress: $RUNNING" >> "$LOG"`,
+		`: > "$RUNNING"`,
 		// Extract phase
 		`echo "[INFO] --- EXTRACT PHASE ---" >> "$LOG"`,
 		`echo "[DEBUG] Executing: tar -xzf $BACKUP -C /" >> "$LOG"`,
@@ -827,8 +851,8 @@ func buildRollbackScript(markerPath, backupPath, logPath string, restartNetworki
 	}
 
 	lines = append(lines,
-		`echo "[DEBUG] Removing marker file..." >> "$LOG"`,
-		`rm -f "$MARKER"`,
+		`echo "[DEBUG] Removing marker and running sentinel..." >> "$LOG"`,
+		`rm -f "$MARKER" "$RUNNING"`,
 		`echo "[INFO] ========================================" >> "$LOG"`,
 		`echo "[INFO] NETWORK ROLLBACK SCRIPT FINISHED" >> "$LOG"`,
 		`echo "[INFO] Timestamp: $(date -Is)" >> "$LOG"`,

--- a/internal/orchestrator/network_apply.go
+++ b/internal/orchestrator/network_apply.go
@@ -833,6 +833,16 @@ func buildRollbackScript(markerPath, backupPath, logPath string, restartNetworki
 		`echo "[INFO] NETWORK ROLLBACK SCRIPT FINISHED" >> "$LOG"`,
 		`echo "[INFO] Timestamp: $(date -Is)" >> "$LOG"`,
 		`echo "[INFO] ========================================" >> "$LOG"`,
+		// Signal extraction failure to the caller via a nonzero exit. The tar step
+		// runs inside an `if`, which suspends `set -e`, so without this the script
+		// exits 0 even when it restored nothing - making a failed rollback
+		// indistinguishable from a successful one and causing the caller to report
+		// "rolled back to the pre-restore state" when it did not. Placed after the
+		// marker removal so the marker lifecycle is unchanged.
+		`if [ "$TAR_OK" -ne 1 ]; then`,
+		`  echo "[ERROR] Rollback failed: pre-restore files were NOT restored (extract phase failed)" >> "$LOG"`,
+		`  exit 1`,
+		`fi`,
 	)
 	return strings.Join(lines, "\n") + "\n"
 }

--- a/internal/orchestrator/network_apply_failure_notcommitted_audited_test.go
+++ b/internal/orchestrator/network_apply_failure_notcommitted_audited_test.go
@@ -1,0 +1,54 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// Regression for apply-failure-leaves-armed-timer-unsurfaced (2026-06-09 audit):
+// armRollbackAndApply armed the rollback then, when applyNetworkConfig failed,
+// returned the raw error. The caller treats a non-NotCommitted error as a generic
+// "apply step skipped or failed" and never surfaces that the rollback is armed and
+// will revert the network. The apply-failure path now returns a
+// NetworkApplyNotCommittedError so the rollback-armed/reconnect guidance is logged.
+func TestArmRollbackAndApply_ApplyFailureSurfacesNotCommitted(t *testing.T) {
+	origFS, origCmd, origTime := restoreFS, restoreCmd, restoreTime
+	t.Cleanup(func() { restoreFS, restoreCmd, restoreTime = origFS, origCmd, origTime })
+
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	restoreCmd = &FakeCommandRunner{} // default success for the nohup arm command
+	restoreTime = &FakeTime{Current: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)}
+
+	// Empty PATH: no ifreload/systemctl/ifup -> applyNetworkConfig fails via its
+	// default branch; no systemd-run -> the rollback arms via the nohup fallback
+	// (restoreCmd is mocked, so nothing actually backgrounds).
+	t.Setenv("PATH", t.TempDir())
+
+	f := &networkRollbackUIApplyFlow{
+		ctx:                context.Background(),
+		ui:                 &fakeRestoreWorkflowUI{},
+		logger:             newDiscardLogger(),
+		rollbackBackupPath: "/safety-backup.tar",
+		timeout:            time.Hour,
+		iface:              "",
+		diagnosticsDir:     "",
+	}
+
+	err := f.armRollbackAndApply()
+
+	var nc *NetworkApplyNotCommittedError
+	if !errors.As(err, &nc) {
+		t.Fatalf("armRollbackAndApply on apply failure = %v; want *NetworkApplyNotCommittedError", err)
+	}
+	if !nc.RollbackArmed {
+		t.Errorf("RollbackArmed should be true: the timer was armed before the failed apply")
+	}
+	if f.handle == nil {
+		t.Errorf("the rollback handle should be set (armed) even though apply failed")
+	}
+}

--- a/internal/orchestrator/network_apply_rollback_commit_audited_test.go
+++ b/internal/orchestrator/network_apply_rollback_commit_audited_test.go
@@ -1,0 +1,128 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Regression for two 2026-06-09 audit findings on the live network apply/rollback
+// flow, where the network path was the lone outlier (firewall/HA/access-control
+// handle the same cases correctly):
+//   - expired-window-returns-success: waitForCommit returned nil when the rollback
+//     window had already elapsed, which the caller reads as "committed", while the
+//     timer was still armed and about to revert the network.
+//   - completed-rollback-misreported-as-commit: commitNetworkConfig only checked
+//     `systemctl is-active` and so missed a rollback that had ALREADY run, reporting
+//     a successful commit after the network was reverted.
+// Written after the fix, hence the _audited suffix.
+
+func useRealRestoreFS(t *testing.T) {
+	t.Helper()
+	orig := restoreFS
+	restoreFS = osFS{}
+	t.Cleanup(func() { restoreFS = orig })
+}
+
+// Bug #1: an expired rollback window must surface a not-committed error (with the
+// rollback reported as armed), not nil.
+func TestWaitForCommit_ExpiredWindowReportsNotCommitted(t *testing.T) {
+	useRealRestoreFS(t)
+
+	markerPath := filepath.Join(t.TempDir(), "network_rollback_pending")
+	if err := os.WriteFile(markerPath, []byte("pending"), 0o600); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	ui := &fakeRestoreWorkflowUI{networkCommit: true} // if the prompt were (wrongly) reached and committed, commit would return nil
+	f := &networkRollbackUIApplyFlow{
+		ctx:            context.Background(),
+		ui:             ui,
+		logger:         newDiscardLogger(),
+		iface:          "",
+		diagnosticsDir: t.TempDir(),
+		handle: &networkRollbackHandle{
+			markerPath: markerPath,
+			armedAt:    time.Now().Add(-2 * time.Hour), // window of 1h already elapsed
+			timeout:    time.Hour,
+		},
+	}
+
+	err := f.waitForCommit()
+
+	var nc *NetworkApplyNotCommittedError
+	if !errors.As(err, &nc) {
+		t.Fatalf("waitForCommit on an expired window = %v; want *NetworkApplyNotCommittedError", err)
+	}
+	if !nc.RollbackArmed {
+		t.Errorf("RollbackArmed = false; want true (marker present, rollback will fire)")
+	}
+	if len(ui.shownMessages) == 0 {
+		t.Errorf("expected reconnect/rollback guidance to be shown")
+	}
+}
+
+// Bug #2: a commit arriving after the rollback already ran (marker removed by the
+// rollback script, systemd unit no longer active) must report not-committed.
+func TestCommitNetworkConfig_AlreadyExecutedReportsNotCommitted(t *testing.T) {
+	useRealRestoreFS(t)
+
+	// markerPath intentionally NOT created -> rollback already executed.
+	missingMarker := filepath.Join(t.TempDir(), "network_rollback_pending_gone")
+
+	f := &networkRollbackUIApplyFlow{
+		ctx:    context.Background(),
+		ui:     &fakeRestoreWorkflowUI{},
+		logger: newDiscardLogger(),
+		iface:  "",
+		handle: &networkRollbackHandle{
+			markerPath: missingMarker,
+			// unitName empty -> rollbackAlreadyRunning is a no-op (no systemctl call).
+			armedAt: time.Now(),
+			timeout: time.Hour,
+		},
+	}
+
+	err := f.commitNetworkConfig()
+
+	var nc *NetworkApplyNotCommittedError
+	if !errors.As(err, &nc) {
+		t.Fatalf("commitNetworkConfig with a completed rollback = %v; want *NetworkApplyNotCommittedError", err)
+	}
+	if nc.RollbackArmed {
+		t.Errorf("RollbackArmed = true; want false (marker gone = rollback already ran)")
+	}
+}
+
+// Positive control: when the rollback is still pending (marker present) and not
+// running, a genuine commit must succeed and disarm (remove the marker).
+func TestCommitNetworkConfig_CommitsWhenRollbackPendingAndNotRunning(t *testing.T) {
+	useRealRestoreFS(t)
+
+	markerPath := filepath.Join(t.TempDir(), "network_rollback_pending")
+	if err := os.WriteFile(markerPath, []byte("pending"), 0o600); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	f := &networkRollbackUIApplyFlow{
+		ctx:    context.Background(),
+		ui:     &fakeRestoreWorkflowUI{},
+		logger: newDiscardLogger(),
+		iface:  "",
+		handle: &networkRollbackHandle{
+			markerPath: markerPath, // unitName empty -> disarm only removes the marker
+			armedAt:    time.Now(),
+			timeout:    time.Hour,
+		},
+	}
+
+	if err := f.commitNetworkConfig(); err != nil {
+		t.Fatalf("commitNetworkConfig on a pending, non-running rollback = %v; want nil", err)
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Errorf("marker should have been removed by disarm on a successful commit")
+	}
+}

--- a/internal/orchestrator/network_apply_workflow_ui_rollback.go
+++ b/internal/orchestrator/network_apply_workflow_ui_rollback.go
@@ -392,8 +392,13 @@ func (f *networkRollbackUIApplyFlow) runPostApplyHealthChecks() {
 func (f *networkRollbackUIApplyFlow) waitForCommit() error {
 	remaining := f.handle.remaining(time.Now())
 	if remaining <= 0 {
-		f.warning("Rollback window already expired; leaving rollback armed")
-		return nil
+		// The rollback window elapsed before we could prompt for COMMIT: the timer
+		// is still armed and will revert the network shortly. This is NOT a
+		// successful commit, so surface the not-committed/reconnect guidance
+		// (matching the firewall/HA/access-control flows) instead of returning nil,
+		// which the caller reads as "committed successfully".
+		f.warning("Rollback window already expired before COMMIT; network configuration NOT committed (rollback armed)")
+		return f.handleNetworkNotCommitted()
 	}
 
 	logging.DebugStep(f.logger, "network safe apply (ui)", "Wait for COMMIT (rollback in %ds)", int(remaining.Seconds()))
@@ -416,8 +421,14 @@ func (f *networkRollbackUIApplyFlow) waitForCommit() error {
 }
 
 func (f *networkRollbackUIApplyFlow) commitNetworkConfig() error {
-	if rollbackAlreadyRunning(f.ctx, f.logger, f.handle) {
-		f.warning("Commit received too late: rollback already running. Network configuration NOT committed.")
+	// Treat the commit as too-late if the rollback is currently running OR has
+	// already run to completion. rollbackAlreadyRunning only sees an 'active'
+	// systemd unit; a finished rollback is inactive/dead, so we also check the
+	// marker file (removed by the rollback script on completion, and not yet by
+	// us since disarm runs below) to avoid reporting a successful commit after the
+	// network was already reverted.
+	if rollbackAlreadyRunning(f.ctx, f.logger, f.handle) || rollbackAlreadyExecuted(f.logger, f.handle) {
+		f.warning("Commit received too late: rollback already running or completed. Network configuration NOT committed.")
 		return buildNetworkApplyNotCommittedError(f.ctx, f.logger, f.iface, f.handle)
 	}
 	disarmNetworkRollback(f.ctx, f.logger, f.handle)

--- a/internal/orchestrator/network_apply_workflow_ui_rollback.go
+++ b/internal/orchestrator/network_apply_workflow_ui_rollback.go
@@ -341,7 +341,11 @@ func (f *networkRollbackUIApplyFlow) armRollbackAndApply() error {
 	logging.DebugStep(f.logger, "network safe apply (ui)", "Apply network configuration now")
 	if err := applyNetworkConfig(f.ctx, f.logger); err != nil {
 		f.warning("Network apply failed: %v", err)
-		return err
+		// The rollback timer is already armed and will revert the network, but the
+		// config was NOT committed. Surface the not-committed/reconnect guidance
+		// (matching the COMMIT-timeout and expired-window paths) so the caller logs
+		// the rollback-armed state instead of a bare "apply step failed".
+		return f.handleNetworkNotCommitted()
 	}
 	return nil
 }

--- a/internal/orchestrator/network_preflight.go
+++ b/internal/orchestrator/network_preflight.go
@@ -35,6 +35,14 @@ func (r networkPreflightResult) Ok() bool {
 	return !r.Skipped && r.ExitError == nil
 }
 
+// networkPreflightWarrantsRollback reports whether a non-OK preflight result is a
+// genuine validation FAILURE (so the staged network config must be rolled back),
+// as opposed to a SKIP (no validator binary available), which must keep the staged
+// config rather than reverting a valid restore.
+func networkPreflightWarrantsRollback(r networkPreflightResult) bool {
+	return !r.Ok() && !r.Skipped
+}
+
 func (r networkPreflightResult) Summary() string {
 	if r.Skipped {
 		return fmt.Sprintf("Network preflight: SKIPPED (%s)", strings.TrimSpace(r.SkipReason))

--- a/internal/orchestrator/network_preflight_rollback_audited_test.go
+++ b/internal/orchestrator/network_preflight_rollback_audited_test.go
@@ -1,0 +1,31 @@
+package orchestrator
+
+import (
+	"errors"
+	"testing"
+)
+
+// Regression for preflight-skip-rolls-back-valid-config (2026-06-09 audit):
+// maybeInstallNetworkConfigFromStage routed every !preflight.Ok() straight to the
+// automatic rollback. But Ok() is `!Skipped && ExitError==nil`, so when NO validator
+// binary (ifup/ifreload) was available the preflight returned Skipped=true and Ok()
+// was false, rolling back a perfectly valid restored network config. The fix keys
+// the rollback off a genuine FAILURE, not a SKIP. Written after that change.
+func TestNetworkPreflightWarrantsRollback(t *testing.T) {
+	cases := []struct {
+		name   string
+		result networkPreflightResult
+		want   bool
+	}{
+		{"ok (ran, no error)", networkPreflightResult{}, false},
+		{"skipped (no validator)", networkPreflightResult{Skipped: true, SkipReason: "ifup/ifreload not found"}, false},
+		{"genuine validation failure", networkPreflightResult{ExitError: errors.New("ifup -na failed")}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := networkPreflightWarrantsRollback(c.result); got != c.want {
+				t.Fatalf("networkPreflightWarrantsRollback(%+v) = %v, want %v", c.result, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/network_rollback_running_sentinel_audited_test.go
+++ b/internal/orchestrator/network_rollback_running_sentinel_audited_test.go
@@ -1,0 +1,125 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression for nohup-disarm-cannot-stop-running-rollback (2026-06-09 audit): in
+// the nohup fallback (no systemd unit) an in-progress rollback was undetectable, so
+// commitNetworkConfig could report a successful commit while the script was actively
+// reverting the network. The rollback script now writes a "<marker>.running" sentinel
+// for the duration of the revert; rollbackAlreadyRunning stats it, turning the
+// previously-microsecond commit-during-revert race into a deterministic, detectable
+// state in nohup mode. Written after adding the sentinel.
+
+func TestRollbackAlreadyRunning_DetectsRunningSentinelInNohupMode(t *testing.T) {
+	origFS := restoreFS
+	restoreFS = osFS{}
+	t.Cleanup(func() { restoreFS = origFS })
+
+	marker := filepath.Join(t.TempDir(), "network_rollback_pending")
+	if err := os.WriteFile(marker, []byte("pending"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// unitName empty => nohup fallback (no systemd unit to query).
+	handle := &networkRollbackHandle{markerPath: marker}
+
+	// No sentinel yet => not running (the normal sleep-window state, commit allowed).
+	if rollbackAlreadyRunning(context.Background(), newDiscardLogger(), handle) {
+		t.Fatalf("without the .running sentinel a nohup rollback must read as NOT running")
+	}
+
+	// The script signals it started the revert.
+	if err := os.WriteFile(marker+".running", nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !rollbackAlreadyRunning(context.Background(), newDiscardLogger(), handle) {
+		t.Fatalf("with the .running sentinel present a nohup rollback must read as running")
+	}
+}
+
+// End-to-end: a COMMIT arriving while the nohup rollback is mid-revert must be
+// reported as NOT committed (previously it falsely reported success because the
+// in-progress revert was invisible without a systemd unit).
+func TestCommitNetworkConfig_NotCommittedWhileNohupRollbackRunning(t *testing.T) {
+	origFS := restoreFS
+	restoreFS = osFS{}
+	t.Cleanup(func() { restoreFS = origFS })
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "network_rollback_pending")
+	if err := os.WriteFile(marker, []byte("pending"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker+".running", nil, 0o600); err != nil { // revert in progress
+		t.Fatal(err)
+	}
+
+	f := &networkRollbackUIApplyFlow{
+		ctx:    context.Background(),
+		ui:     &fakeRestoreWorkflowUI{},
+		logger: newDiscardLogger(),
+		iface:  "",
+		handle: &networkRollbackHandle{markerPath: marker}, // unitName empty => nohup
+	}
+
+	err := f.commitNetworkConfig()
+	var nc *NetworkApplyNotCommittedError
+	if !errors.As(err, &nc) {
+		t.Fatalf("commitNetworkConfig while the rollback is running = %v; want *NetworkApplyNotCommittedError", err)
+	}
+	// commit must NOT have disarmed: marker and sentinel stay for the running revert.
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("marker must survive a not-committed late commit: %v", statErr)
+	}
+}
+
+// The generated script must create the sentinel before reverting and remove it when
+// it finishes, so its presence/absence faithfully tracks "revert in progress".
+func TestBuildRollbackScript_RunningSentinelLifecycle(t *testing.T) {
+	for _, bin := range []string{"sh", "tar"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available", bin)
+		}
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "rollback.log")
+	marker := filepath.Join(dir, "marker")
+	backup := filepath.Join(dir, "backup.tar.gz")
+	if err := os.WriteFile(marker, []byte("pending"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Invalid archive: tar -xzf fails at the gzip stage, writing nothing to /. The
+	// sentinel is still created (before extract) and removed (cleanup), and
+	// restartNetworking=false keeps the live network untouched.
+	if err := os.WriteFile(backup, []byte("not a gzip tar archive\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	script := buildRollbackScript(marker, backup, logPath, false)
+	scriptPath := filepath.Join(dir, "rollback.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_ = exec.Command("sh", scriptPath).Run() // exits nonzero on the failed extract (covered elsewhere)
+
+	// The sentinel-write code path must have been reached...
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logData), "Signalling rollback in progress") {
+		t.Errorf("script did not signal rollback-in-progress; log:\n%s", logData)
+	}
+	// ...and the sentinel must be cleaned up afterwards (not left behind).
+	if _, statErr := os.Stat(marker + ".running"); !os.IsNotExist(statErr) {
+		t.Errorf(".running sentinel should be removed when the script finishes, err=%v", statErr)
+	}
+}

--- a/internal/orchestrator/network_rollback_script_audited_test.go
+++ b/internal/orchestrator/network_rollback_script_audited_test.go
@@ -1,0 +1,85 @@
+package orchestrator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// Regression for rollback-tar-failure-swallowed (2026-06-09 audit): buildRollbackScript
+// wrapped the tar extraction in an `if`, which suspends `set -e`, so a failed/corrupt
+// extraction still let the script exit 0. rollbackNetworkFilesNow then returned nil and
+// maybeInstallNetworkConfigFromStage falsely reported "rolled back to the pre-restore
+// state". The script must now exit nonzero when the extract phase fails. Written after
+// the fix, hence the _audited suffix.
+//
+// These tests run the REAL generated script but only along paths that never touch the
+// live system: a failing extraction writes nothing (gzip rejects a non-archive before
+// tar extracts), the prune phase is gated on a successful extract, and restartNetworking
+// is false so no network reload commands run.
+
+func TestBuildRollbackScript_ExitsNonzeroWhenExtractFails(t *testing.T) {
+	for _, bin := range []string{"sh", "tar"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available", bin)
+		}
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "rollback.log")
+	markerPath := filepath.Join(dir, "marker")
+	backupPath := filepath.Join(dir, "backup.tar.gz")
+
+	// Marker present so the script proceeds past the disarm check.
+	if err := os.WriteFile(markerPath, []byte("pending"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A deliberately invalid archive: `tar -xzf` fails at the gzip stage and extracts
+	// nothing, so this never writes to the real root filesystem.
+	if err := os.WriteFile(backupPath, []byte("this is not a gzip tar archive\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	script := buildRollbackScript(markerPath, backupPath, logPath, false /* restartNetworking */)
+	scriptPath := filepath.Join(dir, "rollback.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	err := exec.Command("sh", scriptPath).Run()
+	if err == nil {
+		t.Fatalf("rollback script exited 0 on a failed extraction; want nonzero exit so the caller can detect the failed rollback")
+	}
+	if _, ok := err.(*exec.ExitError); !ok {
+		t.Fatalf("expected a nonzero exit (*exec.ExitError), got %T: %v", err, err)
+	}
+
+	// The marker must still be cleaned up even on the failure path.
+	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
+		t.Errorf("marker should be removed even when the rollback extraction fails")
+	}
+}
+
+func TestBuildRollbackScript_NoopExitsZeroWhenMarkerAbsent(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	dir := t.TempDir()
+	// Marker absent -> the script is a no-op (already disarmed) and must exit 0. No
+	// tar runs, so nothing touches the filesystem.
+	script := buildRollbackScript(
+		filepath.Join(dir, "absent-marker"),
+		filepath.Join(dir, "backup.tar.gz"),
+		filepath.Join(dir, "rollback.log"),
+		false,
+	)
+	scriptPath := filepath.Join(dir, "rollback.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("sh", scriptPath).Run(); err != nil {
+		t.Fatalf("no-op rollback (marker absent) should exit 0, got: %v", err)
+	}
+}

--- a/internal/orchestrator/network_staged_apply_failure_audited_test.go
+++ b/internal/orchestrator/network_staged_apply_failure_audited_test.go
@@ -1,0 +1,49 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression for apply-failure-no-rollback (2026-06-09 audit): when
+// applyNetworkFilesFromStage failed partway (e.g. /etc/network copied but
+// writeFileAtomic of /etc/hostname failed), maybeInstallNetworkConfigFromStage
+// returned the error and NEVER rolled back, leaving /etc half-written even though
+// the rollback backup was already validated as available. Written after routing the
+// apply-failure path through rollbackAfterFailedStagedNetworkApply.
+func TestRollbackAfterFailedStagedNetworkApply_RollsBackAndReturnsOriginalError(t *testing.T) {
+	origFS, origCmd, origTime := restoreFS, restoreCmd, restoreTime
+	t.Cleanup(func() {
+		restoreFS, restoreCmd, restoreTime = origFS, origCmd, origTime
+	})
+
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	cmd := &FakeCommandRunner{}
+	restoreCmd = cmd
+	restoreTime = &FakeTime{Current: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)}
+
+	applyErr := errors.New("write /etc/hostname failed")
+	got := rollbackAfterFailedStagedNetworkApply(context.Background(), newTestLogger(), applyErr, "/backup.tar")
+
+	if !errors.Is(got, applyErr) {
+		t.Fatalf("returned error = %v, want the original apply error", got)
+	}
+
+	// The rollback must have been attempted: the script is executed via `sh`.
+	ranSh := false
+	for _, c := range cmd.Calls {
+		if strings.HasPrefix(c, "sh") {
+			ranSh = true
+			break
+		}
+	}
+	if !ranSh {
+		t.Fatalf("expected the rollback script to be invoked via sh; calls=%v", cmd.Calls)
+	}
+}

--- a/internal/orchestrator/network_staged_install.go
+++ b/internal/orchestrator/network_staged_install.go
@@ -60,7 +60,11 @@ func maybeInstallNetworkConfigFromStage(
 	logging.DebugStep(logger, "network staged install", "Apply staged network files to system paths (no reload)")
 	applied, err := applyNetworkFilesFromStage(logger, stageRoot)
 	if err != nil {
-		return false, err
+		// A partial apply may have written some of /etc/network/*, /etc/hosts,
+		// /etc/hostname, /etc/resolv.conf. Roll back to the pre-restore state
+		// (rollbackPath was validated non-empty above) instead of leaving /etc
+		// half-written.
+		return false, rollbackAfterFailedStagedNetworkApply(ctx, logger, err, rollbackPath)
 	}
 	logging.DebugStep(logger, "network staged install", "Staged network files applied: %d", len(applied))
 
@@ -110,6 +114,24 @@ func maybeInstallNetworkConfigFromStage(
 	)
 	logger.Info("Staged network files remain available under: %s", stageRoot)
 	return false, fmt.Errorf("network staged install preflight failed; network files rolled back")
+}
+
+// rollbackAfterFailedStagedNetworkApply rolls the staged network apply back to the
+// pre-restore state after applyNetworkFilesFromStage failed partway (which may have
+// left /etc half-written), then returns the original apply error. The bare error
+// return previously left the host with a half-applied network config and no revert.
+func rollbackAfterFailedStagedNetworkApply(ctx context.Context, logger *logging.Logger, applyErr error, rollbackPath string) error {
+	logger.Warning("Network staged apply failed: %v", applyErr)
+	rbLog, rbErr := rollbackNetworkFilesNow(ctx, logger, rollbackPath, "")
+	if strings.TrimSpace(rbLog) != "" {
+		logger.Info("Network rollback log: %s", rbLog)
+	}
+	if rbErr != nil {
+		logger.Error("Network staged apply rollback also failed: %v", rbErr)
+	} else {
+		logger.Warning("Rolled back /etc/network/*, /etc/hosts, /etc/hostname, /etc/resolv.conf to the pre-restore state (rollback=%s)", rollbackPath)
+	}
+	return applyErr
 }
 
 func maybeRepairNICNamesAuto(ctx context.Context, logger *logging.Logger, archivePath string) *nicRepairResult {

--- a/internal/orchestrator/network_staged_install.go
+++ b/internal/orchestrator/network_staged_install.go
@@ -80,6 +80,14 @@ func maybeInstallNetworkConfigFromStage(
 		return true, nil
 	}
 
+	// A SKIPPED preflight (no validator binary such as ifup/ifreload available) is
+	// NOT a validation failure: we could not validate, but the staged config is in
+	// place and presumed good, so keep it instead of rolling back a valid restore.
+	if !networkPreflightWarrantsRollback(preflight) {
+		logger.Warning("Network restore: preflight validation skipped (%s); keeping staged configuration without live validation.", strings.TrimSpace(preflight.SkipReason))
+		return true, nil
+	}
+
 	logger.Warning("%s", preflight.Summary())
 	if out := strings.TrimSpace(preflight.Output); out != "" {
 		logger.Debug("Network preflight output:\n%s", out)

--- a/internal/orchestrator/pve_mapping_create_failure_audited_test.go
+++ b/internal/orchestrator/pve_mapping_create_failure_audited_test.go
@@ -1,0 +1,116 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Regression for create-failure-undifferentiated (2026-06-09 audit):
+// applyPVEClusterResourceMapping proceeded to the merge/set path after ANY create
+// failure, discarding the create error and assuming "already exists". If create
+// failed for another reason and the subsequent get also failed/returned empty, it
+// still ran `set` with only the backup entries - overwriting a live mapping or
+// masking the real cause. The set now runs only when the existing mapping is
+// actually read; otherwise the original create error is surfaced.
+
+type scriptedPveshRunner struct {
+	createErr error
+	getOut    []byte
+	getErr    error
+	setErr    error
+	calls     []string
+}
+
+func (r *scriptedPveshRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, name+" "+strings.Join(args, " "))
+	if name != "pvesh" || len(args) == 0 {
+		return nil, nil
+	}
+	switch args[0] {
+	case "create":
+		return []byte("create stderr"), r.createErr
+	case "get":
+		return r.getOut, r.getErr
+	case "set":
+		return nil, r.setErr
+	}
+	return nil, nil
+}
+
+func (r *scriptedPveshRunner) sawSet() bool {
+	for _, c := range r.calls {
+		if strings.HasPrefix(c, "pvesh set ") {
+			return true
+		}
+	}
+	return false
+}
+
+func withScriptedPvesh(t *testing.T, r *scriptedPveshRunner) {
+	t.Helper()
+	orig := restoreCmd
+	restoreCmd = r
+	t.Cleanup(func() { restoreCmd = orig })
+}
+
+func pciSpec() pveClusterMappingSpec {
+	return pveClusterMappingSpec{ID: "device1", MapEntries: []string{"node=pve01,path=0000:01:00.0"}}
+}
+
+func TestApplyPVEClusterResourceMapping_CreateOkReturnsWithoutSet(t *testing.T) {
+	r := &scriptedPveshRunner{createErr: nil}
+	withScriptedPvesh(t, r)
+
+	if err := applyPVEClusterResourceMapping(context.Background(), newTestLogger(), "pci", pciSpec()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.sawSet() {
+		t.Errorf("a successful create must not fall through to set; calls=%v", r.calls)
+	}
+}
+
+func TestApplyPVEClusterResourceMapping_CreateFailsAndGetUnreadable_SurfacesErrorNoSet(t *testing.T) {
+	r := &scriptedPveshRunner{
+		createErr: errors.New("exit status 2"), // e.g. permission denied / bad value
+		getErr:    errors.New("exit status 2"), // existing mapping cannot be read
+	}
+	withScriptedPvesh(t, r)
+
+	err := applyPVEClusterResourceMapping(context.Background(), newTestLogger(), "pci", pciSpec())
+	if err == nil {
+		t.Fatalf("expected an error when create failed and the existing mapping is unreadable")
+	}
+	if r.sawSet() {
+		t.Errorf("must NOT run set when the existing mapping could not be read (blind overwrite); calls=%v", r.calls)
+	}
+}
+
+func TestApplyPVEClusterResourceMapping_CreateFailsButMappingExists_MergesViaSet(t *testing.T) {
+	r := &scriptedPveshRunner{
+		createErr: errors.New("exit status 2"),
+		// live mapping has a DIFFERENT node entry that must be preserved (unioned).
+		getOut: []byte(`[{"id":"device1","map":["node=pve02,path=0000:09:00.0"]}]`),
+	}
+	withScriptedPvesh(t, r)
+
+	if err := applyPVEClusterResourceMapping(context.Background(), newTestLogger(), "pci", pciSpec()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.sawSet() {
+		t.Fatalf("expected a set call to merge entries; calls=%v", r.calls)
+	}
+	var setCall string
+	for _, c := range r.calls {
+		if strings.HasPrefix(c, "pvesh set ") {
+			setCall = c
+		}
+	}
+	// The set must union the live and backup entries (not overwrite with backup only).
+	for _, want := range []string{"node=pve01,path=0000:01:00.0", "node=pve02,path=0000:09:00.0"} {
+		if !strings.Contains(setCall, want) {
+			t.Errorf("set call missing %q (entries must be unioned); set=%q", want, setCall)
+		}
+	}
+}

--- a/internal/orchestrator/pve_safe_apply_mappings.go
+++ b/internal/orchestrator/pve_safe_apply_mappings.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,9 +15,66 @@ import (
 )
 
 type pveClusterMappingJSON struct {
-	ID      string                   `json:"id"`
-	Comment string                   `json:"comment,omitempty"`
-	Map     []map[string]interface{} `json:"map,omitempty"`
+	ID      string            `json:"id"`
+	Comment string            `json:"comment,omitempty"`
+	Map     []pveMappingEntry `json:"map,omitempty"`
+}
+
+// pveMappingEntry is one per-node mapping inside a cluster resource mapping.
+// `pvesh get /cluster/mapping/<type> --output-format=json` emits each entry as a
+// PVE property string ("node=pve01,path=0000:01:00.0,id=8086:1234"), which is the
+// real on-disk backup format. We also accept an object ({"node":"pve01",...}) for
+// robustness, since earlier code and fixtures assumed that (never-emitted) shape.
+type pveMappingEntry struct {
+	props map[string]string
+}
+
+func (e *pveMappingEntry) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		e.props = nil
+		return nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		e.props = parsePVEPropertyString(s)
+		return nil
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	props := make(map[string]string, len(obj))
+	for k, v := range obj {
+		k = strings.TrimSpace(k)
+		if k == "" || v == nil {
+			continue
+		}
+		props[k] = strings.TrimSpace(fmt.Sprint(v))
+	}
+	e.props = props
+	return nil
+}
+
+// parsePVEPropertyString splits a PVE property string "k=v,k=v" into its fields.
+func parsePVEPropertyString(s string) map[string]string {
+	out := make(map[string]string)
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		k = strings.TrimSpace(k)
+		if !ok || k == "" {
+			continue
+		}
+		out[k] = strings.TrimSpace(v)
+	}
+	return out
 }
 
 type pveClusterMappingSpec struct {
@@ -134,18 +192,7 @@ func readPVEClusterResourceMappingsFromExport(exportRoot, mappingType string) ([
 		}
 
 		for _, m := range item.Map {
-			entry := make(map[string]string, len(m))
-			for k, v := range m {
-				k = strings.TrimSpace(k)
-				if k == "" || v == nil {
-					continue
-				}
-				entry[k] = strings.TrimSpace(fmt.Sprint(v))
-			}
-			if len(entry) == 0 {
-				continue
-			}
-			if rendered := renderMappingEntry(entry); rendered != "" {
+			if rendered := renderMappingEntry(m.props); rendered != "" {
 				spec.MapEntries = append(spec.MapEntries, rendered)
 			}
 		}
@@ -247,15 +294,7 @@ func parsePVEClusterMappingObject(data []byte) (pveClusterMappingSpec, bool, err
 		Comment: strings.TrimSpace(obj.Comment),
 	}
 	for _, m := range obj.Map {
-		entry := make(map[string]string, len(m))
-		for k, v := range m {
-			k = strings.TrimSpace(k)
-			if k == "" || v == nil {
-				continue
-			}
-			entry[k] = strings.TrimSpace(fmt.Sprint(v))
-		}
-		if rendered := renderMappingEntry(entry); rendered != "" {
+		if rendered := renderMappingEntry(m.props); rendered != "" {
 			spec.MapEntries = append(spec.MapEntries, rendered)
 		}
 	}

--- a/internal/orchestrator/pve_safe_apply_mappings.go
+++ b/internal/orchestrator/pve_safe_apply_mappings.go
@@ -240,22 +240,35 @@ func applyPVEClusterResourceMapping(ctx context.Context, logger *logging.Logger,
 		createArgs = append(createArgs, "--map", entry)
 	}
 
-	if err := runPvesh(ctx, logger, createArgs); err == nil {
+	createErr := runPvesh(ctx, logger, createArgs)
+	if createErr == nil {
 		return nil
 	}
 
-	// Create may fail if mapping already exists. Try to merge by unioning current+backup entries and updating via set.
-	mergedEntries := append([]string(nil), spec.MapEntries...)
-	comment := strings.TrimSpace(spec.Comment)
-
+	// Create failed. It commonly means the mapping already exists, in which case we
+	// merge the live entries with the backup ones and update via set. Only do that if
+	// we can actually READ the existing mapping: if the get fails or returns nothing
+	// parseable, the create may have failed for another reason (invalid value,
+	// permission denied, transient cluster lock) and a blind set could overwrite a
+	// live mapping with only the backup entries or mask the real cause - so surface
+	// the original create error instead.
 	getArgs := []string{"get", fmt.Sprintf("/cluster/mapping/%s/%s", mappingType, id), "--output-format=json"}
-	if out, getErr := runPveshSensitive(ctx, logger, getArgs); getErr == nil && len(out) > 0 {
-		if existing, ok, parseErr := parsePVEClusterMappingObject(out); parseErr == nil && ok {
-			mergedEntries = uniqueSortedStrings(append(existing.MapEntries, mergedEntries...))
-			if comment == "" {
-				comment = strings.TrimSpace(existing.Comment)
-			}
+	out, getErr := runPveshSensitive(ctx, logger, getArgs)
+	var existing pveClusterMappingSpec
+	ok := false
+	if getErr == nil && len(out) > 0 {
+		if parsed, parsedOK, parseErr := parsePVEClusterMappingObject(out); parseErr == nil && parsedOK {
+			existing, ok = parsed, true
 		}
+	}
+	if !ok {
+		return fmt.Errorf("create %s mapping %q failed and the existing mapping could not be read (get error: %v): %w", mappingType, id, getErr, createErr)
+	}
+
+	mergedEntries := uniqueSortedStrings(append(existing.MapEntries, spec.MapEntries...))
+	comment := strings.TrimSpace(spec.Comment)
+	if comment == "" {
+		comment = strings.TrimSpace(existing.Comment)
 	}
 
 	setArgs := []string{"set", fmt.Sprintf("/cluster/mapping/%s/%s", mappingType, id)}

--- a/internal/orchestrator/pve_safe_apply_mappings_audited_test.go
+++ b/internal/orchestrator/pve_safe_apply_mappings_audited_test.go
@@ -1,0 +1,101 @@
+package orchestrator
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression for backup-file-parse-fails-feature-broken (2026-06-09 audit):
+// mapping_<type>.json is the raw output of `pvesh get /cluster/mapping/<type>
+// --output-format=json`, whose `map` field is an ARRAY OF PROPERTY STRINGS
+// ("node=pve01,path=...,id=..."), not an array of objects. The old struct
+// (Map []map[string]interface{}) failed to unmarshal real output, so the whole
+// resource-mapping restore silently never ran on any real backup. Written after
+// the fix to accept the real string-array shape, hence the _audited suffix.
+
+// Direct parser test with the real on-disk format, plus a non-canonical key order
+// to also exercise renderMappingEntry's normalization (node, path, id first).
+func TestReadPVEClusterResourceMappings_RealStringArrayFormat(t *testing.T) {
+	origFS := restoreFS
+	restoreFS = osFS{}
+	t.Cleanup(func() { restoreFS = origFS })
+
+	exportRoot := t.TempDir()
+	mappingPath := filepath.Join(exportRoot, "var", "lib", "proxsave-info", "commands", "pve", "mapping_pci.json")
+	if err := os.MkdirAll(filepath.Dir(mappingPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Real pvesh output: map is an array of property strings (one per node).
+	if err := os.WriteFile(mappingPath, []byte(strings.TrimSpace(`[
+  {"id":"gpu","map":["path=0000:01:00.0,id=8086:1234,node=pve01","node=pve02,path=0000:02:00.0,id=8086:1234"]}
+]`)), 0o640); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	specs, err := readPVEClusterResourceMappingsFromExport(exportRoot, "pci")
+	if err != nil {
+		t.Fatalf("readPVEClusterResourceMappingsFromExport returned error on real pvesh format: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1: %+v", len(specs), specs)
+	}
+	if specs[0].ID != "gpu" {
+		t.Errorf("ID = %q, want gpu", specs[0].ID)
+	}
+	want := []string{
+		"node=pve01,path=0000:01:00.0,id=8086:1234", // keys normalized to node,path,id
+		"node=pve02,path=0000:02:00.0,id=8086:1234",
+	}
+	if strings.Join(specs[0].MapEntries, "|") != strings.Join(want, "|") {
+		t.Errorf("MapEntries = %#v, want %#v", specs[0].MapEntries, want)
+	}
+}
+
+// End-to-end: a real-format backup must actually produce the pvesh create call
+// (before the fix it silently produced none).
+func TestRunSafeClusterApply_AppliesRealStringArrayMappings(t *testing.T) {
+	origCmd := restoreCmd
+	origFS := restoreFS
+	t.Cleanup(func() {
+		restoreCmd = origCmd
+		restoreFS = origFS
+	})
+	restoreFS = osFS{}
+
+	pathDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pathDir, "pvesh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write pvesh stub: %v", err)
+	}
+	t.Setenv("PATH", pathDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	runner := &recordingRunner{}
+	restoreCmd = runner
+
+	exportRoot := t.TempDir()
+	mappingPath := filepath.Join(exportRoot, "var", "lib", "proxsave-info", "commands", "pve", "mapping_pci.json")
+	if err := os.MkdirAll(filepath.Dir(mappingPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(mappingPath, []byte(strings.TrimSpace(`[
+  {"id":"device1","map":["node=pve01,path=0000:01:00.0"]}
+]`)), 0o640); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	reader := bufio.NewReader(strings.NewReader("yes\n"))
+	if err := runSafeClusterApply(context.Background(), reader, exportRoot, newTestLogger()); err != nil {
+		t.Fatalf("runSafeClusterApply error: %v", err)
+	}
+
+	wantPrefix := "pvesh create /cluster/mapping/pci --id device1 --map node=pve01,path=0000:01:00.0"
+	for _, call := range runner.calls {
+		if strings.HasPrefix(call, wantPrefix) {
+			return
+		}
+	}
+	t.Fatalf("expected a pvesh create call with prefix %q; calls=%#v", wantPrefix, runner.calls)
+}

--- a/internal/orchestrator/restore_filesystem.go
+++ b/internal/orchestrator/restore_filesystem.go
@@ -354,59 +354,58 @@ func parseBlkidInventory(content string) map[string]fstabDeviceIdentity {
 func parseLsblkTextInventory(content string) map[string]fstabDeviceIdentity {
 	out := make(map[string]fstabDeviceIdentity)
 	lines := strings.Split(content, "\n")
+
 	headerIdx := -1
-	var headerFields []string
+	headerLine := ""
 	for i, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		headerFields = strings.Fields(line)
-		if len(headerFields) >= 2 && strings.EqualFold(headerFields[0], "NAME") {
+		stripped := strings.TrimRight(line, "\r")
+		fields := strings.Fields(stripped)
+		if len(fields) >= 2 && strings.EqualFold(fields[0], "NAME") {
 			headerIdx = i
+			headerLine = stripped
 			break
 		}
 	}
-	if headerIdx == -1 || len(headerFields) == 0 {
+	if headerIdx == -1 {
 		return out
 	}
 
-	uuidCol := -1
-	labelCol := -1
-	for i, field := range headerFields {
-		switch strings.ToUpper(strings.TrimSpace(field)) {
-		case "UUID":
-			uuidCol = i
-		case "LABEL":
-			labelCol = i
-		}
-	}
-	if uuidCol == -1 && labelCol == -1 {
+	// lsblk -f prints a fixed-width, column-aligned table. Parse UUID/LABEL by
+	// their column rune-offsets taken from the header, NOT by whitespace tokens:
+	// strings.Fields collapses runs of whitespace and emits no token for an empty
+	// cell, so the Nth token is not the Nth column whenever an earlier cell is
+	// blank (which lsblk routinely leaves for FSTYPE/FSVER/LABEL/FSAVAIL, and
+	// FSVER values like "LVM2 001" even contain a space). Offsets are in rune
+	// space so multi-byte tree glyphs (├─, └─) in the NAME column stay aligned.
+	bounds := lsblkColumnBounds(headerLine)
+	uuidBounds, hasUUID := bounds["UUID"]
+	labelBounds, hasLabel := bounds["LABEL"]
+	if !hasUUID && !hasLabel {
 		return out
 	}
 
 	for _, raw := range lines[headerIdx+1:] {
-		raw = strings.TrimSpace(raw)
-		if raw == "" {
-			continue
-		}
-		fields := strings.Fields(raw)
-		if len(fields) == 0 {
+		row := strings.TrimRight(raw, "\r")
+		tokens := strings.Fields(row)
+		if len(tokens) == 0 {
 			continue
 		}
 
-		name := sanitizeLsblkName(fields[0])
+		// NAME is column 0 and never contains internal spaces, so the first
+		// whitespace token is safe to use directly.
+		name := sanitizeLsblkName(tokens[0])
 		if name == "" {
 			continue
 		}
 		path := filepath.Join("/dev", name)
 
+		rowRunes := []rune(row)
 		id := fstabDeviceIdentity{}
-		if uuidCol >= 0 && uuidCol < len(fields) {
-			id.UUID = strings.TrimSpace(fields[uuidCol])
+		if hasUUID {
+			id.UUID = strings.TrimSpace(sliceRunes(rowRunes, uuidBounds[0], uuidBounds[1]))
 		}
-		if labelCol >= 0 && labelCol < len(fields) {
-			id.Label = strings.TrimSpace(fields[labelCol])
+		if hasLabel {
+			id.Label = strings.TrimSpace(sliceRunes(rowRunes, labelBounds[0], labelBounds[1]))
 		}
 		if id.UUID == "" && id.Label == "" {
 			continue
@@ -415,6 +414,58 @@ func parseLsblkTextInventory(content string) map[string]fstabDeviceIdentity {
 	}
 
 	return out
+}
+
+// lsblkColumnBounds derives, from a fixed-width lsblk header line, the [start,end)
+// rune offsets of each column keyed by upper-cased column name. end == -1 marks
+// the final column, which runs to the end of each row.
+func lsblkColumnBounds(header string) map[string][2]int {
+	runes := []rune(header)
+	type col struct {
+		name  string
+		start int
+	}
+	var cols []col
+	i := 0
+	for i < len(runes) {
+		for i < len(runes) && runes[i] == ' ' {
+			i++
+		}
+		if i >= len(runes) {
+			break
+		}
+		start := i
+		for i < len(runes) && runes[i] != ' ' {
+			i++
+		}
+		cols = append(cols, col{name: strings.ToUpper(string(runes[start:i])), start: start})
+	}
+
+	bounds := make(map[string][2]int, len(cols))
+	for j, c := range cols {
+		end := -1
+		if j+1 < len(cols) {
+			end = cols[j+1].start
+		}
+		bounds[c.name] = [2]int{c.start, end}
+	}
+	return bounds
+}
+
+// sliceRunes returns runes[start:end] clamped to the slice bounds. end == -1 (or
+// any value past the end) means "to the end of the slice". An out-of-range start
+// yields "".
+func sliceRunes(runes []rune, start, end int) string {
+	if start < 0 || start >= len(runes) {
+		return ""
+	}
+	if end < 0 || end > len(runes) {
+		end = len(runes)
+	}
+	if end < start {
+		return ""
+	}
+	return string(runes[start:end])
 }
 
 func sanitizeLsblkName(field string) string {

--- a/internal/orchestrator/restore_filesystem_lsblk_audited_test.go
+++ b/internal/orchestrator/restore_filesystem_lsblk_audited_test.go
@@ -1,0 +1,120 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// Regression for the 2026-06-09 audit finding lsblk-text-column-index-vs-fields:
+// parseLsblkTextInventory used strings.Fields + absolute token index, so an empty
+// earlier cell (or a space inside FSVER) shifted UUID/LABEL onto the wrong values,
+// corrupting the /dev->identity map used to rewrite fstab. Written after the fix
+// to fixed-width column-offset parsing, hence the _audited suffix.
+
+// formatLsblkTable renders a fixed-width, column-aligned table the way `lsblk -f`
+// does: each column padded (in display/rune cells) to the widest of its header
+// label and values, columns separated by a single space, trailing space trimmed.
+func formatLsblkTable(header []string, rows [][]string) string {
+	width := make([]int, len(header))
+	for i, h := range header {
+		width[i] = utf8.RuneCountInString(h)
+	}
+	for _, r := range rows {
+		for i := 0; i < len(header) && i < len(r); i++ {
+			if w := utf8.RuneCountInString(r[i]); w > width[i] {
+				width[i] = w
+			}
+		}
+	}
+	pad := func(s string, w int) string {
+		if n := w - utf8.RuneCountInString(s); n > 0 {
+			return s + strings.Repeat(" ", n)
+		}
+		return s
+	}
+	render := func(cells []string) string {
+		parts := make([]string, len(header))
+		for i := range header {
+			v := ""
+			if i < len(cells) {
+				v = cells[i]
+			}
+			parts[i] = pad(v, width[i])
+		}
+		return strings.TrimRight(strings.Join(parts, " "), " ")
+	}
+	var b strings.Builder
+	b.WriteString(render(header))
+	b.WriteByte('\n')
+	for _, r := range rows {
+		b.WriteString(render(r))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func TestParseLsblkTextInventory_EmptyCellsAndSpacesDoNotShiftColumns(t *testing.T) {
+	header := []string{"NAME", "FSTYPE", "FSVER", "LABEL", "UUID", "FSAVAIL", "FSUSE%", "MOUNTPOINTS"}
+	rows := [][]string{
+		// Whole disk: no filesystem at all -> dropped (no uuid/label).
+		{"sda", "", "", "", "", "", "", ""},
+		// EFI vfat: empty LABEL, UUID present. The classic mis-parse: token index
+		// would put the UUID into LABEL and FSAVAIL into UUID.
+		{"├─sda2", "vfat", "FAT32", "", "E843-7857", "500M", "5%", "/boot/efi"},
+		// LVM member: empty LABEL AND an FSVER value that contains a space.
+		{"└─sda3", "LVM2_member", "LVM2 001", "", "rfsqkR-aaaa-bbbb-cccc", "", "", ""},
+		// Fully populated row: the only shape the old token parser got right.
+		{"pve-root", "ext4", "1.0", "root-fs", "11111111-2222-3333-4444-555555555555", "2.5G", "87%", "/"},
+	}
+
+	got := parseLsblkTextInventory(formatLsblkTable(header, rows))
+
+	want := map[string]struct{ uuid, label string }{
+		"/dev/sda2":     {uuid: "E843-7857", label: ""},
+		"/dev/sda3":     {uuid: "rfsqkR-aaaa-bbbb-cccc", label: ""},
+		"/dev/pve-root": {uuid: "11111111-2222-3333-4444-555555555555", label: "root-fs"},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("entry count = %d, want %d; got=%+v", len(got), len(want), got)
+	}
+	for dev, w := range want {
+		id, ok := got[dev]
+		if !ok {
+			t.Errorf("%s missing from inventory", dev)
+			continue
+		}
+		if id.UUID != w.uuid {
+			t.Errorf("%s UUID = %q, want %q", dev, id.UUID, w.uuid)
+		}
+		if id.Label != w.label {
+			t.Errorf("%s Label = %q, want %q", dev, id.Label, w.label)
+		}
+	}
+
+	// The whole-disk row must not appear (it has neither UUID nor LABEL).
+	if _, ok := got["/dev/sda"]; ok {
+		t.Errorf("/dev/sda should be skipped (no uuid/label)")
+	}
+}
+
+// TestParseLsblkTextInventory_AltHeaderOrderWithoutFSVER guards an older lsblk
+// layout (no FSVER column) - offsets must be derived from whatever header is
+// present, not hard-coded indices.
+func TestParseLsblkTextInventory_AltHeaderOrderWithoutFSVER(t *testing.T) {
+	header := []string{"NAME", "FSTYPE", "LABEL", "UUID", "MOUNTPOINT"}
+	rows := [][]string{
+		{"sdb1", "ext4", "", "abcd-1234-ef56", "/data"},
+		{"sdb2", "swap", "swaplbl", "9999-8888", "[SWAP]"},
+	}
+
+	got := parseLsblkTextInventory(formatLsblkTable(header, rows))
+
+	if id := got["/dev/sdb1"]; id.UUID != "abcd-1234-ef56" || id.Label != "" {
+		t.Errorf("/dev/sdb1 = %+v, want UUID=abcd-1234-ef56 Label=\"\"", id)
+	}
+	if id := got["/dev/sdb2"]; id.UUID != "9999-8888" || id.Label != "swaplbl" {
+		t.Errorf("/dev/sdb2 = %+v, want UUID=9999-8888 Label=swaplbl", id)
+	}
+}

--- a/internal/orchestrator/restore_staged_ctx_cancel_audited_test.go
+++ b/internal/orchestrator/restore_staged_ctx_cancel_audited_test.go
@@ -1,0 +1,52 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// Regression for ctx-cancel-swallowed-staged-loop (2026-06-09 audit): the staged
+// apply loop never re-checked w.ctx.Err() between steps. The PVE step degrades all
+// of its sub-errors (including a context.Canceled from applyStorageCfg) to a
+// warning+nil, so an operator's Ctrl+C mid-PVE-apply was lost and the loop kept
+// applying later sensitive steps (PVE SDN, access-control secrets, notifications).
+// Written after adding the between-steps cancellation re-check.
+
+func TestRunStagedApplySteps_AbortsBetweenStepsOnSwallowedCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &restoreUIWorkflowRun{ctx: ctx, logger: newTestLogger()}
+
+	laterRan := false
+	steps := []restoreStageApplyStep{
+		// Simulates the PVE step swallowing a context.Canceled into a warning+nil.
+		{name: "swallows cancel", run: func() error { cancel(); return nil }},
+		{name: "sensitive later step", run: func() error { laterRan = true; return nil }},
+	}
+
+	err := w.runStagedApplySteps(steps)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runStagedApplySteps = %v, want context.Canceled", err)
+	}
+	if laterRan {
+		t.Errorf("a sensitive step after a swallowed cancellation must NOT run")
+	}
+}
+
+func TestRunStagedApplySteps_RunsAllWhenNotCancelled(t *testing.T) {
+	w := &restoreUIWorkflowRun{ctx: context.Background(), logger: newTestLogger()}
+
+	var order []string
+	steps := []restoreStageApplyStep{
+		{name: "a", run: func() error { order = append(order, "a"); return nil }},
+		{name: "b", run: func() error { order = append(order, "b"); return nil }},
+		{name: "c", run: func() error { order = append(order, "c"); return nil }},
+	}
+
+	if err := w.runStagedApplySteps(steps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(order) != 3 || order[0] != "a" || order[1] != "b" || order[2] != "c" {
+		t.Fatalf("steps order = %v, want [a b c]", order)
+	}
+}

--- a/internal/orchestrator/restore_tui.go
+++ b/internal/orchestrator/restore_tui.go
@@ -794,6 +794,20 @@ func promptYesNoTUIWithCountdown(ctx context.Context, logger *logging.Logger, ti
 	return result, nil
 }
 
+// configureNetworkCommitButtons wires the COMMIT / "Let rollback run" buttons and
+// defaults keyboard focus to the SAFE choice ("Let rollback run", button index 1).
+// COMMIT keeps the just-applied (possibly broken) network config and disarms the
+// automatic rollback, so a reflexive Enter must not select it. Defaulting to the
+// safe button matches the CLI prompt (a blank line means "not committed = let
+// rollback run") and the SetDefaultButton(safe) convention of the sibling
+// destructive prompts.
+func configureNetworkCommitButtons(form *components.Form) {
+	form.AddSubmitButton("COMMIT")
+	form.AddCancelButton("Let rollback run")
+	enableFormNavigation(form, nil)
+	form.SetDefaultButton(defaultButtonIndex(false))
+}
+
 func promptNetworkCommitTUI(ctx context.Context, timeout time.Duration, health networkHealthReport, nicRepair *nicRepairResult, diagnosticsDir, configPath, buildSig string) (bool, error) {
 	app := newTUIApp()
 	var committed bool
@@ -899,9 +913,7 @@ func promptNetworkCommitTUI(ctx context.Context, timeout time.Duration, health n
 	form.SetOnCancel(func() {
 		cancelled = true
 	})
-	form.AddSubmitButton("COMMIT")
-	form.AddCancelButton("Let rollback run")
-	enableFormNavigation(form, nil)
+	configureNetworkCommitButtons(form)
 
 	content := tview.NewFlex().
 		SetDirection(tview.FlexRow).

--- a/internal/orchestrator/restore_tui_netcommit_audited_test.go
+++ b/internal/orchestrator/restore_tui_netcommit_audited_test.go
@@ -1,0 +1,41 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/tui"
+	"github.com/tis24dev/proxsave/internal/tui/components"
+)
+
+// Regression for netcommit-default-focuses-commit (2026-06-09 audit): the TUI
+// network-commit gate added COMMIT first (button 0) and never called
+// SetDefaultButton, so tview focused COMMIT by default. A reflexive Enter then
+// committed a possibly-broken network config and disarmed the automatic rollback
+// (remote lockout). The default must be the safe "Let rollback run" button, like
+// the CLI (blank line = rollback) and every sibling destructive prompt. Written
+// after the fix, hence the _audited suffix.
+func TestConfigureNetworkCommitButtons_DefaultsToLetRollbackRun(t *testing.T) {
+	form := components.NewForm(tui.NewApp())
+	configureNetworkCommitButtons(form)
+
+	if got := form.GetButtonCount(); got != 2 {
+		t.Fatalf("button count = %d, want 2", got)
+	}
+
+	// Button order is COMMIT(0), "Let rollback run"(1); pin the labels so the
+	// index-based default below cannot silently point at the wrong button.
+	if got := form.GetButton(0).GetLabel(); got != "COMMIT" {
+		t.Fatalf("button 0 label = %q, want COMMIT", got)
+	}
+	if got := form.GetButton(1).GetLabel(); got != "Let rollback run" {
+		t.Fatalf("button 1 label = %q, want 'Let rollback run'", got)
+	}
+
+	// The safe choice must hold the default keyboard focus.
+	if !form.GetButton(1).HasFocus() {
+		t.Errorf("default focus should be on 'Let rollback run' (index 1) so a reflexive Enter lets the rollback run")
+	}
+	if form.GetButton(0).HasFocus() {
+		t.Errorf("COMMIT (index 0) must NOT be the default focus (it disarms rollback)")
+	}
+}

--- a/internal/orchestrator/restore_workflow_ui_extract.go
+++ b/internal/orchestrator/restore_workflow_ui_extract.go
@@ -305,12 +305,28 @@ func (w *restoreUIWorkflowRun) applyStagedCategories() error {
 			return maybeApplyNotificationsFromStage(w.ctx, w.logger, w.plan, w.stageRoot, w.cfg.DryRun)
 		}},
 	}
+	return w.runStagedApplySteps(steps)
+}
+
+// runStagedApplySteps applies each staged-config step in order, re-checking for
+// cancellation BETWEEN steps. A step may degrade a context.Canceled into a
+// warning+nil (e.g. the PVE step swallows all sub-errors), which would otherwise
+// let the loop proceed to apply later sensitive steps (PVE SDN, access-control
+// secrets, notifications) on a system the operator already aborted. Since
+// restoreAbortOrInput recognises context.Canceled, returning w.ctx.Err() here
+// aborts the workflow instead of finishing "with warnings".
+func (w *restoreUIWorkflowRun) runStagedApplySteps(steps []restoreStageApplyStep) error {
 	for _, step := range steps {
+		if err := w.ctx.Err(); err != nil {
+			return err
+		}
 		if err := w.runStageApplyStep(step); err != nil {
 			return err
 		}
 	}
-	return nil
+	// Catch a cancellation that landed during the final step so the run is
+	// reported as aborted rather than completed.
+	return w.ctx.Err()
 }
 
 type restoreStageApplyStep struct {

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -1301,6 +1301,18 @@ func (c *CloudStorage) Delete(ctx context.Context, backupFile string) error {
 	return err
 }
 
+// errCloudSidecarDeleteOnly marks a delete where the backup archive itself was
+// removed but one or more associated sidecar files (.sha256/.metadata) could not
+// be. Retention counting treats it as a successful deletion (the backup IS gone)
+// rather than over-reporting the backup as still present.
+var errCloudSidecarDeleteOnly = errors.New("backup archive deleted; associated file(s) could not be removed")
+
+// isCloudBackupSidecar reports whether a candidate path is an associated sidecar
+// (checksum/metadata) rather than the backup data archive itself.
+func isCloudBackupSidecar(rel string) bool {
+	return strings.HasSuffix(rel, ".sha256") || strings.HasSuffix(rel, ".metadata")
+}
+
 func (c *CloudStorage) deleteBackupInternal(ctx context.Context, backupFile string) (logDeleted bool, err error) {
 	done := logging.DebugStart(c.logger, "cloud delete", "file=%s", backupFile)
 	defer func() { done(err) }()
@@ -1330,6 +1342,7 @@ func (c *CloudStorage) deleteBackupInternal(ctx context.Context, backupFile stri
 	}
 
 	failedFiles := make([]string, 0)
+	dataFailed := false // true if the backup data archive (not just a sidecar) failed to delete
 
 	// Delete all files
 	for _, rel := range relativeNames {
@@ -1357,6 +1370,9 @@ func (c *CloudStorage) deleteBackupInternal(ctx context.Context, backupFile stri
 			c.logger.Warning("WARNING: Cloud storage - failed to delete %s: %v: %s",
 				filepath.Base(f), err, msg)
 			failedFiles = append(failedFiles, filepath.Base(f))
+			if !isCloudBackupSidecar(rel) {
+				dataFailed = true
+			}
 			// Continue with other files
 			continue
 		}
@@ -1367,6 +1383,11 @@ func (c *CloudStorage) deleteBackupInternal(ctx context.Context, backupFile stri
 	logDeleted = c.deleteAssociatedLog(ctx, backupFile)
 
 	if len(failedFiles) > 0 {
+		if !dataFailed {
+			// Only sidecars failed; the backup archive itself is gone. Surface a
+			// sentinel error so retention counting still treats this as deleted.
+			return logDeleted, fmt.Errorf("%w: %v", errCloudSidecarDeleteOnly, failedFiles)
+		}
 		return logDeleted, fmt.Errorf("failed to delete %d file(s): %v", len(failedFiles), failedFiles)
 	}
 
@@ -1632,8 +1653,14 @@ func (c *CloudStorage) deleteBatched(ctx context.Context, backups []*types.Backu
 
 		logDeleted, err := c.deleteBackupInternal(ctx, backup.BackupFile)
 		if err != nil {
-			c.logger.Warning("WARNING: Cloud storage - failed to delete %s: %v", backup.BackupFile, err)
-			continue
+			if !errors.Is(err, errCloudSidecarDeleteOnly) {
+				// The backup archive itself is still present; do not count it.
+				c.logger.Warning("WARNING: Cloud storage - failed to delete %s: %v", backup.BackupFile, err)
+				continue
+			}
+			// The archive is gone, only sidecars remained: count it as deleted but
+			// warn about the leftover associated files.
+			c.logger.Warning("WARNING: Cloud storage - %s archive removed but sidecar cleanup failed: %v", backup.BackupFile, err)
 		}
 
 		deleted++

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -789,7 +789,16 @@ func (c *CloudStorage) countBackups(ctx context.Context) int {
 func (c *CloudStorage) uploadWithRetry(ctx context.Context, localFile, remoteFile string) error {
 	var lastErr error
 
-	for attempt := 1; attempt <= c.config.RcloneRetries; attempt++ {
+	// Guarantee at least one upload attempt. RCLONE_RETRIES is read with a default
+	// of 3 but never clamped, so a misconfigured RCLONE_RETRIES<=0 would otherwise
+	// skip the loop entirely, never call rclone, and return a bogus
+	// "upload failed after 0 attempts: <nil>" while silently uploading nothing.
+	retries := c.config.RcloneRetries
+	if retries < 1 {
+		retries = 1
+	}
+
+	for attempt := 1; attempt <= retries; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -797,7 +806,7 @@ func (c *CloudStorage) uploadWithRetry(ctx context.Context, localFile, remoteFil
 		if attempt > 1 {
 			c.logger.Info("Upload retry attempt %d/%d for %s",
 				attempt,
-				c.config.RcloneRetries,
+				retries,
 				filepath.Base(localFile))
 		}
 
@@ -812,12 +821,12 @@ func (c *CloudStorage) uploadWithRetry(ctx context.Context, localFile, remoteFil
 		if ctx.Err() == context.DeadlineExceeded {
 			c.logger.Warning("Upload attempt %d/%d failed: operation timeout (%ds exceeded)",
 				attempt,
-				c.config.RcloneRetries,
+				retries,
 				c.config.RcloneTimeoutOperation)
 		} else {
 			c.logger.Warning("Upload attempt %d/%d failed: %v",
 				attempt,
-				c.config.RcloneRetries,
+				retries,
 				err)
 		}
 
@@ -827,7 +836,7 @@ func (c *CloudStorage) uploadWithRetry(ctx context.Context, localFile, remoteFil
 		}
 
 		// Keep retry delays bounded and avoid shift/multiplication overflow.
-		if attempt < c.config.RcloneRetries {
+		if attempt < retries {
 			waitTime := cloudRetryBackoff(attempt)
 			c.logger.Debug("Waiting %v before retry...", waitTime)
 			if err := c.callWaitForRetry(ctx, waitTime); err != nil {
@@ -839,11 +848,11 @@ func (c *CloudStorage) uploadWithRetry(ctx context.Context, localFile, remoteFil
 	if ctx.Err() == context.DeadlineExceeded {
 		return fmt.Errorf("upload failed: operation timeout (%ds exceeded) after %d attempts",
 			c.config.RcloneTimeoutOperation,
-			c.config.RcloneRetries)
+			retries)
 	}
 
 	return fmt.Errorf("upload failed after %d attempts: %w",
-		c.config.RcloneRetries,
+		retries,
 		lastErr)
 }
 

--- a/internal/storage/cloud_delete_sidecar_audited_test.go
+++ b/internal/storage/cloud_delete_sidecar_audited_test.go
@@ -1,0 +1,67 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+)
+
+// Regression for delete-partialfail-not-counted (2026-06-09 audit): deleteBackupInternal
+// returned an error whenever ANY file failed - including a sidecar (.sha256/.metadata) -
+// even after the backup archive itself was removed. deleteBatched then treated that as
+// "not deleted" and skipped incrementing the counter, so the retention summary
+// over-reported "remaining" backups while the archive was actually gone. The delete now
+// distinguishes a sidecar-only failure (errCloudSidecarDeleteOnly) and counts it.
+func TestCloudStorageApplyRetention_CountsBackupWhenOnlySidecarDeleteFails(t *testing.T) {
+	cfg := &config.Config{
+		CloudEnabled:          true,
+		CloudRemote:           "remote",
+		CloudBatchSize:        1,
+		CloudBatchPause:       0,
+		BundleAssociatedFiles: false,
+	}
+	cs := newCloudStorageForTest(cfg)
+	cs.sleep = func(time.Duration) {}
+
+	listOutput := strings.TrimSpace(`
+100 2024-11-12 10:00:00 gamma-backup-3.tar.zst
+100 2024-11-11 10:00:00 beta-backup-2.tar.zst
+100 2024-11-10 10:00:00 alpha-backup-1.tar.zst
+`)
+	recountOutput := strings.TrimSpace(`
+100 2024-11-12 10:00:00 gamma-backup-3.tar.zst
+100 2024-11-11 10:00:00 beta-backup-2.tar.zst
+`)
+
+	queue := &commandQueue{
+		t: t,
+		queue: []queuedResponse{
+			{name: "rclone", args: []string{"lsl", "remote:"}, out: listOutput},
+			// The data archive deletes fine...
+			{name: "rclone", args: []string{"deletefile", "remote:alpha-backup-1.tar.zst"}},
+			// ...but a sidecar deletion fails with a real (non-"not found") error.
+			{name: "rclone", args: []string{"deletefile", "remote:alpha-backup-1.tar.zst.sha256"}, out: "permission denied", err: errors.New("exit status 1")},
+			{name: "rclone", args: []string{"deletefile", "remote:alpha-backup-1.tar.zst.metadata"}},
+			{name: "rclone", args: []string{"deletefile", "remote:alpha-backup-1.tar.zst.metadata.sha256"}},
+			{name: "rclone", args: []string{"lsl", "remote:"}, out: recountOutput},
+		},
+	}
+	cs.execCommand = queue.exec
+
+	deleted, err := cs.ApplyRetention(context.Background(), RetentionConfig{Policy: "simple", MaxBackups: 2})
+	if err != nil {
+		t.Fatalf("ApplyRetention() error = %v", err)
+	}
+	// The archive is gone, so the backup must be counted as deleted despite the
+	// failed sidecar (previously this returned 0, over-reporting remaining backups).
+	if deleted != 1 {
+		t.Fatalf("ApplyRetention() deleted = %d, want 1 (sidecar-only failure must still count)", deleted)
+	}
+	if got := cs.lastRet.BackupsRemaining; got != 2 {
+		t.Fatalf("lastRet.BackupsRemaining = %d, want 2", got)
+	}
+}

--- a/internal/storage/cloud_upload_retries_audited_test.go
+++ b/internal/storage/cloud_upload_retries_audited_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+)
+
+// Regression for zero-retries-skips-upload (2026-06-09 audit): uploadWithRetry's
+// loop `for attempt := 1; attempt <= RcloneRetries` never ran when a user set
+// RCLONE_RETRIES<=0 (never clamped), so rclone was never called, lastErr stayed
+// nil, and the function returned a bogus "upload failed after 0 attempts: <nil>"
+// while silently uploading nothing. Written after the clamp-to-1 fix.
+func TestCloudStorageUploadWithRetry_ZeroRetriesStillUploadsOnce(t *testing.T) {
+	cfg := &config.Config{
+		CloudEnabled:           true,
+		CloudRemote:            "remote",
+		RcloneRetries:          0, // misconfigured: must NOT skip the upload entirely
+		RcloneTimeoutOperation: 5,
+	}
+	cs := newCloudStorageForTest(cfg)
+
+	queue := &commandQueue{
+		t:     t,
+		queue: []queuedResponse{{name: "rclone", out: "ok"}},
+	}
+	cs.execCommand = queue.exec
+	cs.waitForRetry = func(context.Context, time.Duration) error { return nil }
+
+	if err := cs.uploadWithRetry(context.Background(), "/tmp/local.tar", "remote:local.tar"); err != nil {
+		t.Fatalf("uploadWithRetry with RcloneRetries=0 should still attempt the upload, got: %v", err)
+	}
+	if len(queue.calls) != 1 {
+		t.Fatalf("expected exactly 1 upload attempt despite RcloneRetries=0, got %d", len(queue.calls))
+	}
+}
+
+func TestCloudStorageUploadWithRetry_NegativeRetriesStillUploadsOnce(t *testing.T) {
+	cfg := &config.Config{
+		CloudEnabled:           true,
+		CloudRemote:            "remote",
+		RcloneRetries:          -5,
+		RcloneTimeoutOperation: 5,
+	}
+	cs := newCloudStorageForTest(cfg)
+
+	queue := &commandQueue{
+		t:     t,
+		queue: []queuedResponse{{name: "rclone", out: "ok"}},
+	}
+	cs.execCommand = queue.exec
+	cs.waitForRetry = func(context.Context, time.Duration) error { return nil }
+
+	if err := cs.uploadWithRetry(context.Background(), "/tmp/local.tar", "remote:local.tar"); err != nil {
+		t.Fatalf("uploadWithRetry with negative RcloneRetries should still attempt the upload, got: %v", err)
+	}
+	if len(queue.calls) != 1 {
+		t.Fatalf("expected exactly 1 upload attempt with negative RcloneRetries, got %d", len(queue.calls))
+	}
+}


### PR DESCRIPTION
- **ci: bump the actions-updates group across 1 directory with 3 updates (#228)**
- **docs: add test strategy with *_audited_test.go audit convention**
- **fix(checks): make ReleaseLock ownership-aware to preserve backup mutual exclusion**
- **fix(backup): verify pigz/bzip2/lzma archive integrity instead of skipping it**
- **fix(restore): parse lsblk -f inventory by column offsets, not whitespace tokens**
- **fix(restore): report network apply not-committed on expired window and completed rollback**
- **fix(restore): exit nonzero from the network rollback script when extraction fails**
- **fix(restore): parse PVE cluster mappings in the real pvesh string-array format**
- **fix(restore): default the TUI network-commit gate to 'Let rollback run', not COMMIT**
- **fix(storage): always attempt at least one cloud upload (clamp RcloneRetries)**
- **fix(upgrade): make compareVersions agree with isNewerVersion on pre-releases**
- **fix(upgrade): make the download/install trace reflect the real error**
- **fix(cron): preserve every distinct schedule when migrating legacy cron entries**
- **fix(install): replace the proxsave entrypoint symlink atomically**
- **fix(restore): keep staged network config when preflight is skipped, not failed**
- **fix(restore): re-check cancellation between staged-apply steps**
- **fix(restore): roll back a partially-applied staged network config**
- **fix(restore): detect an in-progress nohup network rollback via a .running sentinel**
- **fix(upgrade): reject architectures with no published release (amd64-only)**
- **fix(upgrade): non-zero exit when the config upgrade fails after a good install**
- **fix(cron): route migrateLegacyCronEntries logs through nil-safe helpers**
- **fix(permissions): don't abort the ownership walk on one unreadable entry**
- **fix(storage): count a cloud backup as deleted when only its sidecars fail**
- **fix(restore): only merge-and-set a PVE mapping when the existing one is readable**
- **fix(backup): never demote the age finalize error behind a prior close error**
- **fix(restore): surface rollback-armed state when the network apply itself fails**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upgrade exit codes to properly report configuration failures
  * Enhanced pre-release version comparison logic
  * Strengthened network rollback safety with ownership verification
  * Extended archive verification support to bzip2 and lzma compression formats
  * Improved lock file ownership protection against accidental deletion
  * Enhanced cron schedule preservation during legacy migrations

* **Tests**
  * Expanded regression test coverage across critical workflows and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes 26 correctness bugs identified via a pre-test audit, touching core areas including lock ownership, archive verification, network restore, cron migration, upgrade, and cloud storage. Each fix is accompanied by a matching `*_audited_test.go` file that encodes the failure scenario.

- **Lock / upload / cron fixes**: `ReleaseLock` is now ownership-aware (guards against removing another process's lock), `uploadWithRetry` clamps zero retries to one, and `filterCronLines` preserves every distinct legacy schedule rather than collapsing them.
- **Network restore chain**: multiple interconnected fixes cover LZMA/bzip2 archive verification, atomic symlink installation, lsblk fixed-width column parsing, rollback-armed state reporting, staged-apply partial rollback, preflight-skip vs preflight-fail distinction, cancellation checks between staged steps, and a nohup running-sentinel race.
- **Upgrade**: `compareVersions` now agrees with `isNewerVersion` on pre-release ordering, `downloadAndInstallLatest` uses named returns so the trace span reflects the real error, `resolveReleaseTarget` rejects non-amd64 architectures up front, and `cfgUpgradeErr` is surfaced as a non-zero exit code.

<h3>Confidence Score: 4/5</h3>

This PR is safe to merge; all 26 stated fixes are implemented correctly and each is backed by an audited test that encodes the failure scenario.

No bugs were found across the reviewed changes. The breadth of the PR — 51 files, 2,500+ lines touching backup archiving, lock ownership, cloud retries, cron migration, atomic symlink installation, lsblk column parsing, PVE mapping JSON, network rollback scripting, staged-apply cancellation, and TUI commit defaults — means the surface area is large enough that a second human read of the network-rollback and restore-workflow orchestration code would add confidence before merge.

The network apply / rollback chain (network_apply.go, network_apply_workflow_ui_rollback.go, network_staged_install.go) is the most intricate part of the change and benefits from the most careful review; the remaining files are well-contained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/checks/checks.go | ReleaseLock is now ownership-aware: guards with lockAcquired flag and ownsLockFile PID check before removing; osRemove already had !os.IsNotExist guard so the missing-file path is a true no-op |
| internal/backup/archiver.go | Adds bzip2/lzma verification stubs (matching gzip pattern), fixes encryption-finalize error demotion with errors.Join, and routes pigz through the gzip verifier; all look correct |
| internal/storage/cloud.go | Clamps RcloneRetries to minimum 1 and introduces errCloudSidecarDeleteOnly sentinel so retention counting still decrements when only sidecars fail to delete; logic is clean |
| cmd/proxsave/upgrade.go | Named return on downloadAndInstallLatest fixes deferred trace, compareVersions handles pre-release tie-breaking, resolveReleaseTarget rejects non-amd64, cfgUpgradeErr propagated as non-zero exit |
| cmd/proxsave/runtime_helpers.go | Atomic symlink installation via rename(2), cron multi-schedule preservation, nil-safe bootstrap logging helpers — all changes are correct |
| internal/orchestrator/network_apply.go | Adds .running sentinel for nohup rollback detection, rollbackAlreadyExecuted for post-completion detection, TAR_OK nonzero exit after marker removal; TAR_OK is correctly initialised before use |
| internal/orchestrator/network_apply_workflow_ui_rollback.go | expired-window and apply-failure paths now route through handleNetworkNotCommitted; commitNetworkConfig checks both running and already-executed states |
| internal/orchestrator/network_staged_install.go | Partial staged-apply now triggers rollback; preflight-skip distinguished from preflight-fail via networkPreflightWarrantsRollback |
| internal/orchestrator/restore_filesystem.go | lsblk -f parsing rewritten from whitespace-token indexing to fixed-width rune-offset slicing; handles multi-byte tree glyphs correctly |
| internal/orchestrator/restore_workflow_ui_extract.go | runStagedApplySteps re-checks ctx.Err() between steps and after the last step, preventing cancelled workflows from finishing as completed |
| internal/orchestrator/pve_safe_apply_mappings.go | pveMappingEntry custom unmarshal handles real PVE property-string format; merge-and-set path gated on successful get |
| internal/orchestrator/restore_tui.go | configureNetworkCommitButtons defaults to index 1 (Let rollback run), preventing reflexive Enter from committing a potentially broken network config |
| cmd/proxsave/permissions.go | applyOwnershipWalkEntry extracted; walk errors are now skipped (logged, nil returned) instead of aborting the walk early |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Backup starts] --> B[CheckLockFile]
    B -->|lock created| C[lockAcquired=true, lockPath recorded]
    B -->|already locked| D[return error — no lock held]
    C --> E[Run backup]
    E --> F[ReleaseLock]
    F --> G{lockAcquired?}
    G -->|false| H[no-op: never held lock]
    G -->|true| I{ownsLockFile?}
    I -->|PID mismatch| J[Warning: not removing foreign lock]
    I -->|owned| K[osRemove — IsNotExist suppressed]
    K --> L[lockAcquired=false]

    subgraph Network Restore
        M[maybeInstallNetworkConfigFromStage] --> N[applyNetworkFilesFromStage]
        N -->|err| O[rollbackAfterFailedStagedNetworkApply]
        N -->|ok| P[runNetworkPreflightValidation]
        P -->|Ok| Q[staged config kept]
        P -->|Skipped| R[kept — no validator binary]
        P -->|Failed| S[rollbackNetworkFilesNow]
    end

    subgraph Commit Window
        T[armRollbackAndApply] --> U{apply ok?}
        U -->|fail| V[handleNetworkNotCommitted — rollback armed]
        U -->|ok| W[waitForCommit]
        W -->|expired| X[handleNetworkNotCommitted — window elapsed]
        W -->|COMMIT pressed| Y{rollbackAlreadyRunning OR rollbackAlreadyExecuted?}
        Y -->|yes| Z[too late — not committed]
        Y -->|no| AA[disarm — committed]
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(restore): surface rollback-armed sta..."](https://github.com/tis24dev/proxsave/commit/c9aebf83dbdc3b024756661bde7976df7295b163) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36474238)</sub>

<!-- /greptile_comment -->