### PR TITLE
fix(restore): clear chattr +i mount-guard fallback in --cleanup-guards

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -482,9 +482,9 @@ Next step: ./build/proxsave --dry-run
 
 ### Cleanup Mount Guards (Optional)
 
-During some restores (notably PBS datastores on mountpoints under `/mnt`), ProxSave may apply **mount guards** to prevent accidental writes to `/` when the underlying storage is offline/not mounted yet.
+During some restores (notably PBS datastores and PVE network storages on mountpoints under `/mnt`), ProxSave may apply **mount guards** to prevent accidental writes to `/` when the underlying storage is offline/not mounted yet. A guard is either a read-only bind mount over the mountpoint, or — if a bind mount cannot be created — an immutable flag (`chattr +i`) on the mountpoint directory.
 
-If you want to remove those guards manually (optional):
+`--cleanup-guards` reverses **both** guard types: it unmounts bind-mount guards **and** clears the recorded `chattr +i` immutable flags. For safety it only acts on mountpoints that are **not currently mounted** (a real mount on top shadows the guard; clearing it then would touch the wrong inode), and it keeps the guard directory until nothing is pending.
 
 ```bash
 # Preview (no changes)
@@ -493,6 +493,11 @@ If you want to remove those guards manually (optional):
 # Apply cleanup (requires root)
 ./build/proxsave --cleanup-guards
 ```
+
+Notes:
+- Bringing the storage back online is enough to *use* it again (a real mount stacks on top of the guard automatically); `--cleanup-guards` just removes the leftover guard. A bind-mount guard also clears on reboot; a `chattr +i` flag does **not** — it persists until cleared.
+- To clear a flag while the storage is mounted: unmount it, run `--cleanup-guards` again (or `chattr -i <mountpoint>`), then remount.
+- If you deleted `/var/lib/proxsave/guards` manually and a mountpoint is still read-only, ProxSave has no record left: check `lsattr -d <mountpoint>` and run `chattr -i <mountpoint>` while the storage is unmounted.
 
 ## Logging
 

--- a/docs/RESTORE_GUIDE.md
+++ b/docs/RESTORE_GUIDE.md
@@ -2013,14 +2013,20 @@ if cleanDestRoot == "/" && strings.HasPrefix(target, "/etc/pve") {
 **PBS Datastore Mount Guards**:
 - When restoring PBS datastore definitions, ProxSave can apply a temporary mount guard (read-only bind mount; fallback `chattr +i`) on mount roots that currently resolve to the root filesystem.
 - Purpose: prevent accidental writes to `/` if a datastore mountpoint is missing/offline at restore time (PBS will show the datastore as unavailable until storage is mounted).
-- Optional cleanup: `./build/proxsave --cleanup-guards` (use `--dry-run` to preview).
+- Optional cleanup: `./build/proxsave --cleanup-guards` (use `--dry-run` to preview). See **Clearing mount guards after the storage is back** below.
 
 **PVE Storage Mount Guards**:
 - When restoring PVE storage definitions (from `storage.cfg`), ProxSave applies the same “restore even if offline” strategy for mount-backed storage:
   - Network storages (`nfs`, `cifs`, `cephfs`, `glusterfs`) use mountpoints under `/mnt/pve/<storageid>`. ProxSave attempts `pvesm activate <storageid>`; if the mountpoint still resolves to the root filesystem, it applies a temporary mount guard (read-only bind mount; fallback `chattr +i`).
   - `dir` storages are guarded only when their `path` lives under a mountpoint restored via `/etc/fstab` (to avoid guarding local root filesystem paths).
 - Purpose: prevent PVE from writing into `/mnt/pve/...` (or other mount roots) when the backing storage is offline at restore time.
-- Optional cleanup: `./build/proxsave --cleanup-guards` (use `--dry-run` to preview).
+- Optional cleanup: `./build/proxsave --cleanup-guards` (use `--dry-run` to preview). See **Clearing mount guards after the storage is back** below.
+
+**Clearing mount guards after the storage is back**:
+- Bringing the storage online again is enough to *use* it: a real mount stacks on top of a bind-mount guard automatically. The guard is not deleted, only shadowed — a reboot or `--cleanup-guards` removes the bind-mount leftover; a `chattr +i` fallback, however, leaves the directory immutable across reboots until it is cleared.
+- `./build/proxsave --cleanup-guards` (preview with `--dry-run`) unmounts bind-mount guards **and** clears the recorded `chattr +i` immutable flags, but only on mountpoints that are **not currently mounted** (clearing a live mount would touch the wrong inode). The guard directory is kept until nothing is pending.
+- To clear a flag while the storage is mounted: unmount it, run `--cleanup-guards` again (or `chattr -i <mountpoint>`), then remount.
+- If you deleted `/var/lib/proxsave/guards` manually and a mountpoint is still read-only, ProxSave has no record left to clear: check `lsattr -d <mountpoint>` and run `chattr -i <mountpoint>` while the storage is unmounted.
 
 ### 7. Service Management Fail-Fast
 
@@ -2375,7 +2381,8 @@ zpool import <pool-name>
 #   so you do not lose datastore entries after a restore.
 # - If a datastore path looks like a mount-root location (e.g. under `/mnt`) but currently resolves to the root filesystem,
 #   ProxSave applies a temporary **mount guard** (read-only bind mount; fallback `chattr +i`) on the mount root to prevent writes to `/`
-#   until the storage becomes available. When the real storage is mounted later, it overlays the guard and the datastore becomes available.
+#   until the storage becomes available. A bind-mount guard is shadowed when the real storage mounts on top (and is cleared by a reboot or --cleanup-guards);
+#   a chattr +i fallback persists across reboots and is cleared only by --cleanup-guards (recorded under /var/lib/proxsave/guards/chattr-targets) or a manual chattr -i.
 # - If the datastore path is not empty and contains unexpected files/directories (not a PBS datastore), ProxSave will defer that datastore block
 #   and save it under `/tmp/proxsave/datastore.cfg.deferred.*` for manual review.
 # - ProxSave does not format disks or import ZFS pools: mount/import the underlying storage first, then restart PBS.

--- a/docs/RESTORE_TECHNICAL.md
+++ b/docs/RESTORE_TECHNICAL.md
@@ -1533,10 +1533,14 @@ For PBS datastores whose paths live under typical mount roots (for example `/mnt
 - When a mountpoint used by a datastore currently resolves to the root filesystem (mount missing), ProxSave applies a **temporary mount guard** on the mount root:
   - Preferred: read-only bind-mount guard
   - Fallback: `chattr +i` on the mountpoint directory
-- Guards prevent PBS from writing into `/` if the storage is missing at restore time. When the real storage is mounted later, it overlays the guard and the datastore becomes available again.
+- Guards prevent PBS from writing into `/` if the storage is missing at restore time.
+- **Bind-mount guard:** when the real storage is mounted later it stacks on top of the read-only guard and the datastore becomes available again; the guard is then shadowed underneath and is discarded by a reboot or by `--cleanup-guards`.
+- **`chattr +i` fallback** (used only when a bind mount cannot be created): the immutable flag is set on the mountpoint *directory inode*. Mounting the real storage on top later still works, **but the immutable flag remains on the shadowed directory and is NOT removed by a reboot.** ProxSave records each such mountpoint under `/var/lib/proxsave/guards/chattr-targets` so cleanup can reverse it.
 
 Optional maintenance:
-- `proxsave --cleanup-guards` removes guard bind mounts and the guard directory when they are still visible on mountpoints.
+- `./build/proxsave --cleanup-guards` (preview with `--dry-run`) unmounts guard bind mounts **and** clears the recorded `chattr +i` immutable flags — but only on mountpoints that are **not currently mounted** (clearing a live mount would touch the wrong inode). The guard directory and its index are kept until nothing is pending.
+- To clear an immutable flag on a mountpoint whose storage is already mounted: unmount it, run `--cleanup-guards` again (or `chattr -i <mountpoint>`), then remount.
+- If you deleted `/var/lib/proxsave/guards` manually and a mountpoint is still read-only, ProxSave no longer has a record to clear: check with `lsattr -d <mountpoint>` and clear it yourself with `chattr -i <mountpoint>` while the storage is unmounted.
 
 #### PVE Storage Mount Guards (Offline Storage)
 
@@ -1548,7 +1552,7 @@ For PVE storages that use mountpoints (notably `nfs`, `cifs`, `cephfs`, `gluster
   - Fallback: `chattr +i` on the mountpoint directory
 - For `dir` storages, guards are only applied when the storage `path` can be associated with a mountpoint present in `/etc/fstab` (to avoid guarding local root filesystem paths).
 
-This prevents accidental writes into the root filesystem when storage is offline at restore time. When the real mount comes back, it overlays the guard and normal operation resumes.
+This prevents accidental writes into the root filesystem when storage is offline at restore time. When the real mount comes back it stacks on top of a bind-mount guard and normal operation resumes; a `chattr +i` fallback, however, leaves the immutable flag on the shadowed directory (it survives reboot) until `--cleanup-guards` clears it (or a manual `chattr -i`). See the cleanup notes under PBS Datastore Mount Guards above.
 
 ### 5. Root Privilege Check
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -665,6 +665,33 @@ MIN_DISK_SPACE_PRIMARY_GB=5  # Lower threshold
 ---
 ### 7. Restore Issues
 
+#### Mountpoint is read-only / `Operation not permitted` after a restore (NFS/storage not restored)
+
+**Symptoms**:
+- After a restore, a storage mountpoint (e.g. `/mnt/pve/<id>` or a PBS datastore path) is read-only, or writes fail with `Operation not permitted`.
+- An NFS/CIFS/network share "wasn't restored" and the storage shows as unavailable.
+
+**Explanation**:
+- The storage *definition* is restored, but the share was offline/unreachable at restore time, so ProxSave applied a **mount guard** on the mountpoint to stop Proxmox from silently writing into the root filesystem (`/`). The guard is either a read-only bind mount, or — as a fallback — a `chattr +i` immutable flag on the mountpoint directory.
+- Bringing the share back online and mounting it is enough to *use* it again (a real mount stacks on top of the guard automatically). The guard is not deleted, only shadowed: a bind-mount guard clears on reboot or via cleanup; a `chattr +i` flag persists across reboots until cleared.
+
+**Resolution**:
+```bash
+# 1. Bring the share online and mount/activate the storage
+pvesm status
+mount -t nfs <server>:<export> /mnt/pve/<id>   # or: pvesm activate <id>
+
+# 2. Remove the leftover guards (run as root; preview first)
+./build/proxsave --cleanup-guards --dry-run
+./build/proxsave --cleanup-guards
+```
+- `--cleanup-guards` unmounts bind-mount guards and clears recorded `chattr +i` flags, but only on mountpoints that are **not currently mounted**. To clear a flag while the storage is mounted: unmount it, run `--cleanup-guards` again (or `chattr -i <mountpoint>`), then remount.
+- If you already deleted `/var/lib/proxsave/guards` by hand and a mountpoint is still read-only, ProxSave has no record left to clear. Check for the immutable flag and remove it manually while the storage is unmounted:
+```bash
+lsattr -d /mnt/pve/<id>        # an 'i' in the flags means immutable
+chattr -i /mnt/pve/<id>
+```
+
 #### Restore drops SSH / IP changes during network restore
 
 **Symptoms**:

--- a/internal/orchestrator/guards_cleanup.go
+++ b/internal/orchestrator/guards_cleanup.go
@@ -19,6 +19,21 @@ var (
 	cleanupReadFile   = os.ReadFile
 	cleanupRemoveAll  = os.RemoveAll
 	cleanupSysUnmount = syscall.Unmount
+
+	// cleanupChattrReadFile reads the immutable-guard index. Separate from
+	// cleanupReadFile (which reads /proc) so tests can supply index bytes
+	// without faking /proc.
+	cleanupChattrReadFile = os.ReadFile
+	// cleanupResolveTarget resolves an immutable-guard target through any symlinks
+	// before it is re-validated and cleared, so a parent-component symlink cannot
+	// make `chattr -i` escape the datastore-root allowlist. Injectable for tests.
+	cleanupResolveTarget = filepath.EvalSymlinks
+	// cleanupRunCmd runs the `chattr -i` that reverses an immutable fallback
+	// guard. Injectable like the other cleanup* seams; defaults to the restore
+	// command runner.
+	cleanupRunCmd = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return restoreCmd.Run(ctx, name, args...)
+	}
 )
 
 // CleanupMountGuards removes ProxSave mount guards created under mountGuardBaseDir.
@@ -27,8 +42,6 @@ var (
 // mount on the mountpoint (i.e. the guard is the top-most mount at that mountpoint).
 // If a real mount is stacked on top, the guard will be left in place.
 func CleanupMountGuards(ctx context.Context, logger *logging.Logger, dryRun bool) error {
-	_ = ctx // reserved for future timeouts/cancellation hooks
-
 	if logger == nil {
 		logger = logging.GetDefaultLogger()
 	}
@@ -39,11 +52,18 @@ func CleanupMountGuards(ctx context.Context, logger *logging.Logger, dryRun bool
 
 	if _, err := cleanupStat(mountGuardBaseDir); err != nil {
 		if os.IsNotExist(err) {
-			logger.Info("No guard directory found at %s", mountGuardBaseDir)
+			logger.Info("No guard directory found at %s — nothing to clean up. If you deleted it manually and a mountpoint is still read-only, check 'lsattr -d <mountpoint>' and clear it with 'chattr -i <mountpoint>' while the storage is unmounted.", mountGuardBaseDir)
 			return nil
 		}
 		return fmt.Errorf("stat guards dir: %w", err)
 	}
+
+	// Reverse the chattr +i fallback guards first, independently of the bind-mount
+	// state below. This runs on BOTH paths (the no-guard-mounts early return AND the
+	// bind-mount loop). pending counts targets left immutable (mounted/unresolvable/
+	// failed); while it is > 0 we keep the guard directory and its index so a later
+	// run can finish the job.
+	pending := clearImmutableGuards(ctx, logger, dryRun)
 
 	mountinfo, err := cleanupReadFile("/proc/self/mountinfo")
 	if err != nil {
@@ -52,6 +72,10 @@ func CleanupMountGuards(ctx context.Context, logger *logging.Logger, dryRun bool
 
 	visibleMountpoints, hiddenMountpoints, totalGuardMounts := guardMountpointsFromMountinfo(string(mountinfo))
 	if totalGuardMounts == 0 {
+		if pending > 0 {
+			logger.Info("Guard cleanup: %d immutable guard target(s) still pending (mounted or uncleared); keeping %s", pending, mountGuardBaseDir)
+			return nil
+		}
 		if dryRun {
 			logger.Info("DRY RUN: would remove %s", mountGuardBaseDir)
 			return nil
@@ -111,18 +135,23 @@ func CleanupMountGuards(ctx context.Context, logger *logging.Logger, dryRun bool
 	}
 
 	if dryRun {
-		logger.Info("DRY RUN: would remove %s", mountGuardBaseDir)
+		if pending > 0 {
+			logger.Info("DRY RUN: would keep %s (%d immutable guard target(s) still pending)", mountGuardBaseDir, pending)
+		} else {
+			logger.Info("DRY RUN: would remove %s", mountGuardBaseDir)
+		}
 		return nil
 	}
 
-	// If any guard mounts remain (for example hidden under a real mount), avoid removing the directory.
-	after, err := cleanupReadFile("/proc/self/mountinfo")
-	if err == nil {
-		_, _, remaining := guardMountpointsFromMountinfo(string(after))
-		if remaining > 0 {
-			logger.Warning("Guard cleanup: %d guard mount(s) still present; not removing %s", remaining, mountGuardBaseDir)
-			return nil
-		}
+	// If any guard mounts remain (for example hidden under a real mount), or any
+	// immutable guard target is still pending, avoid removing the directory/index.
+	remaining := 0
+	if after, rerr := cleanupReadFile("/proc/self/mountinfo"); rerr == nil {
+		_, _, remaining = guardMountpointsFromMountinfo(string(after))
+	}
+	if remaining > 0 || pending > 0 {
+		logger.Warning("Guard cleanup: %d guard mount(s) and %d immutable target(s) still present; not removing %s", remaining, pending, mountGuardBaseDir)
+		return nil
 	}
 
 	if err := cleanupRemoveAll(mountGuardBaseDir); err != nil {
@@ -189,4 +218,94 @@ func guardMountpointsFromMountinfo(mountinfo string) (visible, hidden []string, 
 	sort.Strings(visible)
 	sort.Strings(hidden)
 	return visible, hidden, guardMounts
+}
+
+// clearImmutableGuards reverses the `chattr +i` immutable fallback that restore
+// applied when a guard bind-mount could not be created. It is the symmetric
+// counterpart to the bind-mount unmount loop and processes ONLY the targets
+// ProxSave itself recorded in the immutable-guard index. For each one:
+//
+//   - a non-datastore mount root is skipped (defense-in-depth against a tampered
+//     or corrupt index — the operation can never escape /mnt, /media, /run/media);
+//   - a target that is currently mounted is skipped, because the immutable flag is
+//     on the shadowed underlying directory and `chattr -i` would touch the live
+//     mount instead (this mirrors how a hidden bind-mount guard is left in place);
+//   - dry-run only logs the intended action.
+//
+// Every step is best-effort and non-fatal: a missing/empty index is a no-op, and a
+// failed `chattr -i` on one target does not stop the others or abort cleanup.
+//
+// It returns the number of targets left immutable ("pending"): those skipped because
+// they are currently mounted, whose mount status or path could not be resolved, or
+// whose `chattr -i` failed. The caller keeps the guard directory (and its index) on
+// disk while pending > 0, so a later run — once the storage is unmounted — can still
+// clear them; the index is removed (with the directory) only when nothing is pending
+// and no bind-mount guards remain. In dry-run, pending reflects what a real run would
+// leave behind (mounted/unresolvable targets), so the "would remove" preview is honest.
+func clearImmutableGuards(ctx context.Context, logger *logging.Logger, dryRun bool) int {
+	data, err := cleanupChattrReadFile(mountGuardChattrTargetsPath())
+	if err != nil {
+		return 0 // missing/unreadable index => nothing was recorded => no-op
+	}
+
+	pending := 0
+	for _, target := range parseImmutableGuardTargets(data) {
+		// Defense-in-depth against a tampered/corrupt index: only ever touch a
+		// datastore mount root (/mnt, /media, /run/media). A dropped entry is not
+		// pending — it is removed when the directory is finally cleaned up.
+		if !isConfirmableDatastoreMountRoot(target) {
+			logger.Debug("Guard cleanup: skip non-datastore immutable target %s", target)
+			continue
+		}
+
+		mounted, mErr := isMounted(target)
+		if mErr != nil {
+			logger.Warning("Guard cleanup: cannot determine mount status of %s: %v; leaving immutable flag (clear manually with: chattr -i %s)", target, mErr, target)
+			pending++
+			continue
+		}
+		if mounted {
+			// The real storage is mounted on top, so the immutable flag is on the
+			// shadowed underlying directory; clearing here would touch the live mount
+			// instead. Left intact (mirrors how a hidden bind-mount guard is kept).
+			logger.Info("Guard cleanup: %s is currently mounted; its immutable flag is on the shadowed directory and was left intact (to clear it: unmount the storage, run --cleanup-guards again, then remount)", target)
+			pending++
+			continue
+		}
+
+		if dryRun {
+			logger.Info("DRY RUN: would clear immutable flag (chattr -i) on %s", target)
+			continue
+		}
+
+		// Resolve symlinks and re-check the allowlist so a parent-component symlink
+		// cannot make chattr -i escape the datastore roots. A path that no longer
+		// exists has nothing to clear (not pending). If a datastore root itself is a
+		// symlink that resolves outside the allowlist (rare on Proxmox/Debian), the
+		// target is refused and left pending — fail-safe: it never escapes and is
+		// never data loss; the operator can clear it manually with chattr -i.
+		resolved, rErr := cleanupResolveTarget(target)
+		if rErr != nil {
+			if os.IsNotExist(rErr) {
+				logger.Debug("Guard cleanup: immutable target %s no longer exists; nothing to clear", target)
+				continue
+			}
+			logger.Warning("Guard cleanup: cannot resolve %s: %v; leaving immutable flag (clear manually with: chattr -i %s)", target, rErr, target)
+			pending++
+			continue
+		}
+		if !isConfirmableDatastoreMountRoot(resolved) {
+			logger.Warning("Guard cleanup: %s resolves outside the datastore roots (%s); refusing to clear it automatically", target, resolved)
+			pending++
+			continue
+		}
+
+		if _, err := cleanupRunCmd(ctx, "chattr", "-i", resolved); err != nil {
+			logger.Warning("Guard cleanup: failed to clear immutable flag on %s: %v (clear manually with: chattr -i %s)", resolved, err, resolved)
+			pending++
+			continue
+		}
+		logger.Info("Guard cleanup: cleared immutable flag (chattr -i) on %s", resolved)
+	}
+	return pending
 }

--- a/internal/orchestrator/mount_guard.go
+++ b/internal/orchestrator/mount_guard.go
@@ -14,7 +14,11 @@ import (
 	"time"
 )
 
-const mountGuardBaseDir = "/var/lib/proxsave/guards"
+// mountGuardBaseDir is the directory under which ProxSave records mount guards.
+// It is a var (not a const) only so tests can redirect it to a temporary
+// directory; production never reassigns it.
+var mountGuardBaseDir = "/var/lib/proxsave/guards"
+
 const mountGuardMountAttemptTimeout = 10 * time.Second
 
 var (

--- a/internal/orchestrator/mount_guard_apply.go
+++ b/internal/orchestrator/mount_guard_apply.go
@@ -247,6 +247,7 @@ func (a *pbsMountGuardApply) protectOfflineTargetWithChattr(guardTarget string, 
 		return
 	}
 	a.protected[guardTarget] = struct{}{}
+	recordImmutableGuardTarget(a.logger, guardTarget) // so --cleanup-guards can later chattr -i it
 	a.warning("PBS mount guard: %s resolves to root filesystem (mount missing?) — marked immutable (chattr +i) to prevent writes until storage is available", guardTarget)
 }
 

--- a/internal/orchestrator/mount_guard_chattr_index.go
+++ b/internal/orchestrator/mount_guard_chattr_index.go
@@ -95,7 +95,9 @@ func recordImmutableGuardTarget(logger *logging.Logger, target string) {
 		return
 	}
 
-	if err := os.MkdirAll(mountGuardBaseDir, 0o755); err != nil {
+	// 0o750: the guard base dir is root-owned host state (it holds the 0o600 index
+	// and the bind-mount guard subdirs); nothing non-root needs to traverse it.
+	if err := os.MkdirAll(mountGuardBaseDir, 0o750); err != nil {
 		if logger != nil {
 			logger.Warning("Guard chattr index: unable to create %s: %v (cleanup will need a manual chattr -i %s)", mountGuardBaseDir, err, clean)
 		}
@@ -118,10 +120,20 @@ func recordImmutableGuardTarget(logger *logging.Logger, target string) {
 	}
 }
 
-// readImmutableGuardIndex reads and parses the index at path. A missing or
-// unreadable index yields no targets (the index is best-effort metadata).
+// readImmutableGuardIndex reads and parses the index at path through an *os.Root
+// on its directory, so the read is confined there at the syscall level: a symlink
+// or `..` in the basename cannot redirect the read outside the guard directory,
+// and the path is no longer a raw variable sink (resolving gosec G304 structurally
+// rather than with a suppression). A missing or unreadable index yields no targets
+// (the index is best-effort metadata).
 func readImmutableGuardIndex(path string) []string {
-	data, err := os.ReadFile(path)
+	root, err := os.OpenRoot(filepath.Dir(path))
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = root.Close() }()
+
+	data, err := root.ReadFile(filepath.Base(path))
 	if err != nil {
 		return nil
 	}

--- a/internal/orchestrator/mount_guard_chattr_index.go
+++ b/internal/orchestrator/mount_guard_chattr_index.go
@@ -1,0 +1,155 @@
+// Package orchestrator coordinates backup, restore, decrypt, and related workflows.
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+// mountGuardChattrTargetsName is the index file (under mountGuardBaseDir) that
+// records mountpoint directories ProxSave marked immutable via the `chattr +i`
+// fallback guard during restore. CleanupMountGuards reads it back to clear
+// exactly those directories (and only those) with `chattr -i`.
+//
+// Unlike the read-only bind-mount guard — which a later real mount simply shadows
+// and a reboot discards — the immutable flag persists on the directory inode
+// across reboots and is never cleared automatically, so it must be recorded for
+// later cleanup.
+const mountGuardChattrTargetsName = "chattr-targets"
+
+// maxChattrIndexBytes bounds how large the index may grow before we refuse to
+// parse it. A corrupt/oversized index is treated as empty (fail-safe: skip the
+// auto-clear rather than risk unbounded memory); the operator can still run
+// `chattr -i` manually, exactly as before this index existed.
+const maxChattrIndexBytes = 1 << 20 // 1 MiB
+
+// mountGuardChattrTargetsPath returns the absolute path of the immutable-guard index.
+func mountGuardChattrTargetsPath() string {
+	return filepath.Join(mountGuardBaseDir, mountGuardChattrTargetsName)
+}
+
+// isUnsafeIndexRune reports control characters that have no place in a
+// one-path-per-line index (C0 controls incl. newline/CR, DEL, and the C1 range).
+func isUnsafeIndexRune(r rune) bool {
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
+
+// isRecordableImmutableTarget cleans and validates a candidate target for the
+// index. It rejects empty/"."/root, anything that is not a confirmable datastore
+// mount root (/mnt, /media, /run/media), and — critically — any value containing
+// a newline or other control character, so a single malformed path can never
+// inject extra index lines or smuggle a non-datastore path past the cleanup
+// allowlist.
+func isRecordableImmutableTarget(target string) (string, bool) {
+	clean := filepath.Clean(strings.TrimSpace(target))
+	if !isValidGuardTarget(clean) {
+		return "", false
+	}
+	if strings.IndexFunc(clean, isUnsafeIndexRune) >= 0 {
+		return "", false
+	}
+	if !isConfirmableDatastoreMountRoot(clean) {
+		return "", false
+	}
+	return clean, true
+}
+
+// parseImmutableGuardTargets parses index bytes into cleaned, validated,
+// de-duplicated targets in first-seen order. Tolerant of blank lines, trailing
+// newlines, CRLF, and duplicates; lines that fail validation are dropped. An
+// oversized blob is treated as empty (see maxChattrIndexBytes).
+func parseImmutableGuardTargets(data []byte) []string {
+	if len(data) == 0 || len(data) > maxChattrIndexBytes {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		clean := filepath.Clean(strings.TrimSpace(line))
+		if !isValidGuardTarget(clean) {
+			continue
+		}
+		if _, dup := seen[clean]; dup {
+			continue
+		}
+		seen[clean] = struct{}{}
+		out = append(out, clean)
+	}
+	return out
+}
+
+// recordImmutableGuardTarget appends target to the immutable-guard index after a
+// successful `chattr +i`, so CleanupMountGuards can later clear exactly the
+// directories ProxSave itself made immutable. Best-effort: any failure is logged
+// and swallowed so a recording problem never aborts the restore. The write is
+// atomic and de-duplicated.
+func recordImmutableGuardTarget(logger *logging.Logger, target string) {
+	clean, ok := isRecordableImmutableTarget(target)
+	if !ok {
+		if logger != nil {
+			logger.Warning("Guard chattr index: refusing to record unsafe immutable target %q", target)
+		}
+		return
+	}
+
+	if err := os.MkdirAll(mountGuardBaseDir, 0o755); err != nil {
+		if logger != nil {
+			logger.Warning("Guard chattr index: unable to create %s: %v (cleanup will need a manual chattr -i %s)", mountGuardBaseDir, err, clean)
+		}
+		return
+	}
+
+	indexPath := mountGuardChattrTargetsPath()
+	existing := readImmutableGuardIndex(indexPath)
+	for _, t := range existing {
+		if t == clean {
+			return // already recorded; keep the index stable
+		}
+	}
+
+	payload := strings.Join(append(existing, clean), "\n") + "\n"
+	if err := writeImmutableGuardIndex(indexPath, []byte(payload), 0o600); err != nil {
+		if logger != nil {
+			logger.Warning("Guard chattr index: unable to record %s in %s: %v (cleanup will need a manual chattr -i)", clean, indexPath, err)
+		}
+	}
+}
+
+// readImmutableGuardIndex reads and parses the index at path. A missing or
+// unreadable index yields no targets (the index is best-effort metadata).
+func readImmutableGuardIndex(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return parseImmutableGuardTargets(data)
+}
+
+// writeImmutableGuardIndex writes the index atomically (temp file + rename) on the
+// REAL host filesystem. The index is host state under /var/lib/proxsave — it is not
+// part of the staged restore tree — so it deliberately uses os.* directly rather
+// than the restoreFS abstraction (which may be a fake/overlay during restore).
+func writeImmutableGuardIndex(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".chattr-targets-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/orchestrator/mount_guard_chattr_index_test.go
+++ b/internal/orchestrator/mount_guard_chattr_index_test.go
@@ -1,0 +1,489 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTempGuardBaseDir redirects mountGuardBaseDir to an isolated temp dir for the
+// duration of a test and restores it afterward. Mirrors the cleanup*/mountGuard*
+// save/restore pattern used throughout this package and keeps the chattr index off
+// the real /var/lib/proxsave path.
+func withTempGuardBaseDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := mountGuardBaseDir
+	mountGuardBaseDir = dir
+	t.Cleanup(func() { mountGuardBaseDir = orig })
+	return dir
+}
+
+// readGuardIndexLines returns the recorded immutable-target lines (trimmed, no
+// blank lines). A missing index yields nil.
+func readGuardIndexLines(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile(mountGuardChattrTargetsPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read guard index: %v", err)
+	}
+	var out []string
+	for _, l := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(l) != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// --- record (apply-time) ---------------------------------------------------
+
+// Kills: removing the dedup loop (would yield 2 identical lines) or any mutation
+// that drops/reorders the second distinct target.
+func TestRecordImmutableGuardTarget_DedupAndOrder(t *testing.T) {
+	withTempGuardBaseDir(t)
+	logger := newTestLogger()
+
+	recordImmutableGuardTarget(logger, "/mnt/pve/store-a")
+	recordImmutableGuardTarget(logger, "/mnt/pve/store-a") // duplicate
+	if got := readGuardIndexLines(t); len(got) != 1 || got[0] != "/mnt/pve/store-a" {
+		t.Fatalf("after duplicate record, index=%#v want [/mnt/pve/store-a]", got)
+	}
+
+	recordImmutableGuardTarget(logger, "/media/usb-b")
+	got := readGuardIndexLines(t)
+	if len(got) != 2 || got[0] != "/mnt/pve/store-a" || got[1] != "/media/usb-b" {
+		t.Fatalf("index=%#v want [/mnt/pve/store-a, /media/usb-b] in order", got)
+	}
+
+	// The index records mount-root paths, not secrets, but should not be world-readable.
+	info, err := os.Stat(mountGuardChattrTargetsPath())
+	if err != nil {
+		t.Fatalf("stat index: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("index mode = %o, want 0600", perm)
+	}
+}
+
+// Kills: dropping the newline/control-char guard (a newline target would inject an
+// extra index line), the isValidGuardTarget guard ("/"/"" rejected), or the
+// isConfirmableDatastoreMountRoot guard (a non-datastore path would be recorded).
+func TestRecordImmutableGuardTarget_RejectsUnsafe(t *testing.T) {
+	withTempGuardBaseDir(t)
+	logger := newTestLogger()
+
+	for _, bad := range []string{
+		"", "   ", ".", "/",
+		"/etc/cron.d",            // not a datastore root
+		"/var/lib/x",             // not a datastore root
+		"/mnt/ok\n/etc/passwd",   // newline injection
+		"/mnt/with\ttab",         // control char
+	} {
+		recordImmutableGuardTarget(logger, bad)
+	}
+	if got := readGuardIndexLines(t); len(got) != 0 {
+		t.Fatalf("index should be empty after only-invalid records, got %#v", got)
+	}
+
+	// A legitimate one still records, proving the rejections above were selective.
+	recordImmutableGuardTarget(logger, "/mnt/pve/legit")
+	if got := readGuardIndexLines(t); len(got) != 1 || got[0] != "/mnt/pve/legit" {
+		t.Fatalf("index=%#v want [/mnt/pve/legit]", got)
+	}
+}
+
+// Kills: removing tmp.Chmod(perm) in writeImmutableGuardIndex. os.CreateTemp
+// defaults to 0600, so a non-default perm is required to pin the Chmod call.
+func TestWriteImmutableGuardIndex_AppliesPerm(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "idx")
+	if err := writeImmutableGuardIndex(path, []byte("/mnt/x\n"), 0o640); err != nil {
+		t.Fatalf("writeImmutableGuardIndex: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o640 {
+		t.Fatalf("index perm = %o, want 0640 (Chmod not applied?)", perm)
+	}
+}
+
+// Kills: parser regressions on blank/duplicate/CRLF/non-datastore-not-filtered
+// (note: parse only validates isValidGuardTarget; datastore filtering is the clear
+// loop's job, so /etc survives parse here and is dropped at clear time — see the
+// dedicated cleanup test).
+func TestParseImmutableGuardTargets_MalformedTolerant(t *testing.T) {
+	raw := strings.Join([]string{
+		"", "  /mnt/a  ", "/mnt/a", "/mnt/b\r", "   ", "/", ".", "/media/c", "",
+	}, "\n")
+	got := parseImmutableGuardTargets([]byte(raw))
+	want := []string{"/mnt/a", "/mnt/b", "/media/c"} // first-seen order, deduped, root/empty dropped
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("parse=%v want %v", got, want)
+	}
+}
+
+// Kills: removing the maxChattrIndexBytes size cap.
+func TestParseImmutableGuardTargets_OversizedTreatedEmpty(t *testing.T) {
+	big := make([]byte, maxChattrIndexBytes+1)
+	if got := parseImmutableGuardTargets(big); got != nil {
+		t.Fatalf("oversized index should parse as empty, got %d entries", len(got))
+	}
+}
+
+// Kills: removing the recordImmutableGuardTarget call in the PBS chattr fallback
+// (success records; a chattr +i failure must NOT record).
+func TestPBSChattrFallback_RecordsIndex(t *testing.T) {
+	withTempGuardBaseDir(t)
+
+	origCmd := restoreCmd
+	t.Cleanup(func() { restoreCmd = origCmd })
+
+	a := &pbsMountGuardApply{
+		ctx:       context.Background(),
+		logger:    newTestLogger(),
+		protected: map[string]struct{}{},
+	}
+
+	// chattr +i succeeds -> recorded.
+	restoreCmd = &FakeCommandRunner{}
+	a.protectOfflineTargetWithChattr("/mnt/pbs-ok", errors.New("bind failed"))
+	if _, ok := a.protected["/mnt/pbs-ok"]; !ok {
+		t.Fatalf("/mnt/pbs-ok should be marked protected")
+	}
+	if got := readGuardIndexLines(t); len(got) != 1 || got[0] != "/mnt/pbs-ok" {
+		t.Fatalf("index=%#v want [/mnt/pbs-ok]", got)
+	}
+
+	// chattr +i fails -> NOT recorded.
+	restoreCmd = &FakeCommandRunner{Errors: map[string]error{"chattr +i /mnt/pbs-fail": errors.New("denied")}}
+	a.protectOfflineTargetWithChattr("/mnt/pbs-fail", errors.New("bind failed"))
+	got := readGuardIndexLines(t)
+	for _, l := range got {
+		if l == "/mnt/pbs-fail" {
+			t.Fatalf("a failed chattr +i must not be recorded; index=%#v", got)
+		}
+	}
+}
+
+// Kills: removing the recordImmutableGuardTarget call at the PVE chattr fallback
+// site. Drives the PVE guard path entirely through seams so it ALWAYS runs (the
+// pre-existing _EarlyAndFallback test is skip-gated on a writable /mnt/pve + root).
+func TestPVEChattrFallback_RecordsIndex(t *testing.T) {
+	ctx := context.Background()
+	logger := newTestLogger()
+	withTempGuardBaseDir(t)
+
+	origFS := restoreFS
+	origCmd := restoreCmd
+	origGeteuid := mountGuardGeteuid
+	origMkdir := mountGuardMkdirAll
+	origRootFS := mountGuardIsPathOnRootFilesystem
+	origMount := mountGuardSysMount
+	origUnmount := mountGuardSysUnmount
+	origRead := mountGuardReadFile
+	t.Cleanup(func() {
+		restoreFS = origFS
+		restoreCmd = origCmd
+		mountGuardGeteuid = origGeteuid
+		mountGuardMkdirAll = origMkdir
+		mountGuardIsPathOnRootFilesystem = origRootFS
+		mountGuardSysMount = origMount
+		mountGuardSysUnmount = origUnmount
+		mountGuardReadFile = origRead
+	})
+
+	restoreFS = osFS{}
+	mountGuardGeteuid = func() int { return 0 }
+	mountGuardMkdirAll = func(string, os.FileMode) error { return nil }
+	mountGuardIsPathOnRootFilesystem = func(p string) (bool, string, error) { return true, p, nil } // force offline guard
+	mountGuardSysMount = func(string, string, string, uintptr, string) error { return errors.New("bind denied") } // force chattr fallback
+	mountGuardSysUnmount = func(string, int) error { return nil }
+	mountGuardReadFile = func(string) ([]byte, error) { return []byte(""), nil } // /proc empty -> not mounted
+
+	stageRoot := t.TempDir()
+	stageCfgPath := filepath.Join(stageRoot, "etc/pve/storage.cfg")
+	if err := os.MkdirAll(filepath.Dir(stageCfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir stage cfg dir: %v", err)
+	}
+	id := uniquePveMountTestStorageID(t, "chattr-record")
+	if err := os.WriteFile(stageCfgPath, []byte("nfs: "+id+"\n"), 0o644); err != nil {
+		t.Fatalf("write staged storage.cfg: %v", err)
+	}
+	target := pveMountTargetForStorageID(id)
+
+	fakeCmd := &FakeCommandRunner{
+		Errors: map[string]error{
+			"which pvesm":         errors.New("missing"),
+			"mount " + target:     errors.New("offline"),
+			"chattr +i " + target: nil, // success -> record
+		},
+	}
+	restoreCmd = fakeCmd
+
+	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, pvePlan(false, "storage_pve"), stageRoot, "/"); err != nil {
+		t.Fatalf("guard fallback should be non-fatal, got %v", err)
+	}
+	if !strings.Contains(strings.Join(fakeCmd.CallsList(), "\n"), "chattr +i "+target) {
+		t.Fatalf("expected chattr +i fallback; calls=%v", fakeCmd.CallsList())
+	}
+	if got := readGuardIndexLines(t); len(got) != 1 || got[0] != target {
+		t.Fatalf("PVE chattr fallback must record %q in the index; got %#v", target, got)
+	}
+}
+
+// --- cleanup (clear-time) --------------------------------------------------
+
+// installChattrCleanupSeams wires the cleanup seams for the chattr-clear path.
+// index: bytes returned by the index read seam (nil => missing/ErrNotExist).
+// mountinfo: what isMounted sees via mountGuardReadFile("/proc/self/mountinfo").
+// chattrErr: per-command (commandKey) errors for the chattr runner.
+// Returns a pointer to the list of commands the runner received.
+func installChattrCleanupSeams(t *testing.T, index []byte, mountinfo string, chattrErr map[string]error) *[]string {
+	t.Helper()
+	origGeteuid := cleanupGeteuid
+	origStat := cleanupStat
+	origReadFile := cleanupReadFile
+	origRemoveAll := cleanupRemoveAll
+	origUnmount := cleanupSysUnmount
+	origChattrRead := cleanupChattrReadFile
+	origResolve := cleanupResolveTarget
+	origRunCmd := cleanupRunCmd
+	origMGRead := mountGuardReadFile
+	t.Cleanup(func() {
+		cleanupGeteuid = origGeteuid
+		cleanupStat = origStat
+		cleanupReadFile = origReadFile
+		cleanupRemoveAll = origRemoveAll
+		cleanupSysUnmount = origUnmount
+		cleanupChattrReadFile = origChattrRead
+		cleanupResolveTarget = origResolve
+		cleanupRunCmd = origRunCmd
+		mountGuardReadFile = origMGRead
+	})
+
+	cleanupGeteuid = func() int { return 0 }
+	cleanupStat = func(string) (os.FileInfo, error) { return nil, nil }
+	cleanupReadFile = func(string) ([]byte, error) { return []byte(""), nil } // empty /proc -> no bind guards
+	cleanupRemoveAll = func(string) error { return nil }
+	cleanupSysUnmount = func(string, int) error { return nil }
+	cleanupResolveTarget = func(p string) (string, error) { return p, nil } // identity: no symlink resolution in unit tests
+	cleanupChattrReadFile = func(path string) ([]byte, error) {
+		if path != mountGuardChattrTargetsPath() {
+			t.Fatalf("unexpected index read path %q", path)
+		}
+		if index == nil {
+			return nil, os.ErrNotExist
+		}
+		return index, nil
+	}
+	mountGuardReadFile = func(path string) ([]byte, error) {
+		if path == "/proc/self/mountinfo" {
+			return []byte(mountinfo), nil
+		}
+		return []byte(""), nil
+	}
+
+	var ran []string
+	cleanupRunCmd = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		key := commandKey(name, args)
+		ran = append(ran, key)
+		if chattrErr != nil {
+			if err, ok := chattrErr[key]; ok {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}
+	return &ran
+}
+
+// Kills: removing the clearImmutableGuards call, or any mutation that skips the
+// chattr -i for a valid not-mounted datastore-root target.
+func TestCleanupMountGuards_ClearsImmutableWhenNotMounted(t *testing.T) {
+	withTempGuardBaseDir(t)
+	ran := installChattrCleanupSeams(t, []byte("/mnt/pve/offline\n/media/usb\n"), "", nil)
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("CleanupMountGuards: %v", err)
+	}
+	want := map[string]bool{"chattr -i /mnt/pve/offline": true, "chattr -i /media/usb": true}
+	if len(*ran) != 2 || !want[(*ran)[0]] || !want[(*ran)[1]] {
+		t.Fatalf("runner calls=%#v want both chattr -i targets", *ran)
+	}
+}
+
+// Kills: removing the isMounted skip (a re-mounted target would be wrongly cleared,
+// touching the live mount instead of the shadowed dir).
+func TestCleanupMountGuards_SkipsImmutableWhenMounted(t *testing.T) {
+	withTempGuardBaseDir(t)
+	mountinfo := "36 35 0:30 / /mnt/pve/offline rw - nfs server:/export rw\n"
+	ran := installChattrCleanupSeams(t, []byte("/mnt/pve/offline\n"), mountinfo, nil)
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("CleanupMountGuards: %v", err)
+	}
+	if len(*ran) != 0 {
+		t.Fatalf("chattr -i must not run for a mounted (shadowed) target, calls=%#v", *ran)
+	}
+}
+
+// Kills: a mutation that ignores dryRun and clears anyway.
+func TestCleanupMountGuards_DryRunNoChattr(t *testing.T) {
+	withTempGuardBaseDir(t)
+	ran := installChattrCleanupSeams(t, []byte("/mnt/pve/offline\n"), "", nil)
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), true); err != nil {
+		t.Fatalf("CleanupMountGuards dry-run: %v", err)
+	}
+	if len(*ran) != 0 {
+		t.Fatalf("dry-run must not run chattr -i, calls=%#v", *ran)
+	}
+}
+
+// Kills: removing the isConfirmableDatastoreMountRoot guard in the clear loop (an
+// arbitrary path like /etc would otherwise get chattr -i).
+func TestCleanupMountGuards_RejectsNonDatastoreIndexEntry(t *testing.T) {
+	withTempGuardBaseDir(t)
+	ran := installChattrCleanupSeams(t, []byte("/etc/passwd-dir\n/var/lib/x\n/mnt/pve/legit\n"), "", nil)
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("CleanupMountGuards: %v", err)
+	}
+	if len(*ran) != 1 || (*ran)[0] != "chattr -i /mnt/pve/legit" {
+		t.Fatalf("only the datastore-root entry may be cleared, calls=%#v", *ran)
+	}
+}
+
+// Kills: making a chattr -i failure abort cleanup (return non-nil) or break out of
+// the loop (the second target would never be processed).
+func TestCleanupMountGuards_ChattrFailureNonFatalContinues(t *testing.T) {
+	withTempGuardBaseDir(t)
+	ran := installChattrCleanupSeams(t, []byte("/mnt/pve/first\n/mnt/pve/second\n"), "",
+		map[string]error{"chattr -i /mnt/pve/first": errors.New("operation not permitted")})
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("per-target chattr failure must be non-fatal, got %v", err)
+	}
+	if len(*ran) != 2 || (*ran)[0] != "chattr -i /mnt/pve/first" || (*ran)[1] != "chattr -i /mnt/pve/second" {
+		t.Fatalf("both targets must be attempted in order despite failure, calls=%#v", *ran)
+	}
+}
+
+// Kills: a mutation that calls chattr (or errors) when the index is absent.
+func TestCleanupMountGuards_MissingIndexNoOp(t *testing.T) {
+	withTempGuardBaseDir(t)
+	ran := installChattrCleanupSeams(t, nil, "", nil)
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("CleanupMountGuards: %v", err)
+	}
+	if len(*ran) != 0 {
+		t.Fatalf("missing index must be a no-op, calls=%#v", *ran)
+	}
+}
+
+// Kills: a mutation that clears (rather than skips) when isMounted cannot be
+// determined.
+func TestCleanupMountGuards_IsMountedErrorSkips(t *testing.T) {
+	withTempGuardBaseDir(t)
+	ran := installChattrCleanupSeams(t, []byte("/mnt/pve/offline\n"), "", nil)
+	// Force isMounted to error: both /proc reads fail.
+	mountGuardReadFile = func(string) ([]byte, error) { return nil, errors.New("procfs unavailable") }
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("CleanupMountGuards: %v", err)
+	}
+	if len(*ran) != 0 {
+		t.Fatalf("chattr -i must not run when mount status is inconclusive, calls=%#v", *ran)
+	}
+}
+
+// Kills: removing the symlink-resolution + post-resolve allowlist re-check (a
+// target whose parent symlink resolves outside /mnt|/media|/run/media must NOT be
+// chattr'd).
+func TestCleanupMountGuards_SymlinkEscapeRefused(t *testing.T) {
+	withTempGuardBaseDir(t)
+	ran := installChattrCleanupSeams(t, []byte("/mnt/pve/evil\n"), "", nil)
+	// /mnt/pve/evil passes the string allowlist but resolves outside it.
+	cleanupResolveTarget = func(string) (string, error) { return "/etc/evil", nil }
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("CleanupMountGuards: %v", err)
+	}
+	if len(*ran) != 0 {
+		t.Fatalf("a symlink-escaping target must not be cleared, calls=%#v", *ran)
+	}
+}
+
+// Kills: removing the pending-gate (a chattr target skipped because it is mounted
+// must NOT cause the guard dir/index to be removed, or its record is lost forever).
+func TestCleanupMountGuards_PendingKeepsIndexDir(t *testing.T) {
+	withTempGuardBaseDir(t)
+	mountinfo := "36 35 0:30 / /mnt/pve/offline rw - nfs server:/export rw\n"
+	ran := installChattrCleanupSeams(t, []byte("/mnt/pve/offline\n"), mountinfo, nil)
+
+	removed := false
+	cleanupRemoveAll = func(string) error { removed = true; return nil }
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("CleanupMountGuards: %v", err)
+	}
+	if len(*ran) != 0 {
+		t.Fatalf("mounted target must be skipped, calls=%#v", *ran)
+	}
+	if removed {
+		t.Fatalf("guard dir/index must be kept while an immutable target is still pending")
+	}
+}
+
+// End-to-end: a real recorded index is read back and cleared by CleanupMountGuards
+// (proves record and clear agree on the on-disk format and path).
+func TestCleanupMountGuards_RoundTripFromRecord(t *testing.T) {
+	withTempGuardBaseDir(t)
+	recordImmutableGuardTarget(newTestLogger(), "/mnt/pve/roundtrip")
+
+	// Stub the dangerous/root-only seams but leave cleanupChattrReadFile at its
+	// default (os.ReadFile) so it reads the file record actually wrote.
+	origGeteuid := cleanupGeteuid
+	origStat := cleanupStat
+	origReadFile := cleanupReadFile
+	origRemoveAll := cleanupRemoveAll
+	origResolve := cleanupResolveTarget
+	origRunCmd := cleanupRunCmd
+	origMGRead := mountGuardReadFile
+	t.Cleanup(func() {
+		cleanupGeteuid = origGeteuid
+		cleanupStat = origStat
+		cleanupReadFile = origReadFile
+		cleanupRemoveAll = origRemoveAll
+		cleanupResolveTarget = origResolve
+		cleanupRunCmd = origRunCmd
+		mountGuardReadFile = origMGRead
+	})
+	cleanupGeteuid = func() int { return 0 }
+	cleanupStat = func(string) (os.FileInfo, error) { return nil, nil }
+	cleanupReadFile = func(string) ([]byte, error) { return []byte(""), nil }
+	cleanupRemoveAll = func(string) error { return nil }
+	cleanupResolveTarget = func(p string) (string, error) { return p, nil } // identity (path is fake)
+	mountGuardReadFile = func(string) ([]byte, error) { return []byte(""), nil } // not mounted
+	var ran []string
+	cleanupRunCmd = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		ran = append(ran, commandKey(name, args))
+		return nil, nil
+	}
+
+	if err := CleanupMountGuards(context.Background(), newTestLogger(), false); err != nil {
+		t.Fatalf("CleanupMountGuards: %v", err)
+	}
+	if len(ran) != 1 || ran[0] != "chattr -i /mnt/pve/roundtrip" {
+		t.Fatalf("round-trip: runner calls=%#v want [chattr -i /mnt/pve/roundtrip]", ran)
+	}
+}

--- a/internal/orchestrator/mount_guard_more_test.go
+++ b/internal/orchestrator/mount_guard_more_test.go
@@ -616,6 +616,7 @@ func TestMaybeApplyPBSDatastoreMountGuards_FullFlow(t *testing.T) {
 	logger := newTestLogger()
 	ctx := context.Background()
 	plan := &RestorePlan{SystemType: SystemTypePBS, NormalCategories: []Category{{ID: "datastore_pbs"}}}
+	withTempGuardBaseDir(t) // keep the chattr index off the real /var/lib/proxsave
 
 	origGeteuid := mountGuardGeteuid
 	origReadFile := mountGuardReadFile

--- a/internal/orchestrator/pve_staged_apply.go
+++ b/internal/orchestrator/pve_staged_apply.go
@@ -343,14 +343,14 @@ func maybeApplyPVEStorageMountGuardsFromStage(ctx context.Context, logger *loggi
 			continue
 		}
 
-		if err := os.MkdirAll(guardTarget, 0o750); err != nil {
+		if err := mountGuardMkdirAll(guardTarget, 0o750); err != nil {
 			if logger != nil {
 				logger.Warning("PVE mount guard: unable to create mountpoint directory %s: %v", guardTarget, err)
 			}
 			continue
 		}
 
-		onRootFS, _, devErr := isPathOnRootFilesystem(guardTarget)
+		onRootFS, _, devErr := mountGuardIsPathOnRootFilesystem(guardTarget)
 		if devErr != nil {
 			if logger != nil {
 				logger.Warning("PVE mount guard: unable to determine filesystem device for %s: %v", guardTarget, devErr)
@@ -377,7 +377,7 @@ func maybeApplyPVEStorageMountGuardsFromStage(ctx context.Context, logger *loggi
 		cancel()
 
 		if attemptErr == nil {
-			onRootFSNow, _, devErrNow := isPathOnRootFilesystem(guardTarget)
+			onRootFSNow, _, devErrNow := mountGuardIsPathOnRootFilesystem(guardTarget)
 			if devErrNow == nil && !onRootFSNow {
 				if logger != nil {
 					logger.Info("PVE mount guard: mountpoint %s is now mounted (activation/mount attempt succeeded)", guardTarget)
@@ -410,6 +410,7 @@ func maybeApplyPVEStorageMountGuardsFromStage(ctx context.Context, logger *loggi
 				}
 				continue
 			}
+			recordImmutableGuardTarget(logger, guardTarget) // so --cleanup-guards can later chattr -i it
 			if logger != nil {
 				logger.Warning("PVE mount guard: %s resolves to root filesystem (mount missing?) — marked immutable (chattr +i) to prevent writes until storage is available", guardTarget)
 			}

--- a/internal/orchestrator/pve_staged_apply_additional_test.go
+++ b/internal/orchestrator/pve_staged_apply_additional_test.go
@@ -656,6 +656,7 @@ func containsGuardTarget(values []string, want string) bool {
 func TestMaybeApplyPVEStorageMountGuardsFromStage_EarlyAndFallback(t *testing.T) {
 	ctx := context.Background()
 	logger := newTestLogger()
+	withTempGuardBaseDir(t) // keep the chattr index off the real /var/lib/proxsave
 
 	if err := maybeApplyPVEStorageMountGuardsFromStage(ctx, logger, nil, "/stage", "/"); err != nil {
 		t.Fatalf("nil plan: expected nil error, got %v", err)
@@ -752,6 +753,9 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_EarlyAndFallback(t *testing.T)
 	if !strings.Contains(calls, "chattr +i "+target) {
 		t.Fatalf("missing chattr fallback call; calls=%v", fakeCmd.CallsList())
 	}
+	if got := readGuardIndexLines(t); len(got) != 1 || got[0] != target {
+		t.Fatalf("chattr fallback must record %q in the immutable index; got %#v", target, got)
+	}
 }
 
 func TestMaybeApplyPVEStorageMountGuardsFromStage_ReadAndNoopBranches(t *testing.T) {
@@ -809,6 +813,7 @@ func TestMaybeApplyPVEStorageMountGuardsFromStage_ActivateAndGuardBranches(t *te
 	logger := newTestLogger()
 	plan := pvePlan(false, "storage_pve")
 	requireWritablePveMountRoot(t)
+	withTempGuardBaseDir(t) // keep any chattr index off the real /var/lib/proxsave
 
 	origFS := restoreFS
 	origCmd := restoreCmd


### PR DESCRIPTION
## Problem

During restore, when a storage mountpoint is offline, ProxSave applies a read-only **bind-mount guard**; if the bind mount can't be created it falls back to `chattr +i` on the mountpoint directory, so PVE/PBS can't silently write into the root filesystem (`/`).

`--cleanup-guards` previously only undid the **bind-mount** guards. The `chattr +i` fallback was left in place — and unlike a bind mount, the immutable flag **persists across reboots** and is never cleared automatically, so a user had to run `chattr -i` by hand (and often didn't know to).

## Change

Record each chattr-guarded mountpoint in a host-side index (`/var/lib/proxsave/guards/chattr-targets`) and make `--cleanup-guards` reverse it:

- **Record** on a successful `chattr +i` at both apply sites (PBS + PVE), written atomically on the **real** filesystem (the index is host state, not part of the staged restore tree), deduped, with strict validation (datastore mount root only; reject newline/control chars).
- **Clear**: `clearImmutableGuards` reads the index and runs `chattr -i`, but only on targets that are **not currently mounted** — a live mount shadows the flagged directory, so clearing it would touch the wrong inode (mirrors how hidden bind-mount guards are left in place). Symlinks are resolved and the allowlist re-checked before clearing, so a parent-component symlink can't escape `/mnt|/media|/run/media`.
- **Pending gate**: keep the guard directory + index while any immutable target is still pending (mounted / unresolvable / failed) so a later run — once the storage is unmounted — can finish the job; remove them only when nothing is pending and no bind-mount guards remain.
- **UX**: surface the skip-while-mounted case at Info level, and point users at the manual recovery (`lsattr -d` / `chattr -i`) when the guard directory was deleted by hand.

PVE guard apply now uses the existing `mountGuardMkdirAll` / `mountGuardIsPathOnRootFilesystem` seams (default behavior unchanged) so the record wiring can be tested without a writable `/mnt/pve`.

## Behavior notes

- Bringing the storage back online is enough to *use* it again (a real mount stacks on top of the guard); `--cleanup-guards` just removes the leftover guard.
- To clear a flag while the storage is mounted: unmount → `--cleanup-guards` (or `chattr -i`) → remount.
- If the guard directory was already deleted manually, there's no record to clear — documented manual recovery via `lsattr -d` / `chattr -i`.

## Tests & validation

- New mutation-aware tests (record dedup/validation, real-FS atomic writer perms, PVE + PBS wiring, clear/skip/dry-run/non-datastore-reject/chattr-failure/missing-index/symlink-escape/pending-keeps-index, end-to-end round-trip).
- Full `internal/orchestrator` suite green with `-race -shuffle=on -count=2`; `cmd/...` + `internal/cli/...` green.
- Adversarially reviewed across correctness, security, and test-rigor over two rounds; all findings closed and mutation-proven.

## Docs

Updated `RESTORE_GUIDE.md`, `RESTORE_TECHNICAL.md`, `CLI_REFERENCE.md`, `TROUBLESHOOTING.md`: distinguish bind-mount vs `chattr +i` guard lifecycle (the latter survives reboot), fix the "real mount overlays the guard" wording, and document the cleanup / mounted-target / deleted-directory recovery procedures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the gap where `--cleanup-guards` only reversed bind-mount guards but left `chattr +i` immutable flags in place — a regression that persists across reboots and requires manual recovery. The fix records each successfully-applied `chattr +i` fallback target in a host-side index (`/var/lib/proxsave/guards/chattr-targets`) and makes `--cleanup-guards` reverse them with appropriate safety checks.

- **Record path**: both PBS and PVE guard-apply sites call `recordImmutableGuardTarget` after a successful `chattr +i`, writing atomically (temp-file + rename) with dedup, strict allowlist validation, and control-character rejection.
- **Clear path**: `clearImmutableGuards` re-validates each recorded target against the datastore-root allowlist, skips currently-mounted targets (the immutable flag is on the shadowed inode, not the live mount), resolves symlinks and re-checks the allowlist, and runs `chattr -i` on the resolved path.
- **Pending gate**: the guard directory and index are kept while any target is still pending (mounted, unresolvable, or failed), so a later run after unmounting can finish the job.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the chattr guard record/clear logic is well-contained, comprehensively tested, and fails safely at every step.

The change correctly closes a real lifecycle gap (immutable flags persisting after reboots). Guard application and cleanup are both best-effort and non-fatal, so recording or clearing failures degrade gracefully to the pre-PR manual-recovery path rather than aborting the restore. The allowlist double-check (once on the raw target, again on the resolved path) prevents symlink-escape. Test coverage is extensive and mutation-aware across all code paths. Two previously-noted edge cases (no fsync before rename; isMounted checked on the unresolved path before symlink resolution) are low-impact theoretical concerns that the PR explicitly acknowledges as acceptable trade-offs.

No files require special attention. The core logic in guards_cleanup.go and mount_guard_chattr_index.go is well-covered by the new test suite.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/mount_guard_chattr_index.go | New file: index record/read/write helpers with allowlist validation, control-char rejection, dedup, atomic write, and size cap. Uses os.OpenRoot for path confinement on the record-time read path. |
| internal/orchestrator/guards_cleanup.go | Adds clearImmutableGuards and three new injectable seams; correctly integrates the pending count with the existing bind-mount guard loop and removal gate. The isMounted check uses the unresolved target path (a known symlink edge-case, previously flagged). |
| internal/orchestrator/mount_guard_apply.go | One-line addition: recordImmutableGuardTarget called after successful chattr +i in the PBS fallback path, correctly placed after the early-return on failure. |
| internal/orchestrator/pve_staged_apply.go | Switches two os.MkdirAll / isPathOnRootFilesystem call sites to the injectable mountGuard* seams; adds recordImmutableGuardTarget call after successful chattr +i, correctly placed after the continue on failure. |
| internal/orchestrator/mount_guard_chattr_index_test.go | 489-line test file covering dedup, injection-rejection, perm verification, parse tolerance, PBS/PVE wiring, and all clearImmutableGuards branches including dry-run, skip-mounted, chattr-failure, symlink-escape, pending-gate, and round-trip. |
| internal/orchestrator/mount_guard.go | mountGuardBaseDir promoted from const to var solely for test redirection; production behavior unchanged. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant R as Restore
    participant GA as Guard Apply (PBS/PVE)
    participant IDX as chattr-targets index
    participant CG as --cleanup-guards

    R->>GA: process offline storage mountpoint
    GA->>GA: attempt bind-mount guard
    alt bind-mount succeeds
        GA-->>R: bind-mount guard active
    else bind-mount fails → chattr fallback
        GA->>GA: chattr +i guardTarget
        GA->>IDX: recordImmutableGuardTarget(target)
        IDX->>IDX: atomic write (temp+rename, 0o600)
    end

    Note over R,IDX: Later, after storage is back online

    CG->>IDX: clearImmutableGuards: read index
    loop each recorded target
        CG->>CG: isConfirmableDatastoreMountRoot(target)?
        CG->>CG: isMounted(target)?
        alt currently mounted
            CG-->>CG: skip (pending++), keep index
        else not mounted
            CG->>CG: EvalSymlinks(target) → resolved
            CG->>CG: isConfirmableDatastoreMountRoot(resolved)?
            CG->>CG: chattr -i resolved
        end
    end
    alt "pending == 0 and no bind-mount guards"
        CG->>IDX: RemoveAll(mountGuardBaseDir)
    else "pending > 0"
        CG-->>CG: keep index for next run
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant R as Restore
    participant GA as Guard Apply (PBS/PVE)
    participant IDX as chattr-targets index
    participant CG as --cleanup-guards

    R->>GA: process offline storage mountpoint
    GA->>GA: attempt bind-mount guard
    alt bind-mount succeeds
        GA-->>R: bind-mount guard active
    else bind-mount fails → chattr fallback
        GA->>GA: chattr +i guardTarget
        GA->>IDX: recordImmutableGuardTarget(target)
        IDX->>IDX: atomic write (temp+rename, 0o600)
    end

    Note over R,IDX: Later, after storage is back online

    CG->>IDX: clearImmutableGuards: read index
    loop each recorded target
        CG->>CG: isConfirmableDatastoreMountRoot(target)?
        CG->>CG: isMounted(target)?
        alt currently mounted
            CG-->>CG: skip (pending++), keep index
        else not mounted
            CG->>CG: EvalSymlinks(target) → resolved
            CG->>CG: isConfirmableDatastoreMountRoot(resolved)?
            CG->>CG: chattr -i resolved
        end
    end
    alt "pending == 0 and no bind-mount guards"
        CG->>IDX: RemoveAll(mountGuardBaseDir)
    else "pending > 0"
        CG-->>CG: keep index for next run
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/orchestrator/guards_cleanup.go`, line 287-320 ([link](https://github.com/tis24dev/proxsave/blob/8df35dbda07eb8b700694f9a22cb9fbccd88feb4/internal/orchestrator/guards_cleanup.go#L287-L320)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Resolved-path mount status not re-checked after symlink resolution**

   The `isMounted(target)` guard at line 261 checks the *original* (possibly symlink) path. After `cleanupResolveTarget` returns a different `resolved` path, the code runs `chattr -i resolved` without verifying that `resolved` is also not currently mounted. On Linux, `mount` follows symlinks: if `/mnt/pve/store` is a symlink to `/mnt/actual-store`, mounting storage there records `/mnt/actual-store` in mountinfo, so `isMounted("/mnt/pve/store")` returns `false` even though the storage is live. The subsequent `chattr -i /mnt/actual-store` would then act on the live mount's top-level inode rather than the shadowed underlying directory — exactly the scenario `isMounted` was added to prevent.

   Proxmox itself does not create symlinks for storage mountpoints, so this is not triggered in normal usage, but the defensive-programming rationale used elsewhere in this function applies equally here. Adding an `isMounted(resolved)` check (with the same skip-and-pending logic) would close the gap.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fguards_cleanup.go%0ALine%3A%20287-320%0A%0AComment%3A%0A**Resolved-path%20mount%20status%20not%20re-checked%20after%20symlink%20resolution**%0A%0AThe%20%60isMounted%28target%29%60%20guard%20at%20line%20261%20checks%20the%20*original*%20%28possibly%20symlink%29%20path.%20After%20%60cleanupResolveTarget%60%20returns%20a%20different%20%60resolved%60%20path%2C%20the%20code%20runs%20%60chattr%20-i%20resolved%60%20without%20verifying%20that%20%60resolved%60%20is%20also%20not%20currently%20mounted.%20On%20Linux%2C%20%60mount%60%20follows%20symlinks%3A%20if%20%60%2Fmnt%2Fpve%2Fstore%60%20is%20a%20symlink%20to%20%60%2Fmnt%2Factual-store%60%2C%20mounting%20storage%20there%20records%20%60%2Fmnt%2Factual-store%60%20in%20mountinfo%2C%20so%20%60isMounted%28%22%2Fmnt%2Fpve%2Fstore%22%29%60%20returns%20%60false%60%20even%20though%20the%20storage%20is%20live.%20The%20subsequent%20%60chattr%20-i%20%2Fmnt%2Factual-store%60%20would%20then%20act%20on%20the%20live%20mount's%20top-level%20inode%20rather%20than%20the%20shadowed%20underlying%20directory%20%E2%80%94%20exactly%20the%20scenario%20%60isMounted%60%20was%20added%20to%20prevent.%0A%0AProxmox%20itself%20does%20not%20create%20symlinks%20for%20storage%20mountpoints%2C%20so%20this%20is%20not%20triggered%20in%20normal%20usage%2C%20but%20the%20defensive-programming%20rationale%20used%20elsewhere%20in%20this%20function%20applies%20equally%20here.%20Adding%20an%20%60isMounted%28resolved%29%60%20check%20%28with%20the%20same%20skip-and-pending%20logic%29%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fguards_cleanup.go%0ALine%3A%20287-320%0A%0AComment%3A%0A**Resolved-path%20mount%20status%20not%20re-checked%20after%20symlink%20resolution**%0A%0AThe%20%60isMounted%28target%29%60%20guard%20at%20line%20261%20checks%20the%20*original*%20%28possibly%20symlink%29%20path.%20After%20%60cleanupResolveTarget%60%20returns%20a%20different%20%60resolved%60%20path%2C%20the%20code%20runs%20%60chattr%20-i%20resolved%60%20without%20verifying%20that%20%60resolved%60%20is%20also%20not%20currently%20mounted.%20On%20Linux%2C%20%60mount%60%20follows%20symlinks%3A%20if%20%60%2Fmnt%2Fpve%2Fstore%60%20is%20a%20symlink%20to%20%60%2Fmnt%2Factual-store%60%2C%20mounting%20storage%20there%20records%20%60%2Fmnt%2Factual-store%60%20in%20mountinfo%2C%20so%20%60isMounted%28%22%2Fmnt%2Fpve%2Fstore%22%29%60%20returns%20%60false%60%20even%20though%20the%20storage%20is%20live.%20The%20subsequent%20%60chattr%20-i%20%2Fmnt%2Factual-store%60%20would%20then%20act%20on%20the%20live%20mount's%20top-level%20inode%20rather%20than%20the%20shadowed%20underlying%20directory%20%E2%80%94%20exactly%20the%20scenario%20%60isMounted%60%20was%20added%20to%20prevent.%0A%0AProxmox%20itself%20does%20not%20create%20symlinks%20for%20storage%20mountpoints%2C%20so%20this%20is%20not%20triggered%20in%20normal%20usage%2C%20but%20the%20defensive-programming%20rationale%20used%20elsewhere%20in%20this%20function%20applies%20equally%20here.%20Adding%20an%20%60isMounted%28resolved%29%60%20check%20%28with%20the%20same%20skip-and-pending%20logic%29%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Fproxsave%22%20on%20the%20existing%20branch%20%22fix%2Fcleanup-guards-clear-immutable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcleanup-guards-clear-immutable%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fguards_cleanup.go%0ALine%3A%20287-320%0A%0AComment%3A%0A**Resolved-path%20mount%20status%20not%20re-checked%20after%20symlink%20resolution**%0A%0AThe%20%60isMounted%28target%29%60%20guard%20at%20line%20261%20checks%20the%20*original*%20%28possibly%20symlink%29%20path.%20After%20%60cleanupResolveTarget%60%20returns%20a%20different%20%60resolved%60%20path%2C%20the%20code%20runs%20%60chattr%20-i%20resolved%60%20without%20verifying%20that%20%60resolved%60%20is%20also%20not%20currently%20mounted.%20On%20Linux%2C%20%60mount%60%20follows%20symlinks%3A%20if%20%60%2Fmnt%2Fpve%2Fstore%60%20is%20a%20symlink%20to%20%60%2Fmnt%2Factual-store%60%2C%20mounting%20storage%20there%20records%20%60%2Fmnt%2Factual-store%60%20in%20mountinfo%2C%20so%20%60isMounted%28%22%2Fmnt%2Fpve%2Fstore%22%29%60%20returns%20%60false%60%20even%20though%20the%20storage%20is%20live.%20The%20subsequent%20%60chattr%20-i%20%2Fmnt%2Factual-store%60%20would%20then%20act%20on%20the%20live%20mount's%20top-level%20inode%20rather%20than%20the%20shadowed%20underlying%20directory%20%E2%80%94%20exactly%20the%20scenario%20%60isMounted%60%20was%20added%20to%20prevent.%0A%0AProxmox%20itself%20does%20not%20create%20symlinks%20for%20storage%20mountpoints%2C%20so%20this%20is%20not%20triggered%20in%20normal%20usage%2C%20but%20the%20defensive-programming%20rationale%20used%20elsewhere%20in%20this%20function%20applies%20equally%20here.%20Adding%20an%20%60isMounted%28resolved%29%60%20check%20%28with%20the%20same%20skip-and-pending%20logic%29%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `internal/orchestrator/mount_guard_chattr_index.go`, line 497-517 ([link](https://github.com/tis24dev/proxsave/blob/8df35dbda07eb8b700694f9a22cb9fbccd88feb4/internal/orchestrator/mount_guard_chattr_index.go#L497-L517)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Index durability: no `fsync` before rename**

   `writeImmutableGuardIndex` writes to a temp file and atomically renames it, but never calls `tmp.Sync()`. If the kernel crashes or loses power between the rename completing and the OS flushing dirty pages, the renamed file can be empty or contain zeros — the guard directory would exist but the index would be unreadable, silently returning 0 targets on the next `--cleanup-guards` run. The PR documentation correctly calls this "best-effort", and the failure mode (manual `chattr -i` required) is the same as the pre-PR situation, so the trade-off is reasonable. Calling `tmp.Sync()` after the last `Write` and before `Close` would eliminate the gap at the cost of an extra fdatasync.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fmount_guard_chattr_index.go%0ALine%3A%20497-517%0A%0AComment%3A%0A**Index%20durability%3A%20no%20%60fsync%60%20before%20rename**%0A%0A%60writeImmutableGuardIndex%60%20writes%20to%20a%20temp%20file%20and%20atomically%20renames%20it%2C%20but%20never%20calls%20%60tmp.Sync%28%29%60.%20If%20the%20kernel%20crashes%20or%20loses%20power%20between%20the%20rename%20completing%20and%20the%20OS%20flushing%20dirty%20pages%2C%20the%20renamed%20file%20can%20be%20empty%20or%20contain%20zeros%20%E2%80%94%20the%20guard%20directory%20would%20exist%20but%20the%20index%20would%20be%20unreadable%2C%20silently%20returning%200%20targets%20on%20the%20next%20%60--cleanup-guards%60%20run.%20The%20PR%20documentation%20correctly%20calls%20this%20%22best-effort%22%2C%20and%20the%20failure%20mode%20%28manual%20%60chattr%20-i%60%20required%29%20is%20the%20same%20as%20the%20pre-PR%20situation%2C%20so%20the%20trade-off%20is%20reasonable.%20Calling%20%60tmp.Sync%28%29%60%20after%20the%20last%20%60Write%60%20and%20before%20%60Close%60%20would%20eliminate%20the%20gap%20at%20the%20cost%20of%20an%20extra%20fdatasync.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fmount_guard_chattr_index.go%0ALine%3A%20497-517%0A%0AComment%3A%0A**Index%20durability%3A%20no%20%60fsync%60%20before%20rename**%0A%0A%60writeImmutableGuardIndex%60%20writes%20to%20a%20temp%20file%20and%20atomically%20renames%20it%2C%20but%20never%20calls%20%60tmp.Sync%28%29%60.%20If%20the%20kernel%20crashes%20or%20loses%20power%20between%20the%20rename%20completing%20and%20the%20OS%20flushing%20dirty%20pages%2C%20the%20renamed%20file%20can%20be%20empty%20or%20contain%20zeros%20%E2%80%94%20the%20guard%20directory%20would%20exist%20but%20the%20index%20would%20be%20unreadable%2C%20silently%20returning%200%20targets%20on%20the%20next%20%60--cleanup-guards%60%20run.%20The%20PR%20documentation%20correctly%20calls%20this%20%22best-effort%22%2C%20and%20the%20failure%20mode%20%28manual%20%60chattr%20-i%60%20required%29%20is%20the%20same%20as%20the%20pre-PR%20situation%2C%20so%20the%20trade-off%20is%20reasonable.%20Calling%20%60tmp.Sync%28%29%60%20after%20the%20last%20%60Write%60%20and%20before%20%60Close%60%20would%20eliminate%20the%20gap%20at%20the%20cost%20of%20an%20extra%20fdatasync.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Fproxsave%22%20on%20the%20existing%20branch%20%22fix%2Fcleanup-guards-clear-immutable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcleanup-guards-clear-immutable%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fmount_guard_chattr_index.go%0ALine%3A%20497-517%0A%0AComment%3A%0A**Index%20durability%3A%20no%20%60fsync%60%20before%20rename**%0A%0A%60writeImmutableGuardIndex%60%20writes%20to%20a%20temp%20file%20and%20atomically%20renames%20it%2C%20but%20never%20calls%20%60tmp.Sync%28%29%60.%20If%20the%20kernel%20crashes%20or%20loses%20power%20between%20the%20rename%20completing%20and%20the%20OS%20flushing%20dirty%20pages%2C%20the%20renamed%20file%20can%20be%20empty%20or%20contain%20zeros%20%E2%80%94%20the%20guard%20directory%20would%20exist%20but%20the%20index%20would%20be%20unreadable%2C%20silently%20returning%200%20targets%20on%20the%20next%20%60--cleanup-guards%60%20run.%20The%20PR%20documentation%20correctly%20calls%20this%20%22best-effort%22%2C%20and%20the%20failure%20mode%20%28manual%20%60chattr%20-i%60%20required%29%20is%20the%20same%20as%20the%20pre-PR%20situation%2C%20so%20the%20trade-off%20is%20reasonable.%20Calling%20%60tmp.Sync%28%29%60%20after%20the%20last%20%60Write%60%20and%20before%20%60Close%60%20would%20eliminate%20the%20gap%20at%20the%20cost%20of%20an%20extra%20fdatasync.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(orchestrator): resolve gosec G301/G3..."](https://github.com/tis24dev/proxsave/commit/cf646b832818222421a59852db011aa42f0da2c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39572851)</sub>

<!-- /greptile_comment -->