### PR TITLE
Release v0.27.0

### DIFF
--- a/cmd/proxsave/main_profiling_test.go
+++ b/cmd/proxsave/main_profiling_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/config"
+)
+
+func setProfileBaseDir(t *testing.T, v string) {
+	t.Helper()
+	orig := profileBaseDir
+	profileBaseDir = v
+	t.Cleanup(func() { profileBaseDir = orig })
+}
+
+func TestBuildProfileDir(t *testing.T) {
+	base := t.TempDir()
+	setProfileBaseDir(t, base)
+	got := buildProfileDir()
+	want := filepath.Join(base, "proxsave")
+	if got != want {
+		t.Fatalf("buildProfileDir = %q; want %q", got, want)
+	}
+	if fi, err := os.Stat(got); err != nil || !fi.IsDir() {
+		t.Fatalf("profile dir not created: stat err = %v", err)
+	}
+
+	// MkdirAll failure (base is a regular file) -> "" so the caller skips profiling.
+	fileBase := filepath.Join(t.TempDir(), "iamafile")
+	if err := os.WriteFile(fileBase, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	setProfileBaseDir(t, fileBase)
+	if got := buildProfileDir(); got != "" {
+		t.Fatalf("buildProfileDir on a non-dir base = %q; want \"\"", got)
+	}
+}
+
+// initializeRunProfiling must write BOTH profiles under <profileBaseDir>/proxsave
+// and NOTHING under LOG_PATH (issue #242: LOG_PATH may be a dead/stale mount).
+func TestInitializeRunProfiling_WritesOffLogPath(t *testing.T) {
+	base := t.TempDir()
+	logDir := t.TempDir()
+	setProfileBaseDir(t, base)
+
+	rt := &appRuntime{
+		cfg:          &config.Config{ProfilingEnabled: true, LogPath: logDir},
+		hostname:     "host",
+		timestampStr: "ts",
+	}
+	initializeRunProfiling(rt)
+	// Always stop the (process-global) profiler, even if an assertion fails.
+	t.Cleanup(func() {
+		if rt.cpuProfileFile != nil {
+			pprof.StopCPUProfile()
+			_ = rt.cpuProfileFile.Close()
+		}
+	})
+
+	if rt.cpuProfileFile == nil {
+		t.Fatal("profiling should be enabled (cpuProfileFile is nil)")
+	}
+	wantDir := filepath.Join(base, "proxsave")
+	if cpus, _ := filepath.Glob(filepath.Join(wantDir, "cpu-*.pprof")); len(cpus) != 1 {
+		t.Fatalf("want 1 cpu profile under %s, got %v", wantDir, cpus)
+	}
+	if dir := filepath.Dir(rt.heapProfilePath); dir != wantDir {
+		t.Fatalf("heapProfilePath dir = %s; want %s", dir, wantDir)
+	}
+	if leaked, _ := filepath.Glob(filepath.Join(logDir, "*.pprof")); len(leaked) != 0 {
+		t.Fatalf("no profile may be written under LOG_PATH, got %v", leaked)
+	}
+}
+
+func TestInitializeRunProfiling_DisabledIsNoOp(t *testing.T) {
+	rt := &appRuntime{
+		cfg:          &config.Config{ProfilingEnabled: false, LogPath: t.TempDir()},
+		hostname:     "host",
+		timestampStr: "ts",
+	}
+	initializeRunProfiling(rt)
+	if rt.cpuProfileFile != nil || rt.heapProfilePath != "" {
+		t.Fatalf("disabled profiling must be a no-op; cpuProfileFile=%v heapProfilePath=%q", rt.cpuProfileFile, rt.heapProfilePath)
+	}
+}

--- a/cmd/proxsave/main_runtime.go
+++ b/cmd/proxsave/main_runtime.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/environment"
 	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/internal/types"
 )
 
@@ -207,7 +208,9 @@ func initializeRunLogFile(rt *appRuntime) {
 
 	logFileName := fmt.Sprintf("backup-%s-%s.log", rt.hostname, rt.timestampStr)
 	logFilePath := filepath.Join(rt.cfg.LogPath, logFileName)
-	if err := os.MkdirAll(rt.cfg.LogPath, defaultDirPerm); err != nil {
+	// Bounded so a dead/stale LOG_PATH mount cannot wedge the run here, before the
+	// security preflight even starts, in an uninterruptible syscall.
+	if err := safefs.MkdirAll(rt.ctx, rt.cfg.LogPath, defaultDirPerm, fsIoTimeoutDuration(rt.cfg)); err != nil {
 		logging.Warning("Failed to create log directory %s: %v", rt.cfg.LogPath, err)
 		return
 	}
@@ -224,7 +227,7 @@ func applyRunPermissions(rt *appRuntime) {
 		return
 	}
 	logging.DebugStep(rt.logger, "main", "applying backup permissions")
-	if err := applyBackupPermissions(rt.cfg, rt.logger); err != nil {
+	if err := applyBackupPermissions(rt.ctx, rt.cfg, rt.logger, rt.dryRun); err != nil {
 		logging.Warning("Failed to apply backup permissions: %v", err)
 	}
 }

--- a/cmd/proxsave/main_runtime.go
+++ b/cmd/proxsave/main_runtime.go
@@ -236,11 +236,21 @@ func applyRunPermissions(rt *appRuntime) {
 	}
 }
 
+// profileBaseDir is the local base dir for pprof artifacts. Both the CPU and heap
+// profiles live under <profileBaseDir>/proxsave, never on LOG_PATH, so a dead/stale
+// LOG_PATH mount cannot wedge the create, the runtime's periodic CPU-sample writes,
+// StopCPUProfile's flush, or Close (issue #242). A var (not const) so tests redirect it.
+var profileBaseDir = "/tmp"
+
 func initializeRunProfiling(rt *appRuntime) {
 	if !rt.cfg.ProfilingEnabled {
 		return
 	}
-	cpuProfilePath := filepath.Join(rt.cfg.LogPath, fmt.Sprintf("cpu-%s-%s.pprof", rt.hostname, rt.timestampStr))
+	profileDir := buildProfileDir()
+	if profileDir == "" {
+		return // could not create the local profile dir; skip profiling (best-effort)
+	}
+	cpuProfilePath := filepath.Join(profileDir, fmt.Sprintf("cpu-%s-%s.pprof", rt.hostname, rt.timestampStr))
 	f, err := os.Create(cpuProfilePath)
 	if err != nil {
 		logging.Warning("Failed to create CPU profile file: %v", err)
@@ -253,16 +263,20 @@ func initializeRunProfiling(rt *appRuntime) {
 	}
 	rt.cpuProfileFile = f
 	logging.Info("CPU profiling enabled: %s", cpuProfilePath)
-	rt.heapProfilePath = buildHeapProfilePath(rt)
+	rt.heapProfilePath = filepath.Join(profileDir, fmt.Sprintf("heap-%s-%s.pprof", rt.hostname, rt.timestampStr))
 }
 
-func buildHeapProfilePath(rt *appRuntime) string {
-	tmpProfileDir := filepath.Join("/tmp", "proxsave")
-	if err := os.MkdirAll(tmpProfileDir, defaultDirPerm); err != nil {
-		logging.Warning("Failed to create temp profile directory %s: %v", tmpProfileDir, err)
+// buildProfileDir creates and returns the local temp directory used for BOTH the cpu
+// and heap pprof output (<profileBaseDir>/proxsave). It is intentionally OFF LOG_PATH
+// so a dead/stale LOG_PATH mount can never wedge profiling I/O. Returns "" (after a
+// warning) if the directory cannot be created, signalling the caller to skip profiling.
+func buildProfileDir() string {
+	profileDir := filepath.Join(profileBaseDir, "proxsave")
+	if err := os.MkdirAll(profileDir, defaultDirPerm); err != nil {
+		logging.Warning("Failed to create temp profile directory %s: %v", profileDir, err)
 		return ""
 	}
-	return filepath.Join(tmpProfileDir, fmt.Sprintf("heap-%s-%s.pprof", rt.hostname, rt.timestampStr))
+	return profileDir
 }
 
 // checkGoRuntimeVersion ensures the running binary was built with at least the specified Go version (semver: major.minor.patch).

--- a/cmd/proxsave/main_runtime.go
+++ b/cmd/proxsave/main_runtime.go
@@ -66,6 +66,12 @@ func bootstrapRuntime(ctx context.Context, args *cli.Args, bootstrap *logging.Bo
 	rt.initialEnvBaseDir = initialEnvBaseDir
 	rt.autoBaseDirFound = autoFound
 	rt.dryRun = args.DryRun || cfg.DryRun
+	// Make the effective dry-run (CLI flag OR config) visible to every cfg.DryRun
+	// consumer, including the security preflight. Without this, a --dry-run *flag*
+	// run would still let the preflight create directories / mutate the filesystem
+	// because cfg.DryRun only reflects the DRY_RUN config key. This only ever adds
+	// the flag's effect (rt.dryRun already ORs in cfg.DryRun).
+	rt.cfg.DryRun = rt.dryRun
 
 	if exitCode, ok := validateRunConfig(rt); !ok {
 		return nil, exitCode, false

--- a/cmd/proxsave/main_runtime.go
+++ b/cmd/proxsave/main_runtime.go
@@ -214,6 +214,10 @@ func initializeRunLogFile(rt *appRuntime) {
 		logging.Warning("Failed to create log directory %s: %v", rt.cfg.LogPath, err)
 		return
 	}
+	// Bound the log-file open/write/close on the run logger so a dead/stale LOG_PATH
+	// mount cannot wedge the run (the open here, or any later O_SYNC write under the
+	// logger mutex). Session loggers (local /tmp) keep the unbounded default.
+	rt.logger.SetIOTimeout(fsIoTimeoutDuration(rt.cfg))
 	if err := rt.logger.OpenLogFile(logFilePath); err != nil {
 		logging.Warning("Failed to open log file %s: %v", logFilePath, err)
 		return

--- a/cmd/proxsave/permissions.go
+++ b/cmd/proxsave/permissions.go
@@ -2,19 +2,32 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/user"
-	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/internal/security"
 	"github.com/tis24dev/proxsave/internal/storage"
 	"github.com/tis24dev/proxsave/internal/types"
 )
+
+// fsIoTimeoutDuration converts the configured FS_IO_TIMEOUT into a per-operation
+// duration for safefs. A non-positive value (the explicit FS_IO_TIMEOUT=0 opt-out)
+// yields 0, which safefs treats as unbounded; the config default is 30s.
+func fsIoTimeoutDuration(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.FsIoTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.FsIoTimeoutSeconds) * time.Second
+}
 
 // applyBackupPermissions applies ownership and basic directory permissions to
 // backup and log paths when SET_BACKUP_PERMISSIONS=true is configured.
@@ -23,7 +36,7 @@ import (
 //   - It never creates users or groups (unlike the legacy Bash scripts).
 //   - It only touches backup/log paths (not binaries/config files).
 //   - Failures are logged as warnings but do not abort the backup.
-func applyBackupPermissions(cfg *config.Config, logger *logging.Logger) error {
+func applyBackupPermissions(ctx context.Context, cfg *config.Config, logger *logging.Logger, dryRun bool) error {
 	backupUser := strings.TrimSpace(cfg.BackupUser)
 	backupGroup := strings.TrimSpace(cfg.BackupGroup)
 	if backupUser == "" || backupGroup == "" {
@@ -40,6 +53,8 @@ func applyBackupPermissions(cfg *config.Config, logger *logging.Logger) error {
 
 	logger.Info("Applying backup permissions (SET_BACKUP_PERMISSIONS=true) for user:group %s:%s", backupUser, backupGroup)
 
+	timeout := fsIoTimeoutDuration(cfg)
+
 	dirs := []string{
 		strings.TrimSpace(cfg.BackupPath),
 		strings.TrimSpace(cfg.LogPath),
@@ -47,7 +62,13 @@ func applyBackupPermissions(cfg *config.Config, logger *logging.Logger) error {
 		strings.TrimSpace(cfg.SecondaryLogPath),
 	}
 
-	fsDetector := storage.NewFilesystemDetector(logger)
+	// Bounded + dry-run-aware detector (parity with the security preflight): a
+	// dead/stale mount must not wedge detection, and a dry run must not write the
+	// network-FS ownership probe file.
+	fsDetector := storage.NewFilesystemDetector(logger,
+		storage.WithIOTimeout(timeout),
+		storage.WithDryRun(dryRun),
+	)
 
 	for _, dir := range dirs {
 		dir = strings.TrimSpace(dir)
@@ -59,13 +80,16 @@ func applyBackupPermissions(cfg *config.Config, logger *logging.Logger) error {
 			continue
 		}
 
-		info, err := os.Stat(dir)
+		info, err := safefs.Stat(ctx, dir, timeout)
 		if err != nil {
-			if os.IsNotExist(err) {
+			switch {
+			case errors.Is(err, safefs.ErrTimeout):
+				logger.Warning("Permissions: stat of %s timed out after %s; skipping (dead/stale mount?)", dir, timeout)
+			case os.IsNotExist(err):
 				logger.Skip("Permissions: directory does not exist: %s", dir)
-				continue
+			default:
+				logger.Warning("Permissions: failed to stat %s (skipping): %v", dir, err)
 			}
-			logger.Warning("Permissions: failed to stat %s (skipping): %v", dir, err)
 			continue
 		}
 		if !info.IsDir() {
@@ -73,9 +97,13 @@ func applyBackupPermissions(cfg *config.Config, logger *logging.Logger) error {
 			continue
 		}
 
-		fsInfo, err := fsDetector.DetectFilesystem(context.Background(), dir)
+		fsInfo, err := fsDetector.DetectFilesystem(ctx, dir)
 		if err != nil {
-			logger.Warning("Permissions: failed to detect filesystem for %s; skipping chown/chmod: %v", dir, err)
+			if errors.Is(err, safefs.ErrTimeout) {
+				logger.Warning("Permissions: filesystem detection on %s timed out after %s; skipping chown/chmod (dead/stale mount?)", dir, timeout)
+			} else {
+				logger.Warning("Permissions: failed to detect filesystem for %s; skipping chown/chmod: %v", dir, err)
+			}
 			continue
 		}
 		if fsInfo.Type.ShouldAutoExclude() || !fsInfo.SupportsOwnership {
@@ -84,7 +112,7 @@ func applyBackupPermissions(cfg *config.Config, logger *logging.Logger) error {
 		}
 
 		logger.Debug("Applying permissions on path: %s (uid=%d,gid=%d)", dir, uid, gid)
-		if err := applyDirOwnershipRecursive(dir, uid, gid, logger); err != nil {
+		if err := applyDirOwnershipRecursive(ctx, dir, uid, gid, timeout, dryRun, logger); err != nil {
 			logger.Warning("Failed to apply permissions on %s: %v", dir, err)
 		}
 	}
@@ -115,49 +143,54 @@ func resolveUserGroupIDs(userName, groupName string) (int, int, error) {
 // applyDirOwnershipRecursive walks a directory tree and applies chown to all
 // entries, and a conservative chmod (0750) on directories only. This matches
 // the intent of the Bash version but avoids touching unrelated system paths.
-func applyDirOwnershipRecursive(root string, uid, gid int, logger *logging.Logger) error {
-	info, err := os.Stat(root)
-	if err != nil {
-		return fmt.Errorf("cannot stat %s: %w", root, err)
-	}
-	if !info.IsDir() {
+//
+// The walk uses safefs.WalkBounded so the directory reads themselves are bounded
+// by FS_IO_TIMEOUT (filepath.WalkDir's internal readdir/lstat would otherwise
+// block forever in an uninterruptible syscall on a dead/stale mount). In dry-run
+// it mutates nothing, matching the read-only dry-run security preflight.
+func applyDirOwnershipRecursive(ctx context.Context, root string, uid, gid int, timeout time.Duration, dryRun bool, logger *logging.Logger) error {
+	if dryRun {
+		logger.Info("DRY RUN: would recursively set ownership %d:%d and 0750 directory perms on %s", uid, gid, root)
 		return nil
 	}
 
 	logger.Debug("Walking directory tree for permissions: %s (uid=%d,gid=%d)", root, uid, gid)
 
-	return filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
-		return applyOwnershipWalkEntry(path, d, walkErr, uid, gid, logger)
+	return safefs.WalkBounded(ctx, root, timeout, func(path string, d fs.DirEntry, walkErr error) error {
+		return applyOwnershipWalkEntry(ctx, path, d, walkErr, uid, gid, timeout, logger)
 	})
 }
 
-// applyOwnershipWalkEntry applies ownership/permissions to a single walked entry.
-// A traversal error (walkErr) is logged and SKIPPED (return nil) rather than
-// propagated: returning it would abort filepath.WalkDir, leaving every not-yet-
-// visited entry with its old ownership. One unreadable subtree must not block
-// fixing the rest of the backup tree.
-func applyOwnershipWalkEntry(path string, d os.DirEntry, walkErr error, uid, gid int, logger *logging.Logger) error {
+// applyOwnershipWalkEntry applies bounded ownership/permissions to a single walked
+// entry. A traversal error (walkErr, including a per-directory ErrTimeout from the
+// bounded walk) is logged and SKIPPED (return nil) rather than propagated:
+// returning it would abort the walk, leaving every not-yet-visited entry with its
+// old ownership. One unreadable/stale subtree must not block fixing the rest of
+// the backup tree.
+func applyOwnershipWalkEntry(ctx context.Context, path string, d fs.DirEntry, walkErr error, uid, gid int, timeout time.Duration, logger *logging.Logger) error {
 	if walkErr != nil {
 		logger.Debug("permission walk: skipping %s: %v", path, walkErr)
 		return nil
 	}
 
-	if err := os.Chown(path, uid, gid); err != nil {
-		// Do not stop on chown errors; just log at debug level.
+	// Lchown (not Chown): bounded, and never follows a symlink to chown a target
+	// outside the backup tree (the walk itself never descends symlinks). For
+	// regular files and directories it is identical to chown.
+	if err := safefs.Lchown(ctx, path, uid, gid, timeout); err != nil {
+		// Do not stop on chown errors (including timeouts); just log at debug level.
 		logger.Debug("chown failed on %s: %v", path, err)
 	}
 
-	if d.IsDir() {
+	if d != nil && d.IsDir() {
 		// Directories must keep the execute bit to stay traversable, so gosec's G302
 		// default ceiling (<=0600, which is appropriate for files) does not fit here.
 		// 0750 = rwxr-x--- grants access to the owner and the backup group - both set
-		// by the os.Chown above to backupUser:backupGroup, which is the whole point of
+		// by the Lchown above to backupUser:backupGroup, which is the whole point of
 		// SET_BACKUP_PERMISSIONS - while denying "others" entirely. Tightening to
 		// <=0700 would silently remove backup-group access; <=0600 would make the
-		// directory non-traversable. There is no stricter value that preserves the
-		// feature, so the broad-but-intentional mode is annotated rather than changed.
-		// #nosec G302 -- intentional 0750 on a chowned backup directory; others have no access.
-		if err := os.Chmod(path, 0o750); err != nil {
+		// directory non-traversable. Routing the chmod through safefs.Chmod (variable
+		// mode) both bounds the call and structurally avoids the G302 finding.
+		if err := safefs.Chmod(ctx, path, 0o750, timeout); err != nil {
 			logger.Debug("chmod failed on %s: %v", path, err)
 		}
 	}
@@ -227,7 +260,9 @@ func fixPermissionsAfterInstall(ctx context.Context, configPath, baseDir string,
 		if bootstrap != nil {
 			bootstrap.Info("Finalizing installation: applying backup directory permissions")
 		}
-		if err := applyBackupPermissions(cfg, logger); err != nil {
+		// Install/upgrade finalization always mutates (dryRun=false); it exists to
+		// leave the environment consistent and has no dry-run mode of its own.
+		if err := applyBackupPermissions(ctx, cfg, logger, false); err != nil {
 			if bootstrap != nil {
 				bootstrap.Warning("Post-install: backup permission adjustment failed (ignored): %v", err)
 			}

--- a/cmd/proxsave/permissions_test.go
+++ b/cmd/proxsave/permissions_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/user"
@@ -40,7 +41,7 @@ func TestApplyBackupPermissionsSkipsMissingDirectories(t *testing.T) {
 	logger := logging.New(types.LogLevelDebug, false)
 	logger.SetOutput(&buf)
 
-	if err := applyBackupPermissions(cfg, logger); err != nil {
+	if err := applyBackupPermissions(context.Background(), cfg, logger, false); err != nil {
 		t.Fatalf("applyBackupPermissions returned error: %v", err)
 	}
 
@@ -84,7 +85,7 @@ func TestApplyBackupPermissionsSkipsNonDirectoryPaths(t *testing.T) {
 	logger := logging.New(types.LogLevelDebug, false)
 	logger.SetOutput(&buf)
 
-	if err := applyBackupPermissions(cfg, logger); err != nil {
+	if err := applyBackupPermissions(context.Background(), cfg, logger, false); err != nil {
 		t.Fatalf("applyBackupPermissions returned error: %v", err)
 	}
 

--- a/cmd/proxsave/permissions_timeout_test.go
+++ b/cmd/proxsave/permissions_timeout_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func currentUserGroup(t *testing.T) (string, string) {
+	t.Helper()
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current: %v", err)
+	}
+	g, err := user.LookupGroupId(u.Gid)
+	if err != nil {
+		t.Fatalf("LookupGroupId: %v", err)
+	}
+	return u.Username, g.Name
+}
+
+func bufLogger() (*logging.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	l := logging.New(types.LogLevelDebug, false)
+	l.SetOutput(buf)
+	return l, buf
+}
+
+func expiredCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestApplyBackupPermissionsHealthyAppliesChmod confirms the bounded walk still
+// applies 0750 to directories on a responsive filesystem.
+func TestApplyBackupPermissionsHealthyAppliesChmod(t *testing.T) {
+	usr, grp := currentUserGroup(t)
+	base := t.TempDir()
+	sub := filepath.Join(base, "sub")
+	if err := os.Mkdir(sub, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := &config.Config{BackupUser: usr, BackupGroup: grp, BackupPath: base, FsIoTimeoutSeconds: 30}
+	logger, _ := bufLogger()
+
+	if err := applyBackupPermissions(context.Background(), cfg, logger, false); err != nil {
+		t.Fatalf("applyBackupPermissions: %v", err)
+	}
+
+	info, err := os.Stat(sub)
+	if err != nil {
+		t.Fatalf("stat sub: %v", err)
+	}
+	if info.Mode().Perm() != 0o750 {
+		t.Fatalf("healthy walk should chmod dir to 0750; got %o", info.Mode().Perm())
+	}
+}
+
+// TestApplyBackupPermissionsDryRunNoMutation confirms a dry-run mutates nothing.
+func TestApplyBackupPermissionsDryRunNoMutation(t *testing.T) {
+	usr, grp := currentUserGroup(t)
+	base := t.TempDir()
+	sub := filepath.Join(base, "sub")
+	if err := os.Mkdir(sub, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := &config.Config{BackupUser: usr, BackupGroup: grp, BackupPath: base, FsIoTimeoutSeconds: 30}
+	logger, buf := bufLogger()
+
+	if err := applyBackupPermissions(context.Background(), cfg, logger, true); err != nil {
+		t.Fatalf("applyBackupPermissions: %v", err)
+	}
+
+	info, err := os.Stat(sub)
+	if err != nil {
+		t.Fatalf("stat sub: %v", err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("dry-run must not chmod; got %o, want 700", info.Mode().Perm())
+	}
+	if !strings.Contains(buf.String(), "DRY RUN: would recursively set ownership") {
+		t.Fatalf("expected dry-run log, got:\n%s", buf.String())
+	}
+}
+
+// TestApplyBackupPermissionsTimeoutIsBestEffort confirms a timed-out (dead/stale)
+// path is skipped with a warning, without hanging or erroring.
+func TestApplyBackupPermissionsTimeoutIsBestEffort(t *testing.T) {
+	usr, grp := currentUserGroup(t)
+	base := t.TempDir()
+	cfg := &config.Config{BackupUser: usr, BackupGroup: grp, BackupPath: base, FsIoTimeoutSeconds: 30}
+	logger, buf := bufLogger()
+
+	if err := applyBackupPermissions(expiredCtx(t), cfg, logger, false); err != nil {
+		t.Fatalf("applyBackupPermissions must be best-effort (nil), got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "timed out") {
+		t.Fatalf("expected a timeout warning, got:\n%s", buf.String())
+	}
+}

--- a/cmd/proxsave/permissions_walk_audited_test.go
+++ b/cmd/proxsave/permissions_walk_audited_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -27,7 +28,7 @@ func permWalkTestLogger() *logging.Logger {
 func TestApplyOwnershipWalkEntry_TraversalErrorIsSkippedNotAborted(t *testing.T) {
 	// A non-nil walkErr (with a nil DirEntry, as WalkDir passes on read failures)
 	// must return nil so the walk continues to the rest of the tree.
-	if err := applyOwnershipWalkEntry("/some/unreadable/subdir", nil, errors.New("permission denied"), 0, 0, permWalkTestLogger()); err != nil {
+	if err := applyOwnershipWalkEntry(context.Background(), "/some/unreadable/subdir", nil, errors.New("permission denied"), 0, 0, 0, permWalkTestLogger()); err != nil {
 		t.Fatalf("a traversal error must be skipped (return nil) so the walk continues, got %v", err)
 	}
 }
@@ -44,7 +45,7 @@ func TestApplyOwnershipWalkEntry_NormalEntryReturnsNil(t *testing.T) {
 	}
 
 	// chown to our own uid/gid is a harmless no-op; the entry must process cleanly.
-	if err := applyOwnershipWalkEntry(file, entries[0], nil, os.Getuid(), os.Getgid(), permWalkTestLogger()); err != nil {
+	if err := applyOwnershipWalkEntry(context.Background(), file, entries[0], nil, os.Getuid(), os.Getgid(), 0, permWalkTestLogger()); err != nil {
 		t.Fatalf("a normal entry must return nil, got %v", err)
 	}
 }

--- a/docs/BACKUP_ENV_MAPPING.md
+++ b/docs/BACKUP_ENV_MAPPING.md
@@ -89,7 +89,7 @@ WEBHOOK_TIMEOUT           = SAME
 
 SYSTEM_ROOT_PREFIX = NEW (Go-only) → Override system root for collection (testing/chroot). Empty or "/" uses the real root.
 PVESH_TIMEOUT = NEW (Go-only) → Timeout (seconds) for each `pvesh` command execution (0=disabled).
-FS_IO_TIMEOUT = NEW (Go-only) → Timeout (seconds) for filesystem probes (stat/readdir/statfs) on storages (0=disabled). Helps avoid hangs on unreachable network mounts.
+FS_IO_TIMEOUT = NEW (Go-only) → Per-operation timeout (seconds) for filesystem syscalls (stat/readdir/open/read/write/close/glob/copy/hash) across the preflight, logging, storage, cloud and restore paths (0=disabled). Prevents hangs on dead/unreachable mounts.
 NOTE: PBS restore behavior is selected interactively during `--restore` and is intentionally not configured via `backup.env`.
 NOTE: There is no dedicated `DUAL_*` environment family. Dual-role hosts are detected automatically and use the same PVE/PBS collector flags in a single run.
 BACKUP_PBS_S3_ENDPOINTS = NEW (Go-only) → Collect `s3.cfg` and S3 endpoint snapshots (PBS).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1044,7 +1044,7 @@ BACKUP_PVE_REPLICATION=true        # VM/CT replication config
 # PVE backup files
 BACKUP_PVE_BACKUP_FILES=true       # Include backup files from /var/lib/vz/dump
 PVESH_TIMEOUT=15                   # Timeout (seconds) for each `pvesh` call (0=disabled)
-FS_IO_TIMEOUT=30                   # Timeout (seconds) for filesystem probes on storages (stat/readdir/statfs). Helps avoid hangs on unreachable network mounts (0=disabled)
+FS_IO_TIMEOUT=30                   # Per-operation timeout (seconds) for filesystem syscalls (stat/readdir/open/read/write/close/glob/copy/hash) across the preflight, logging, storage, cloud and restore paths. Prevents hangs on dead/unreachable mounts (0=disabled)
 BACKUP_SMALL_PVE_BACKUPS=false     # Include small backups only
 MAX_PVE_BACKUP_SIZE=100M           # Max size for "small" backups
 PVE_BACKUP_INCLUDE_PATTERN=        # Glob patterns to include

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,7 +59,7 @@ DEBUG_LEVEL=standard               # standard | advanced | extreme
 DRY_RUN=false                      # true | false
 
 # Enable/disable always-on pprof profiling (CPU + heap)
-PROFILING_ENABLED=true             # true | false (profiles written under LOG_PATH)
+PROFILING_ENABLED=true             # true | false (profiles written under /tmp/proxsave)
 ```
 
 ### DEBUG_LEVEL Details

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1109,7 +1109,7 @@ A: Update your configuration: `proxsave --upgrade-config`
 A: No. Proxsave uses a lock file (`BACKUP_PATH/.backup.lock`) to prevent concurrent runs. The lock stores `pid/host/time`; on the same host, proxsave checks PID liveness to avoid “stuck” locks after an interrupted run.
 
 **Q: Backup hangs during PVE datastore detection when a network storage is unreachable.**
-A: Set `FS_IO_TIMEOUT` to cap how long proxsave waits for filesystem probes (stat/readdir/statfs), and `PVESH_TIMEOUT` to cap `pvesh` calls. This reduces the likelihood of indefinite hangs when a storage becomes unreachable mid-run.
+A: Set `FS_IO_TIMEOUT` to cap how long proxsave waits on any individual filesystem syscall (stat/readdir/open/read/write/close/glob/copy/hash) across the preflight, logging, storage, cloud and restore paths, and `PVESH_TIMEOUT` to cap `pvesh` calls. This reduces the likelihood of indefinite hangs when a storage becomes unreachable mid-run.
 
 **Q: How do I recover from a failed backup?**
 A: Delete the incomplete backup file and re-run. The system automatically handles cleanup.

--- a/internal/backup/checksum.go
+++ b/internal/backup/checksum.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/safefs"
 )
 
 // Manifest represents backup archive metadata with checksums
@@ -66,41 +68,68 @@ func ParseChecksumData(data []byte) (string, error) {
 	return NormalizeChecksum(fields[0])
 }
 
-// GenerateChecksum calculates SHA256 checksum of a file
-func GenerateChecksum(ctx context.Context, logger *logging.Logger, filePath string) (checksum string, err error) {
+// checksumOpen is the file-open seam for the checksum path; tests inject
+// blocking/slow/counting doubles. *os.File satisfies io.ReadCloser.
+var checksumOpen = func(ctx context.Context, path string, timeout time.Duration) (io.ReadCloser, error) {
+	return safefs.Open(ctx, path, timeout)
+}
+
+// GenerateChecksum calculates the SHA256 checksum of a file with NO FS I/O
+// timeout (the FS_IO_TIMEOUT=0 opt-out / legacy behaviour). Prefer
+// GenerateChecksumBounded with the configured FS_IO_TIMEOUT on any path that
+// may touch a removable or network mount.
+func GenerateChecksum(ctx context.Context, logger *logging.Logger, filePath string) (string, error) {
+	return GenerateChecksumBounded(ctx, logger, filePath, 0)
+}
+
+// GenerateChecksumBounded is GenerateChecksum with a per-chunk no-progress
+// (stall) budget on the open, every read+hash chunk, and the close, so a
+// dead/stale mount cannot wedge any of them in an uninterruptible (D-state)
+// syscall. The budget re-arms on every chunk that makes progress, so a healthy
+// large file over a slow-but-alive link still hashes in full. timeout<=0 disables
+// bounding (a plain synchronous read loop, identical to the legacy behaviour).
+// On a stalled read the safefs.CopyBounded worker is abandoned while still
+// holding the fd, so the close is skipped and the *os.File finalizer reclaims the
+// fd once the wedged kernel call returns.
+func GenerateChecksumBounded(ctx context.Context, logger *logging.Logger, filePath string, timeout time.Duration) (checksum string, err error) {
 	logger.Debug("Generating SHA256 checksum for: %s", filePath)
 
-	file, err := os.Open(filePath)
+	// Never open on an already-cancelled context (nothing to leak), and preserve
+	// the unwrapped context error identity callers assert on.
+	if cerr := ctx.Err(); cerr != nil {
+		return "", cerr
+	}
+
+	file, err := checksumOpen(ctx, filePath, timeout)
 	if err != nil {
 		return "", fmt.Errorf("failed to open file: %w", err)
 	}
-	defer closeIntoErr(&err, file, "close checksum source file")
-
-	hash := sha256.New()
-
-	// Copy file to hash in chunks with context checking
-	buf := make([]byte, 32*1024) // 32KB buffer
-	for {
-		// Check context cancellation
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		default:
+	defer func() {
+		// A worker abandoned mid-read may still hold this fd: do not close it
+		// (the close could itself re-wedge on a dead mount). Drop the reference
+		// and let the os.File finalizer reclaim the fd once the call returns.
+		if file == nil || safefs.IsAbandoned(err) {
+			return
 		}
+		// A close that is itself abandoned (ctx cancel / timeout short-circuits
+		// safefs.Run before Close runs) must not clobber an already-computed
+		// checksum: the hash succeeded, the fd is reclaimed by the finalizer.
+		if _, closeErr := safefs.Run(ctx, "close checksum source file", filePath, timeout, func() (struct{}, error) {
+			return struct{}{}, file.Close()
+		}); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) && !safefs.IsAbandoned(closeErr) && err == nil {
+			err = fmt.Errorf("close checksum source file: %w", closeErr)
+		}
+	}()
 
-		n, err := file.Read(buf)
-		if n > 0 {
-			if _, err := hash.Write(buf[:n]); err != nil {
-				return "", fmt.Errorf("failed to write to hash: %w", err)
-			}
+	hash := sha256.New() // fresh per call; never pooled/shared (abandon-safe as CopyBounded dst)
+	// bufSize 0 inherits safefs.CopyBounded's 1 MiB default (the stall floor is
+	// then a few tens of KB/s, harmless for a healthy mount). crypto/sha256.Write
+	// is in-memory and never blocks, so only the file read side can wedge.
+	if _, err = safefs.CopyBounded(ctx, hash, file, 0, timeout, "read checksum source file", filePath); err != nil {
+		if safefs.IsAbandoned(err) {
+			return "", err // ErrTimeout / context.Canceled verbatim (close skipped above)
 		}
-
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return "", fmt.Errorf("failed to read file: %w", err)
-		}
+		return "", fmt.Errorf("failed to read file: %w", err)
 	}
 
 	checksum = hex.EncodeToString(hash.Sum(nil))
@@ -133,8 +162,15 @@ func CreateManifest(ctx context.Context, logger *logging.Logger, manifest *Manif
 	return nil
 }
 
-// VerifyChecksum verifies a file against a manifest's checksum
+// VerifyChecksum verifies a file against a manifest's checksum with NO FS I/O
+// timeout (legacy). Prefer VerifyChecksumBounded on potentially remote/stale paths.
 func VerifyChecksum(ctx context.Context, logger *logging.Logger, filePath, expectedChecksum string) (bool, error) {
+	return VerifyChecksumBounded(ctx, logger, filePath, expectedChecksum, 0)
+}
+
+// VerifyChecksumBounded is VerifyChecksum with a per-chunk FS I/O stall budget
+// (see GenerateChecksumBounded).
+func VerifyChecksumBounded(ctx context.Context, logger *logging.Logger, filePath, expectedChecksum string, timeout time.Duration) (bool, error) {
 	logger.Debug("Verifying checksum for: %s", filePath)
 
 	normalizedExpected, err := NormalizeChecksum(expectedChecksum)
@@ -142,7 +178,7 @@ func VerifyChecksum(ctx context.Context, logger *logging.Logger, filePath, expec
 		return false, fmt.Errorf("invalid expected checksum: %w", err)
 	}
 
-	actualChecksum, err := GenerateChecksum(ctx, logger, filePath)
+	actualChecksum, err := GenerateChecksumBounded(ctx, logger, filePath, timeout)
 	if err != nil {
 		return false, fmt.Errorf("failed to generate checksum: %w", err)
 	}

--- a/internal/backup/checksum_bounded_test.go
+++ b/internal/backup/checksum_bounded_test.go
@@ -1,0 +1,330 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/safefs"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// --- test doubles (chk-prefixed to avoid clashes in package backup) ---
+
+type chkRecordingRC struct {
+	r      io.Reader
+	closed atomic.Bool
+}
+
+func (rc *chkRecordingRC) Read(p []byte) (int, error) { return rc.r.Read(p) }
+func (rc *chkRecordingRC) Close() error               { rc.closed.Store(true); return nil }
+
+type chkBlockingReader struct {
+	prefix  []byte
+	unblock <-chan struct{}
+	reads   atomic.Int32
+}
+
+func (r *chkBlockingReader) Read(p []byte) (int, error) {
+	if r.reads.Add(1) == 1 && len(r.prefix) > 0 {
+		return copy(p, r.prefix), nil
+	}
+	<-r.unblock
+	return 0, io.EOF
+}
+
+type chkSlowReader struct {
+	data  []byte
+	off   int
+	step  int
+	delay time.Duration
+}
+
+func (r *chkSlowReader) Read(p []byte) (int, error) {
+	time.Sleep(r.delay)
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	end := r.off + r.step
+	if end > len(r.data) {
+		end = len(r.data)
+	}
+	n := copy(p, r.data[r.off:end])
+	r.off += n
+	return n, nil
+}
+
+type chkErrReader struct{ err error }
+
+func (r *chkErrReader) Read(p []byte) (int, error) { return 0, r.err }
+
+// chkBlockCloseRC reads fine but blocks forever in Close (a mount that wedges
+// only at close, after the hash already succeeded).
+type chkBlockCloseRC struct {
+	r       io.Reader
+	unblock <-chan struct{}
+}
+
+func (rc *chkBlockCloseRC) Read(p []byte) (int, error) { return rc.r.Read(p) }
+func (rc *chkBlockCloseRC) Close() error               { <-rc.unblock; return nil }
+
+// chkErrCloseRC fails the read AND the close, to prove the read error wins.
+type chkErrCloseRC struct {
+	readErr  error
+	closeErr error
+}
+
+func (rc *chkErrCloseRC) Read(p []byte) (int, error) { return 0, rc.readErr }
+func (rc *chkErrCloseRC) Close() error               { return rc.closeErr }
+
+func withChecksumOpen(t *testing.T, fn func(context.Context, string, time.Duration) (io.ReadCloser, error)) {
+	t.Helper()
+	prev := checksumOpen
+	t.Cleanup(func() { checksumOpen = prev })
+	checksumOpen = fn
+}
+
+func newChkLogger() *logging.Logger { return logging.New(types.LogLevelDebug, false) }
+
+// --- tests ---
+
+// The bounded path must produce the exact crypto/sha256 digest for both the
+// timeout=0 (synchronous) and timeout>0 (per-chunk worker) branches, and the
+// legacy wrapper must equal the bounded(0) result.
+func TestGenerateChecksumBounded_KnownVectors(t *testing.T) {
+	logger := newChkLogger()
+	dir := t.TempDir()
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", nil},
+		{"abc", []byte("abc")},
+		{"multichunk", bytes.Repeat([]byte("proxsave-"), 300000)}, // > 1 MiB => several chunks
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := filepath.Join(dir, c.name)
+			if err := os.WriteFile(p, c.data, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			sum := sha256.Sum256(c.data)
+			want := hex.EncodeToString(sum[:])
+			for _, to := range []time.Duration{0, 5 * time.Second} {
+				got, err := GenerateChecksumBounded(context.Background(), logger, p, to)
+				if err != nil {
+					t.Fatalf("timeout=%v: %v", to, err)
+				}
+				if got != want {
+					t.Fatalf("timeout=%v: got %s want %s", to, got, want)
+				}
+			}
+			if leg, err := GenerateChecksum(context.Background(), logger, p); err != nil || leg != want {
+				t.Fatalf("legacy wrapper = (%s, %v); want %s", leg, err, want)
+			}
+		})
+	}
+}
+
+// A stalled read must time out (not hang) and the handle must NOT be closed,
+// because the abandoned CopyBounded worker may still hold it.
+func TestGenerateChecksumBounded_StallSkipsClose(t *testing.T) {
+	logger := newChkLogger()
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+	rc := &chkRecordingRC{r: &chkBlockingReader{prefix: []byte("partial"), unblock: unblock}}
+	withChecksumOpen(t, func(context.Context, string, time.Duration) (io.ReadCloser, error) { return rc, nil })
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := GenerateChecksumBounded(context.Background(), logger, "/x", 50*time.Millisecond)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, safefs.ErrTimeout) || !safefs.IsAbandoned(err) {
+			t.Fatalf("err = %v; want an abandoned ErrTimeout", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("GenerateChecksumBounded hung on a stalled read")
+	}
+	if rc.closed.Load() {
+		t.Fatal("close must be SKIPPED on an abandoned read (the wedged worker may still hold the fd)")
+	}
+}
+
+// A slow but healthy reader whose cumulative time exceeds the budget, but whose
+// every chunk is under it, must still succeed (per-chunk budget, not whole-file)
+// and must close the handle.
+func TestGenerateChecksumBounded_SlowHealthyReaderNoFalseTimeout(t *testing.T) {
+	logger := newChkLogger()
+	data := bytes.Repeat([]byte("x"), 240)
+	rc := &chkRecordingRC{r: &chkSlowReader{data: data, step: 8, delay: 10 * time.Millisecond}} // ~30 reads * 10ms
+	withChecksumOpen(t, func(context.Context, string, time.Duration) (io.ReadCloser, error) { return rc, nil })
+
+	got, err := GenerateChecksumBounded(context.Background(), logger, "/x", 150*time.Millisecond)
+	if err != nil {
+		t.Fatalf("slow healthy read err = %v; a per-chunk budget must not accumulate across chunks", err)
+	}
+	sum := sha256.Sum256(data)
+	if got != hex.EncodeToString(sum[:]) {
+		t.Fatalf("digest mismatch")
+	}
+	if !rc.closed.Load() {
+		t.Fatal("a healthy read must close the handle")
+	}
+}
+
+// A genuine (non-timeout) read error must propagate as "failed to read file",
+// must NOT be abandoned, and the handle MUST be closed (no fd leak).
+func TestGenerateChecksumBounded_RealReadErrorClosesHandle(t *testing.T) {
+	logger := newChkLogger()
+	sentinel := errors.New("device error")
+	rc := &chkRecordingRC{r: &chkErrReader{err: sentinel}}
+	withChecksumOpen(t, func(context.Context, string, time.Duration) (io.ReadCloser, error) { return rc, nil })
+
+	_, err := GenerateChecksumBounded(context.Background(), logger, "/x", time.Second)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v; want the sentinel", err)
+	}
+	if safefs.IsAbandoned(err) {
+		t.Fatalf("a real read error must not be abandoned: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to read file") {
+		t.Fatalf("err = %v; want 'failed to read file'", err)
+	}
+	if !rc.closed.Load() {
+		t.Fatal("a real read error must still close the handle")
+	}
+}
+
+func TestGenerateChecksumBounded_OpenPaths(t *testing.T) {
+	logger := newChkLogger()
+
+	t.Run("open abandoned wraps ErrTimeout, no nil panic", func(t *testing.T) {
+		withChecksumOpen(t, func(context.Context, string, time.Duration) (io.ReadCloser, error) {
+			return nil, &safefs.TimeoutError{Op: "open"}
+		})
+		_, err := GenerateChecksumBounded(context.Background(), logger, "/x", time.Second)
+		if !errors.Is(err, safefs.ErrTimeout) || !strings.Contains(err.Error(), "failed to open file") {
+			t.Fatalf("err = %v; want a wrapped open ErrTimeout", err)
+		}
+	})
+
+	t.Run("pre-cancelled ctx returns context.Canceled and never opens", func(t *testing.T) {
+		var opened atomic.Bool
+		withChecksumOpen(t, func(context.Context, string, time.Duration) (io.ReadCloser, error) {
+			opened.Store(true)
+			return nil, nil
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := GenerateChecksumBounded(ctx, logger, "/x", time.Second); err != context.Canceled {
+			t.Fatalf("err = %v; want exactly context.Canceled", err)
+		}
+		if opened.Load() {
+			t.Fatal("must not open on an already-cancelled context")
+		}
+	})
+
+	t.Run("missing file via the real seam", func(t *testing.T) {
+		_, err := GenerateChecksumBounded(context.Background(), logger, filepath.Join(t.TempDir(), "nope"), time.Second)
+		if err == nil || !strings.Contains(err.Error(), "failed to open file") {
+			t.Fatalf("err = %v; want open failure", err)
+		}
+	})
+}
+
+// A close that stalls AFTER a successful hash must not clobber the computed
+// checksum: the bounded close is abandoned and its timeout is suppressed.
+func TestGenerateChecksumBounded_SuccessSurvivesAbandonedClose(t *testing.T) {
+	logger := newChkLogger()
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+	rc := &chkBlockCloseRC{r: bytes.NewReader([]byte("abc")), unblock: unblock}
+	withChecksumOpen(t, func(context.Context, string, time.Duration) (io.ReadCloser, error) { return rc, nil })
+
+	type res struct {
+		sum string
+		err error
+	}
+	done := make(chan res, 1)
+	go func() {
+		s, e := GenerateChecksumBounded(context.Background(), logger, "/x", 50*time.Millisecond)
+		done <- res{s, e}
+	}()
+	want := sha256.Sum256([]byte("abc"))
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("err = %v; a stalled close must not clobber a computed checksum", r.err)
+		}
+		if r.sum != hex.EncodeToString(want[:]) {
+			t.Fatalf("sum = %s; want %s", r.sum, hex.EncodeToString(want[:]))
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("GenerateChecksumBounded hung on a stalled close")
+	}
+}
+
+// A real read error must win over a (real) close error: the close error must not
+// clobber the primary failure.
+func TestGenerateChecksumBounded_ReadErrorNotClobberedByCloseError(t *testing.T) {
+	logger := newChkLogger()
+	readErr := errors.New("read boom")
+	closeErr := errors.New("close boom")
+	rc := &chkErrCloseRC{readErr: readErr, closeErr: closeErr}
+	withChecksumOpen(t, func(context.Context, string, time.Duration) (io.ReadCloser, error) { return rc, nil })
+
+	_, err := GenerateChecksumBounded(context.Background(), logger, "/x", time.Second)
+	if !errors.Is(err, readErr) {
+		t.Fatalf("err = %v; the read error must win", err)
+	}
+	if errors.Is(err, closeErr) {
+		t.Fatalf("err = %v; the close error must not clobber the read error", err)
+	}
+	if !strings.Contains(err.Error(), "failed to read file") {
+		t.Fatalf("err = %v; want 'failed to read file'", err)
+	}
+}
+
+// End-to-end wiring through the REAL safefs.Open: a FIFO with no writer makes
+// the open block; the bound must turn that into a prompt ErrTimeout, not a hang.
+func TestGenerateChecksumBounded_FifoOpenWedge(t *testing.T) {
+	logger := newChkLogger()
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "f.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+	t.Cleanup(func() {
+		if w, e := os.OpenFile(fifo, os.O_WRONLY, 0); e == nil {
+			_ = w.Close() // release the abandoned blocked open
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := GenerateChecksumBounded(context.Background(), logger, fifo, 500*time.Millisecond)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, safefs.ErrTimeout) {
+			t.Fatalf("err = %v; want ErrTimeout", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("GenerateChecksumBounded hung on a FIFO open with no writer")
+	}
+}

--- a/internal/backup/checksum_bounded_test.go
+++ b/internal/backup/checksum_bounded_test.go
@@ -309,7 +309,11 @@ func TestGenerateChecksumBounded_FifoOpenWedge(t *testing.T) {
 		t.Skipf("mkfifo unsupported: %v", err)
 	}
 	t.Cleanup(func() {
-		if w, e := os.OpenFile(fifo, os.O_WRONLY, 0); e == nil {
+		// O_NONBLOCK so this never blocks: with the abandoned reader present the
+		// open succeeds and the close releases it; with no reader (a regression
+		// where the code under test never opened the FIFO) it returns ENXIO
+		// immediately -> e != nil -> skip, so the cleanup cannot wedge CI.
+		if w, e := os.OpenFile(fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0); e == nil {
 			_ = w.Close() // release the abandoned blocked open
 		}
 	})

--- a/internal/config/templates/backup.env
+++ b/internal/config/templates/backup.env
@@ -324,7 +324,7 @@ BACKUP_PVE_SCHEDULES=true
 BACKUP_PVE_REPLICATION=true
 BACKUP_PVE_BACKUP_FILES=true
 PVESH_TIMEOUT=15                # Timeout (sec) per singolo comando pvesh (0 = disabilitato)
-FS_IO_TIMEOUT=30                # Timeout (sec) per I/O filesystem su storage (stat/readdir/statfs). Utile per mount di rete irraggiungibili (0 = disabilitato)
+FS_IO_TIMEOUT=30                # Timeout (sec) per OGNI syscall su filesystem (stat/readdir/open/read/write/close/glob/copy/hash) su preflight, log, storage, cloud e restore. Evita hang su mount morti/irraggiungibili (0 = disabilitato)
 BACKUP_SMALL_PVE_BACKUPS=false
 MAX_PVE_BACKUP_SIZE=100M
 PVE_BACKUP_INCLUDE_PATTERN=

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,6 +1,8 @@
 package logging
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,22 +11,44 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/internal/types"
 )
 
+// osOpenFile and fileWrite are indirected so tests can simulate a blocking/dead
+// log mount on the open and the write paths.
+var (
+	osOpenFile = os.OpenFile
+	fileWrite  = func(w io.Writer, s string) (int, error) { return fmt.Fprint(w, s) }
+)
+
+// logWriteTimeoutCap bounds how long a single log-line write may block before the
+// file sink is disabled. It caps the FS_IO_TIMEOUT-derived budget so that a mount
+// dying mid-run stalls logging at most this long (once) before degrading to
+// stdout-only, rather than for the full (generous) FS_IO_TIMEOUT.
+const logWriteTimeoutCap = 5 * time.Second
+
 // Logger handles application logging.
 type Logger struct {
-	mu           sync.Mutex
-	level        types.LogLevel
-	useColor     bool
-	output       io.Writer
-	timeFormat   string
-	logFile      *os.File // Log file (optional)
-	warningCount int64
-	errorCount   int64
-	issueLines   []string // Captured WARNING/ERROR/CRITICAL lines for end-of-run summary
-	exitFunc     func(int)
-	secrets      []secretForm // registered secret values scrubbed from every log line
+	mu         sync.Mutex
+	level      types.LogLevel
+	useColor   bool
+	output     io.Writer
+	timeFormat string
+	logFile    *os.File // Log file (optional)
+	// ioTimeout bounds the log-file open/write/close so a dead/stale LOG_PATH mount
+	// cannot wedge the run in an uninterruptible syscall. Zero means unbounded
+	// (legacy / FS_IO_TIMEOUT=0 opt-out). Set via SetIOTimeout by the run logger;
+	// session loggers (local /tmp) leave it at 0.
+	ioTimeout time.Duration
+	// fileSinkDisabled is set after an open/write/close timeout so subsequent log
+	// lines skip the (dead) file and go to stdout only. Guarded by mu.
+	fileSinkDisabled bool
+	warningCount     int64
+	errorCount       int64
+	issueLines       []string // Captured WARNING/ERROR/CRITICAL lines for end-of-run summary
+	exitFunc         func(int)
+	secrets          []secretForm // registered secret values scrubbed from every log line
 }
 
 // RegisterSecret records a secret value so it is masked out of every subsequent
@@ -77,6 +101,16 @@ func (l *Logger) SetOutput(w io.Writer) {
 	l.output = w
 }
 
+// SetIOTimeout bounds subsequent log-file open/write/close operations so a dead or
+// stale LOG_PATH mount cannot wedge the logger in an uninterruptible syscall. A
+// non-positive value restores unbounded behaviour (the FS_IO_TIMEOUT=0 opt-out).
+// Callers pass fsIoTimeoutDuration(cfg).
+func (l *Logger) SetIOTimeout(d time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.ioTimeout = d
+}
+
 // SetLevel sets the logging level.
 func (l *Logger) SetLevel(level types.LogLevel) {
 	l.mu.Lock()
@@ -109,15 +143,69 @@ func (l *Logger) OpenLogFile(logPath string) error {
 		}
 	}
 
-	// Create the log file (O_CREATE|O_WRONLY|O_APPEND).
-	// O_SYNC forces immediate writes to disk (real-time, no buffering).
-	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0600)
+	file, err := l.openFileBounded(logPath)
 	if err != nil {
 		return fmt.Errorf("failed to open log file %s: %w", logPath, err)
 	}
 
 	l.logFile = file
+	l.fileSinkDisabled = false
 	return nil
+}
+
+// openFileBounded performs the O_SYNC create+open, bounded by l.ioTimeout when set
+// (0 = unbounded, legacy). On timeout safefs returns *TimeoutError and abandons the
+// worker goroutine; the caller falls back to stdout-only. Caller must hold l.mu.
+func (l *Logger) openFileBounded(logPath string) (*os.File, error) {
+	open := func() (*os.File, error) {
+		// O_SYNC forces immediate writes to disk (real-time, no buffering).
+		return osOpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0600)
+	}
+	if l.ioTimeout <= 0 {
+		return open()
+	}
+	return safefs.Run(context.Background(), "logopen", logPath, l.ioTimeout, open)
+}
+
+// writeFileLocked writes one preformatted line to the open log file, bounding the
+// (O_SYNC) write so a dead/stale mount cannot wedge the logger while it holds l.mu.
+// On a write timeout the sink is permanently disabled (subsequent lines skip the
+// file). Caller MUST hold l.mu and have checked logFile != nil && !fileSinkDisabled.
+func (l *Logger) writeFileLocked(line string) {
+	f := l.logFile // local: a disable nils l.logFile, the abandoned goroutine keeps f
+	if l.ioTimeout <= 0 {
+		_, _ = fileWrite(f, line) // opt-out / legacy: unbounded
+		return
+	}
+	wt := l.ioTimeout
+	if wt > logWriteTimeoutCap {
+		wt = logWriteTimeoutCap
+	}
+	_, err := safefs.Run(context.Background(), "logwrite", f.Name(), wt, func() (int, error) {
+		return fileWrite(f, line)
+	})
+	if err != nil && errors.Is(err, safefs.ErrTimeout) {
+		l.disableFileSinkLocked(err)
+	}
+}
+
+// disableFileSinkLocked turns the file sink off after a timed-out write so every
+// subsequent line skips the dead mount. The blocked write goroutine is abandoned
+// and the *os.File is intentionally NOT closed here: a Close() on the dead mount
+// would block too, and the abandoned goroutine still references it. We drop our
+// reference (the fd is reclaimed at process exit). Caller MUST hold l.mu.
+func (l *Logger) disableFileSinkLocked(cause error) {
+	if l.fileSinkDisabled {
+		return
+	}
+	l.fileSinkDisabled = true
+	l.logFile = nil
+	timestamp := time.Now().Format(l.timeFormat)
+	warn := fmt.Sprintf("log file sink disabled after I/O timeout (%v); continuing on stdout only", cause)
+	// stdout only - never route this back through the (dead) file sink.
+	_, _ = fmt.Fprintf(l.output, "[%s] %-8s %s\n", timestamp, types.LogLevelWarning.String(), warn)
+	l.warningCount++
+	l.issueLines = append(l.issueLines, fmt.Sprintf("[%s] %-8s %s", timestamp, types.LogLevelWarning.String(), warn))
 }
 
 // CloseLogFile closes the log file (call after notifications).
@@ -128,8 +216,16 @@ func (l *Logger) CloseLogFile() error {
 		return nil
 	}
 
-	err := l.logFile.Close()
+	f := l.logFile
 	l.logFile = nil
+	if l.ioTimeout <= 0 {
+		return f.Close()
+	}
+	// Bound the flushing close so a dead mount cannot hang shutdown; on timeout the
+	// close goroutine and fd are abandoned (l.logFile is already nil, no double close).
+	_, err := safefs.Run(context.Background(), "logclose", f.Name(), l.ioTimeout, func() (struct{}, error) {
+		return struct{}{}, f.Close()
+	})
 	return err
 }
 
@@ -239,9 +335,10 @@ func (l *Logger) logWithLabel(level types.LogLevel, label string, colorOverride 
 	// Write to stdout with colors.
 	_, _ = fmt.Fprint(l.output, outputStdout)
 
-	// If a log file is open, write there too (without colors).
-	if l.logFile != nil {
-		_, _ = fmt.Fprint(l.logFile, outputFile)
+	// If a log file is open and not disabled, write there too (without colors),
+	// bounded so a dead/stale mount cannot wedge logging while holding l.mu.
+	if l.logFile != nil && !l.fileSinkDisabled {
+		l.writeFileLocked(outputFile)
 	}
 }
 
@@ -364,7 +461,7 @@ func (l *Logger) Fatal(exitCode types.ExitCode, format string, args ...interface
 func (l *Logger) AppendRaw(message string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.logFile == nil {
+	if l.logFile == nil || l.fileSinkDisabled {
 		return
 	}
 	timestamp := time.Now().Format(l.timeFormat)
@@ -373,7 +470,7 @@ func (l *Logger) AppendRaw(message string) {
 		types.LogLevelInfo.String(),
 		message,
 	)
-	_, _ = fmt.Fprint(l.logFile, output)
+	l.writeFileLocked(output)
 }
 
 // Package-level default logger

--- a/internal/logging/logger_timeout_test.go
+++ b/internal/logging/logger_timeout_test.go
@@ -23,10 +23,18 @@ func TestOpenLogFileTimeoutFallsBackToStdout(t *testing.T) {
 	finished := make(chan struct{})
 	// Order matters: unblock + wait for the abandoned worker to finish BEFORE
 	// restoring the package var, so the worker's read of osOpenFile happens-before
-	// the restore (otherwise -race flags it).
+	// the restore (otherwise -race flags it). The wait is BOUNDED so a regression
+	// that never reaches the stub surfaces as a normal t.Error instead of wedging
+	// CI; that timeout branch is a failure path (test already red) where the
+	// happens-before for the restore is not guaranteed. We restore anyway to avoid
+	// leaking the stub into later tests in the package.
 	t.Cleanup(func() {
 		close(unblock)
-		<-finished
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+			t.Error("timed out waiting for the abandoned open worker to finish")
+		}
 		osOpenFile = prev
 	})
 	osOpenFile = func(string, int, os.FileMode) (*os.File, error) {
@@ -76,10 +84,18 @@ func TestLogWriteTimeoutDisablesSink(t *testing.T) {
 	unblock := make(chan struct{})
 	finished := make(chan struct{})
 	// Order matters: unblock + wait for the abandoned worker before restoring the
-	// package var (happens-before, otherwise -race flags the var access).
+	// package var (happens-before, otherwise -race flags the var access). The wait
+	// is BOUNDED so a regression that never reaches the stub surfaces as a normal
+	// t.Error instead of wedging CI; that timeout branch is a failure path (test
+	// already red) where the happens-before is not guaranteed. We restore anyway to
+	// avoid leaking the stub into later tests in the package.
 	t.Cleanup(func() {
 		close(unblock)
-		<-finished
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+			t.Error("timed out waiting for the abandoned write worker to finish")
+		}
 		fileWrite = prev
 	})
 	fileWrite = func(w io.Writer, s string) (int, error) {

--- a/internal/logging/logger_timeout_test.go
+++ b/internal/logging/logger_timeout_test.go
@@ -1,0 +1,180 @@
+package logging
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/safefs"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// TestOpenLogFileTimeoutFallsBackToStdout: a wedged open (dead/stale mount) returns
+// a timeout error and the logger degrades to stdout-only instead of hanging.
+func TestOpenLogFileTimeoutFallsBackToStdout(t *testing.T) {
+	prev := osOpenFile
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	// Order matters: unblock + wait for the abandoned worker to finish BEFORE
+	// restoring the package var, so the worker's read of osOpenFile happens-before
+	// the restore (otherwise -race flags it).
+	t.Cleanup(func() {
+		close(unblock)
+		<-finished
+		osOpenFile = prev
+	})
+	osOpenFile = func(string, int, os.FileMode) (*os.File, error) {
+		<-unblock
+		close(finished)
+		return nil, nil
+	}
+
+	logger := New(types.LogLevelInfo, false)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.SetIOTimeout(25 * time.Millisecond)
+
+	start := time.Now()
+	err := logger.OpenLogFile("/does/not/matter.log")
+	if err == nil || !errors.Is(err, safefs.ErrTimeout) {
+		t.Fatalf("OpenLogFile err = %v; want safefs.ErrTimeout", err)
+	}
+	if time.Since(start) > 250*time.Millisecond {
+		t.Fatalf("OpenLogFile took too long: %s", time.Since(start))
+	}
+	if logger.GetLogFilePath() != "" {
+		t.Fatal("no file sink expected after an open timeout")
+	}
+	logger.Info("still works")
+	if !strings.Contains(buf.String(), "still works") {
+		t.Fatalf("stdout logging must continue; buf=%q", buf.String())
+	}
+}
+
+// TestLogWriteTimeoutDisablesSink: a mid-run write that wedges (mount died after a
+// successful open) must NOT deadlock logging; the sink is disabled after one
+// timeout and subsequent lines skip the file.
+func TestLogWriteTimeoutDisablesSink(t *testing.T) {
+	dir := t.TempDir()
+	logger := New(types.LogLevelInfo, false)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	if err := logger.OpenLogFile(filepath.Join(dir, "x.log")); err != nil {
+		t.Fatal(err)
+	}
+	logger.SetIOTimeout(25 * time.Millisecond)
+
+	prev := fileWrite
+	var mu sync.Mutex
+	calls := 0
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	// Order matters: unblock + wait for the abandoned worker before restoring the
+	// package var (happens-before, otherwise -race flags the var access).
+	t.Cleanup(func() {
+		close(unblock)
+		<-finished
+		fileWrite = prev
+	})
+	fileWrite = func(w io.Writer, s string) (int, error) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n == 1 {
+			<-unblock // first write wedges like a dead mount
+			close(finished)
+			return 0, nil
+		}
+		return prev(w, s)
+	}
+
+	done := make(chan struct{})
+	go func() { logger.Info("first"); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("log write deadlocked on a wedged mount")
+	}
+
+	if logger.GetLogFilePath() != "" {
+		t.Fatal("file sink should be disabled after a write timeout")
+	}
+	if !logger.HasWarnings() {
+		t.Fatal("disabling the sink should record a warning")
+	}
+
+	logger.Info("second")
+	mu.Lock()
+	c := calls
+	mu.Unlock()
+	if c != 1 {
+		t.Fatalf("fileWrite called %d times; want 1 (sink disabled after timeout)", c)
+	}
+
+	// Closing after a disable is a no-op (logFile already nil) and must not panic.
+	if err := logger.CloseLogFile(); err != nil {
+		t.Fatalf("CloseLogFile after disable: %v", err)
+	}
+}
+
+// TestLogFileHealthyBoundedStillWrites: with a positive timeout on a healthy mount,
+// writes still go to the file and the sink is not disabled.
+func TestLogFileHealthyBoundedStillWrites(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "h.log")
+	logger := New(types.LogLevelInfo, false)
+	logger.SetOutput(&bytes.Buffer{})
+	logger.SetIOTimeout(2 * time.Second)
+	if err := logger.OpenLogFile(p); err != nil {
+		t.Fatal(err)
+	}
+	logger.Info("alpha")
+	logger.Warning("beta")
+	if err := logger.CloseLogFile(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "alpha") || !strings.Contains(s, "beta") {
+		t.Fatalf("bounded healthy writes missing from file: %q", s)
+	}
+	if logger.fileSinkDisabled {
+		t.Fatal("a healthy run must not disable the sink")
+	}
+}
+
+// TestLoggerConcurrentBoundedNoRace exercises the bounded write path under
+// concurrency (run with -race).
+func TestLoggerConcurrentBoundedNoRace(t *testing.T) {
+	dir := t.TempDir()
+	logger := New(types.LogLevelInfo, false)
+	logger.SetOutput(&bytes.Buffer{})
+	logger.SetIOTimeout(2 * time.Second)
+	if err := logger.OpenLogFile(filepath.Join(dir, "c.log")); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 30; i++ {
+				logger.Info("x %d", i)
+			}
+		}()
+	}
+	wg.Wait()
+	if err := logger.CloseLogFile(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/notify/email.go
+++ b/internal/notify/email.go
@@ -305,7 +305,7 @@ func (e *EmailNotifier) Send(ctx context.Context, data *NotificationData) (*Noti
 		// Fallback to local sendmail if relay fails and fallback is enabled.
 		if err != nil && e.config.FallbackSendmail {
 			relayErr = err // Store original relay error
-			e.logger.Warning("WARNING: Cloud relay failed: %v", err)
+			e.logger.Warning("WARNING: Email delivery via cloud relay failed: %v", err)
 			e.logger.Info("Attempting sendmail fallback after relay delivery failure...")
 			e.logger.Debug("Email fallback decision: stage=delivery reason=relay_send_failed cause=%v", relayErr)
 

--- a/internal/orchestrator/additional_helpers_test.go
+++ b/internal/orchestrator/additional_helpers_test.go
@@ -1183,6 +1183,17 @@ func TestCleanupPreviousExecutionArtifacts(t *testing.T) {
 		}
 	})
 
+	// issue #242: cpu profiles now live under /tmp/proxsave too (not just LOG_PATH).
+	tmpCPUProfile := filepath.Join(heapDir, fmt.Sprintf("cpu-%d.pprof", time.Now().UnixNano()))
+	if err := os.WriteFile(tmpCPUProfile, []byte("cpu"), 0o640); err != nil {
+		t.Fatalf("write tmp cpu profile: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(tmpCPUProfile); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("cleanup tmp cpu file: %v", err)
+		}
+	})
+
 	registryDir := t.TempDir()
 	registryPath := filepath.Join(registryDir, "registry.json")
 	reg, err := NewTempDirRegistry(logger, registryPath)
@@ -1215,6 +1226,9 @@ func TestCleanupPreviousExecutionArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(cpuProfile); !os.IsNotExist(err) {
 		t.Fatalf("cpu profile should be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(tmpCPUProfile); !os.IsNotExist(err) {
+		t.Fatalf("/tmp/proxsave cpu profile should be removed, got err=%v", err)
 	}
 	if _, err := os.Stat(heapFile); !os.IsNotExist(err) {
 		t.Fatalf("heap profile should be removed, got err=%v", err)

--- a/internal/orchestrator/additional_helpers_test.go
+++ b/internal/orchestrator/additional_helpers_test.go
@@ -1216,7 +1216,7 @@ func TestCleanupPreviousExecutionArtifacts(t *testing.T) {
 	}
 	makeRegistryEntriesStale(t, registryPath)
 
-	returned := o.cleanupPreviousExecutionArtifacts()
+	returned := o.cleanupPreviousExecutionArtifacts(context.Background())
 	if returned != reg {
 		t.Fatalf("cleanup should return configured registry instance")
 	}
@@ -1235,6 +1235,43 @@ func TestCleanupPreviousExecutionArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
 		t.Fatalf("orphan directory should be removed, got err=%v", err)
+	}
+}
+
+// The LOG_PATH globs are bounded: on a dead-deadline ctx (simulating a dead/stale
+// mount) the stats glob must short-circuit with a timeout-skip debug log and never
+// match/remove the file, instead of wedging cleanup in a raw lstat/readdir.
+func TestCleanupPreviousExecutionArtifactsBoundsLogPathGlobOnTimeout(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logging.New(types.LogLevelDebug, false)
+	logger.SetOutput(&buf)
+	o := &Orchestrator{logger: logger}
+
+	origRoot := workspaceRoot
+	workspaceRoot = t.TempDir()
+	t.Cleanup(func() { workspaceRoot = origRoot })
+
+	logDir := t.TempDir()
+	o.logPath = logDir
+	statsFile := filepath.Join(logDir, "backup-stats-old.json")
+	if err := os.WriteFile(statsFile, []byte("stats"), 0o640); err != nil {
+		t.Fatalf("write stats file: %v", err)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+
+	o.cleanupPreviousExecutionArtifacts(ctx)
+
+	if !strings.Contains(buf.String(), "globbing stats files") || !strings.Contains(buf.String(), "timed out") {
+		t.Fatalf("expected a bounded-glob timeout debug log; got:\n%s", buf.String())
+	}
+	// The legacy LOG_PATH cpu glob is bounded too (same dead ctx exercises both).
+	if !strings.Contains(buf.String(), "globbing legacy cpu profiles") {
+		t.Fatalf("expected the legacy cpu glob to also be bounded; got:\n%s", buf.String())
+	}
+	if _, err := os.Stat(statsFile); err != nil {
+		t.Fatalf("stats file must survive a timed-out glob; stat err = %v", err)
 	}
 }
 

--- a/internal/orchestrator/additional_helpers_test.go
+++ b/internal/orchestrator/additional_helpers_test.go
@@ -1275,6 +1275,67 @@ func TestCleanupPreviousExecutionArtifactsBoundsLogPathGlobOnTimeout(t *testing.
 	}
 }
 
+// vanishingRemoveFS embeds osFS and reports os.ErrNotExist from Remove for one
+// basename, simulating the glob->remove TOCTOU race and the LOG_PATH==/tmp/proxsave
+// duplicate second-remove. Remove never touches disk, so the test stays hermetic
+// even though cleanup also globs the shared /tmp/proxsave.
+type vanishingRemoveFS struct {
+	osFS
+	vanished string
+}
+
+func (f *vanishingRemoveFS) Remove(p string) error {
+	if filepath.Base(p) == f.vanished {
+		return os.ErrNotExist
+	}
+	return nil // pretend success; never mutate disk
+}
+
+// A globbed file that is already gone at remove time (TOCTOU, or the
+// /tmp/proxsave cpu-*.pprof duplicate when LOG_PATH is /tmp/proxsave) must count
+// as removed, not as a failure: it must not inflate failedFiles or flip the
+// summary to "completed with errors". A clean removal is planted alongside so the
+// summary line is emitted (it only prints when removedFiles>0). Reverting
+// boundedRemove's os.ErrNotExist no-op turns this red.
+func TestCleanupPreviousExecutionArtifactsTreatsVanishedFileAsRemoved(t *testing.T) {
+	origRoot := workspaceRoot
+	workspaceRoot = t.TempDir()
+	t.Cleanup(func() { workspaceRoot = origRoot })
+
+	logDir := t.TempDir()
+	for _, n := range []string{"backup-stats-AAA.json", "backup-stats-BBB.json"} {
+		if err := os.WriteFile(filepath.Join(logDir, n), []byte("{}"), 0o640); err != nil {
+			t.Fatalf("plant %s: %v", n, err)
+		}
+	}
+
+	var buf bytes.Buffer
+	logger := logging.New(types.LogLevelInfo, false)
+	logger.SetOutput(&buf)
+	o := &Orchestrator{
+		logger:  logger,
+		fs:      &vanishingRemoveFS{vanished: "backup-stats-BBB.json"},
+		logPath: logDir,
+	}
+	// Pin Phase 4 to a throwaway registry so cleanup never resolves the real
+	// /tmp/proxsave temp-dir registry (keeps the test fully hermetic).
+	reg, err := NewTempDirRegistry(logger, filepath.Join(t.TempDir(), "registry.json"))
+	if err != nil {
+		t.Fatalf("NewTempDirRegistry: %v", err)
+	}
+	o.tempRegistry = reg
+
+	o.cleanupPreviousExecutionArtifacts(context.Background())
+
+	out := buf.String()
+	if !strings.Contains(out, "completed successfully") {
+		t.Fatalf("a vanished/duplicate file must be treated as removed; got:\n%s", out)
+	}
+	if strings.Contains(out, "completed with errors") {
+		t.Fatalf("os.ErrNotExist must not count as a failed removal; got:\n%s", out)
+	}
+}
+
 func makeRegistryEntriesStale(t *testing.T, registryPath string) {
 	t.Helper()
 	data, err := os.ReadFile(registryPath)

--- a/internal/orchestrator/backup_run_helpers.go
+++ b/internal/orchestrator/backup_run_helpers.go
@@ -255,7 +255,9 @@ func (o *Orchestrator) recordArchiveSize(stats *BackupStats, artifacts *backupAr
 }
 
 func (o *Orchestrator) generateArchiveChecksum(ctx context.Context, archivePath string) (string, error) {
-	checksum, err := backup.GenerateChecksum(ctx, o.logger, archivePath)
+	// archivePath lives on BACKUP_PATH, which can be a dead/stale mount; bound the
+	// hash with FS_IO_TIMEOUT so it cannot wedge in an uninterruptible read.
+	checksum, err := backup.GenerateChecksumBounded(ctx, o.logger, archivePath, o.fsIoTimeout())
 	if err != nil {
 		return "", &BackupError{
 			Phase: "verification",

--- a/internal/orchestrator/backup_run_helpers_checksum_test.go
+++ b/internal/orchestrator/backup_run_helpers_checksum_test.go
@@ -1,0 +1,61 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/safefs"
+)
+
+// generateArchiveChecksum must thread FS_IO_TIMEOUT (o.fsIoTimeout()) into the
+// bounded hash: hashing an archive on a dead mount (a FIFO with no writer) must
+// produce a prompt timeout, not hang. A regression that drops o.fsIoTimeout()
+// back to a 0/unbounded value would hang here and trip the guard.
+func TestGenerateArchiveChecksum_ThreadsFsIoTimeout(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "archive.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+	t.Cleanup(func() {
+		if w, e := os.OpenFile(fifo, os.O_WRONLY, 0); e == nil {
+			_ = w.Close() // release the abandoned blocked open
+		}
+	})
+
+	o := &Orchestrator{logger: newTestLogger(), cfg: &config.Config{FsIoTimeoutSeconds: 1}}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := o.generateArchiveChecksum(context.Background(), fifo)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, safefs.ErrTimeout) {
+			t.Fatalf("err = %v; want a threaded FS_IO_TIMEOUT (safefs.ErrTimeout)", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("generateArchiveChecksum hung: FS_IO_TIMEOUT was not threaded into the bounded hash")
+	}
+}
+
+// With FS_IO_TIMEOUT unset (0 = opt-out), a healthy archive still hashes fine.
+func TestGenerateArchiveChecksum_HealthyUnbounded(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "archive.tar")
+	if err := os.WriteFile(archive, []byte("archive-bytes"), 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	o := &Orchestrator{logger: newTestLogger(), cfg: &config.Config{}} // FsIoTimeoutSeconds=0
+	sum, err := o.generateArchiveChecksum(context.Background(), archive)
+	if err != nil || sum == "" {
+		t.Fatalf("generateArchiveChecksum = (%q, %v); want a checksum", sum, err)
+	}
+}

--- a/internal/orchestrator/backup_run_helpers_checksum_test.go
+++ b/internal/orchestrator/backup_run_helpers_checksum_test.go
@@ -24,7 +24,11 @@ func TestGenerateArchiveChecksum_ThreadsFsIoTimeout(t *testing.T) {
 		t.Skipf("mkfifo unsupported: %v", err)
 	}
 	t.Cleanup(func() {
-		if w, e := os.OpenFile(fifo, os.O_WRONLY, 0); e == nil {
+		// O_NONBLOCK so this never blocks: with the abandoned reader present the
+		// open succeeds and the close releases it; with no reader (a regression
+		// where the code under test never opened the FIFO) it returns ENXIO
+		// immediately -> e != nil -> skip, so the cleanup cannot wedge CI.
+		if w, e := os.OpenFile(fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0); e == nil {
 			_ = w.Close() // release the abandoned blocked open
 		}
 	})

--- a/internal/orchestrator/decrypt.go
+++ b/internal/orchestrator/decrypt.go
@@ -471,9 +471,19 @@ func downloadRcloneBackup(ctx context.Context, remotePath string, logger *loggin
 	return tmpPath, cleanup, nil
 }
 
-func preparePlainBundle(ctx context.Context, reader *bufio.Reader, cand *backupCandidate, version string, logger *logging.Logger) (bundle *preparedBundle, err error) {
+// fsIoTimeoutFromConfig converts FS_IO_TIMEOUT into a per-op safefs budget; <=0
+// (unset / explicit opt-out) yields 0 = unbounded (legacy). Used to bound the
+// restore/decrypt staging-archive hash and integrity verify.
+func fsIoTimeoutFromConfig(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.FsIoTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.FsIoTimeoutSeconds) * time.Second
+}
+
+func preparePlainBundle(ctx context.Context, reader *bufio.Reader, cand *backupCandidate, version string, logger *logging.Logger, timeout time.Duration) (bundle *preparedBundle, err error) {
 	ui := newCLIWorkflowUI(reader, logger)
-	return preparePlainBundleWithUI(ctx, cand, version, logger, ui)
+	return preparePlainBundleWithUI(ctx, cand, version, logger, ui, timeout)
 }
 
 func prepareDecryptedBackup(ctx context.Context, reader *bufio.Reader, cfg *config.Config, logger *logging.Logger, version string, requireEncrypted bool) (candidate *backupCandidate, prepared *preparedBundle, err error) {
@@ -484,7 +494,7 @@ func prepareDecryptedBackup(ctx context.Context, reader *bufio.Reader, cfg *conf
 		return nil, nil, err
 	}
 
-	prepared, err = preparePlainBundle(ctx, reader, candidate, version, logger)
+	prepared, err = preparePlainBundle(ctx, reader, candidate, version, logger, fsIoTimeoutFromConfig(cfg))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/orchestrator/decrypt.go
+++ b/internal/orchestrator/decrypt.go
@@ -605,7 +605,9 @@ func extractBundleToWorkdirWithLogger(bundlePath, workDir string, logger *loggin
 }
 
 func copyRawArtifactsToWorkdir(ctx context.Context, cand *backupCandidate, workDir string) (staged stagedFiles, err error) {
-	return copyRawArtifactsToWorkdirWithLogger(ctx, cand, workDir, nil)
+	// timeout 0 = unbounded (legacy); the bounded production path passes the
+	// configured FS_IO_TIMEOUT via copyRawArtifactsToWorkdirWithLogger.
+	return copyRawArtifactsToWorkdirWithLogger(ctx, cand, workDir, nil, 0)
 }
 
 func baseNameFromRemoteRef(ref string) string {
@@ -638,7 +640,7 @@ func rcloneCopyTo(ctx context.Context, remotePath, localPath string, showProgres
 	return cmd.Run()
 }
 
-func copyRawArtifactsToWorkdirWithLogger(ctx context.Context, cand *backupCandidate, workDir string, logger *logging.Logger) (staged stagedFiles, err error) {
+func copyRawArtifactsToWorkdirWithLogger(ctx context.Context, cand *backupCandidate, workDir string, logger *logging.Logger, timeout time.Duration) (staged stagedFiles, err error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -690,16 +692,16 @@ func copyRawArtifactsToWorkdirWithLogger(ctx context.Context, cand *backupCandid
 		}
 	} else {
 		logging.DebugStep(logger, "stage raw artifacts", "copy archive to %s", archiveDest)
-		if err := copyFile(restoreFS, cand.RawArchivePath, archiveDest); err != nil {
+		if err := copyFileBounded(ctx, restoreFS, cand.RawArchivePath, archiveDest, timeout); err != nil {
 			return stagedFiles{}, fmt.Errorf("copy archive: %w", err)
 		}
 		logging.DebugStep(logger, "stage raw artifacts", "copy metadata to %s", metadataDest)
-		if err := copyFile(restoreFS, cand.RawMetadataPath, metadataDest); err != nil {
+		if err := copyFileBounded(ctx, restoreFS, cand.RawMetadataPath, metadataDest, timeout); err != nil {
 			return stagedFiles{}, fmt.Errorf("copy metadata: %w", err)
 		}
 		if cand.RawChecksumPath != "" && checksumDest != "" {
 			logging.DebugStep(logger, "stage raw artifacts", "copy checksum to %s", checksumDest)
-			if err := copyFile(restoreFS, cand.RawChecksumPath, checksumDest); err != nil {
+			if err := copyFileBounded(ctx, restoreFS, cand.RawChecksumPath, checksumDest, timeout); err != nil {
 				logWarning(logger, "Failed to copy checksum %s: %v", cand.RawChecksumPath, err)
 				checksumDest = ""
 			}

--- a/internal/orchestrator/decrypt_integrity.go
+++ b/internal/orchestrator/decrypt_integrity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/tis24dev/proxsave/internal/backup"
 	"github.com/tis24dev/proxsave/internal/logging"
@@ -95,7 +96,7 @@ func resolveCandidateIntegrityExpectation(staged stagedFiles, cand *backupCandid
 	return resolveStagedIntegrityExpectation(staged, manifest)
 }
 
-func verifyStagedArchiveIntegrity(ctx context.Context, logger *logging.Logger, staged stagedFiles, cand *backupCandidate) (string, error) {
+func verifyStagedArchiveIntegrity(ctx context.Context, logger *logging.Logger, staged stagedFiles, cand *backupCandidate, timeout time.Duration) (string, error) {
 	if staged.ArchivePath == "" {
 		return "", fmt.Errorf("staged archive path is empty")
 	}
@@ -109,7 +110,7 @@ func verifyStagedArchiveIntegrity(ctx context.Context, logger *logging.Logger, s
 	}
 
 	logger.Info("Verifying staged archive integrity using %s", expectation.Source)
-	ok, err := backup.VerifyChecksum(ctx, logger, staged.ArchivePath, expectation.Checksum)
+	ok, err := backup.VerifyChecksumBounded(ctx, logger, staged.ArchivePath, expectation.Checksum, timeout)
 	if err != nil {
 		return "", fmt.Errorf("verify staged archive: %w", err)
 	}

--- a/internal/orchestrator/decrypt_integrity_test.go
+++ b/internal/orchestrator/decrypt_integrity_test.go
@@ -71,7 +71,7 @@ func TestPreparePlainBundle_RejectsMissingChecksumVerification(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(""))
 	logger := logging.New(types.LogLevelError, false)
 
-	_, err = preparePlainBundle(context.Background(), reader, cand, "", logger)
+	_, err = preparePlainBundle(context.Background(), reader, cand, "", logger, 0)
 	if err == nil {
 		t.Fatalf("expected missing checksum verification error")
 	}
@@ -121,7 +121,7 @@ func TestPreparePlainBundle_RejectsChecksumMismatch(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(""))
 	logger := logging.New(types.LogLevelError, false)
 
-	_, err = preparePlainBundle(context.Background(), reader, cand, "", logger)
+	_, err = preparePlainBundle(context.Background(), reader, cand, "", logger, 0)
 	if err == nil {
 		t.Fatalf("expected checksum mismatch error")
 	}
@@ -149,12 +149,12 @@ func TestVerifyStagedArchiveIntegrity_UsesCandidateIntegrityExpectation(t *testi
 			Checksum: strings.ToUpper(checksumHexForBytes(archiveData)),
 			Source:   "checksum file",
 		},
-	})
+	}, 0)
 	if err != nil {
-		t.Fatalf("verifyStagedArchiveIntegrity() error = %v", err)
+		t.Fatalf("verifyStagedArchiveIntegrity(, 0) error = %v", err)
 	}
 	want := checksumHexForBytes(archiveData)
 	if got != want {
-		t.Fatalf("verifyStagedArchiveIntegrity() = %q; want %q", got, want)
+		t.Fatalf("verifyStagedArchiveIntegrity(, 0) = %q; want %q", got, want)
 	}
 }

--- a/internal/orchestrator/decrypt_prepare_common.go
+++ b/internal/orchestrator/decrypt_prepare_common.go
@@ -112,7 +112,7 @@ func preparePlainBundleCommon(ctx context.Context, cand *backupCandidate, versio
 		staged, err = extractBundleToWorkdirWithLogger(cand.BundlePath, workDir, logger)
 	case sourceRaw:
 		logger.Info("Staging raw artifacts for %s", filepath.Base(cand.RawArchivePath))
-		staged, err = copyRawArtifactsToWorkdirWithLogger(ctx, cand, workDir, logger)
+		staged, err = copyRawArtifactsToWorkdirWithLogger(ctx, cand, workDir, logger, timeout)
 	default:
 		err = fmt.Errorf("unsupported candidate source")
 	}

--- a/internal/orchestrator/decrypt_prepare_common.go
+++ b/internal/orchestrator/decrypt_prepare_common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/tis24dev/proxsave/internal/backup"
 	"github.com/tis24dev/proxsave/internal/logging"
@@ -62,7 +63,7 @@ func resolvePreparedArchivePath(workDir, stagedArchivePath, currentEncryption st
 	return filepath.Join(workDir, archiveBase), nil
 }
 
-func preparePlainBundleCommon(ctx context.Context, cand *backupCandidate, version string, logger *logging.Logger, decryptArchive archiveDecryptFunc) (bundle *preparedBundle, err error) {
+func preparePlainBundleCommon(ctx context.Context, cand *backupCandidate, version string, logger *logging.Logger, decryptArchive archiveDecryptFunc, timeout time.Duration) (bundle *preparedBundle, err error) {
 	if cand == nil || cand.Manifest == nil {
 		return nil, fmt.Errorf("invalid backup candidate")
 	}
@@ -120,7 +121,7 @@ func preparePlainBundleCommon(ctx context.Context, cand *backupCandidate, versio
 		return nil, err
 	}
 
-	sourceChecksum, err := verifyStagedArchiveIntegrity(ctx, logger, staged, cand)
+	sourceChecksum, err := verifyStagedArchiveIntegrity(ctx, logger, staged, cand, timeout)
 	if err != nil {
 		cleanup()
 		return nil, err
@@ -162,7 +163,7 @@ func preparePlainBundleCommon(ctx context.Context, cand *backupCandidate, versio
 		return nil, fmt.Errorf("stat decrypted archive: %w", err)
 	}
 
-	plainChecksum, err := backup.GenerateChecksum(ctx, logger, plainArchivePath)
+	plainChecksum, err := backup.GenerateChecksumBounded(ctx, logger, plainArchivePath, timeout)
 	if err != nil {
 		cleanup()
 		return nil, fmt.Errorf("generate checksum: %w", err)

--- a/internal/orchestrator/decrypt_restore_timeout_test.go
+++ b/internal/orchestrator/decrypt_restore_timeout_test.go
@@ -1,0 +1,147 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/backup"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/safefs"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// verifyStagedArchiveIntegrity must thread FS_IO_TIMEOUT into the bounded checksum
+// verify: a staged archive on a wedged mount (a FIFO with no writer) must time out,
+// not hang. A regression that drops the timeout (reverts to the unbounded
+// VerifyChecksum wrapper, or passes 0) would hang here and trip the guard.
+func TestVerifyStagedArchiveIntegrityThreadsTimeout(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "archive.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+	t.Cleanup(func() {
+		if w, e := os.OpenFile(fifo, os.O_WRONLY, 0); e == nil {
+			_ = w.Close() // release the abandoned blocked open
+		}
+	})
+
+	cand := &backupCandidate{
+		Integrity: &stagedIntegrityExpectation{
+			Checksum: strings.Repeat("a", 64),
+			Source:   "checksum file",
+		},
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := verifyStagedArchiveIntegrity(
+			context.Background(),
+			logging.New(types.LogLevelError, false),
+			stagedFiles{ArchivePath: fifo},
+			cand,
+			time.Second,
+		)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, safefs.ErrTimeout) {
+			t.Fatalf("want safefs.ErrTimeout, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("verifyStagedArchiveIntegrity hung: FS_IO_TIMEOUT was not threaded into the bounded verify")
+	}
+}
+
+// preparePlainBundleCommon must thread its timeout into the plain-archive hash
+// (backup.GenerateChecksumBounded). The decrypt callback writes the plain archive,
+// so we make it a FIFO: the bounded hash then wedges on the read and the threaded
+// timeout must turn it into safefs.ErrTimeout, not a hang. A paired writer goroutine
+// is released after the assertion so the abandoned worker EOFs cleanly (no leak).
+func TestPreparePlainBundleCommon_ThreadsTimeoutIntoPlainChecksum(t *testing.T) {
+	origFS := restoreFS
+	restoreFS = osFS{}
+	t.Cleanup(func() { restoreFS = origFS })
+
+	dir := t.TempDir()
+	workArchive := filepath.Join(dir, "backup.tar.xz.age")
+	if err := os.WriteFile(workArchive, []byte("ciphertext"), 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "backup.metadata")
+	if err := os.WriteFile(manifestPath, []byte(`{"encryption_mode":"age"}`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	checksumPath := filepath.Join(dir, "backup.sha256")
+	if err := os.WriteFile(checksumPath, checksumLineForBytes(filepath.Base(workArchive), []byte("ciphertext")), 0o600); err != nil {
+		t.Fatalf("write checksum: %v", err)
+	}
+
+	cand := &backupCandidate{
+		Manifest:        &backup.Manifest{ArchivePath: workArchive, EncryptionMode: "age"},
+		Source:          sourceRaw,
+		RawArchivePath:  workArchive,
+		RawMetadataPath: manifestPath,
+		RawChecksumPath: checksumPath,
+		DisplayBase:     "backup.tar.xz.age",
+	}
+	logger := logging.New(types.LogLevelError, false)
+	logger.SetOutput(io.Discard)
+
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	skipped := make(chan struct{}, 1)
+
+	decrypt := func(ctx context.Context, encryptedPath, outputPath, displayName string) error {
+		if err := syscall.Mkfifo(outputPath, 0o600); err != nil {
+			skipped <- struct{}{}
+			return err
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w, e := os.OpenFile(outputPath, os.O_WRONLY, 0)
+			if e != nil {
+				return
+			}
+			<-release
+			_ = w.Close()
+		}()
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := preparePlainBundleCommon(context.Background(), cand, "1.0.0", logger, decrypt, time.Second)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		select {
+		case <-skipped:
+			close(release)
+			wg.Wait()
+			t.Skip("mkfifo unsupported")
+		default:
+		}
+		if !errors.Is(err, safefs.ErrTimeout) {
+			close(release)
+			wg.Wait()
+			t.Fatalf("want safefs.ErrTimeout from the plain-archive hash, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("preparePlainBundleCommon hung: FS_IO_TIMEOUT was not threaded into GenerateChecksumBounded")
+	}
+
+	close(release)
+	wg.Wait()
+}

--- a/internal/orchestrator/decrypt_restore_timeout_test.go
+++ b/internal/orchestrator/decrypt_restore_timeout_test.go
@@ -61,6 +61,42 @@ func TestVerifyStagedArchiveIntegrityThreadsTimeout(t *testing.T) {
 	}
 }
 
+// copyRawArtifactsToWorkdirWithLogger stages a LOCAL (non-rclone) raw backup by
+// reading the source from BACKUP_PATH/SECONDARY_PATH (which may be a dead/stale
+// network mount) into the local workdir. That source read must be bounded by
+// FS_IO_TIMEOUT so it cannot wedge the restore before the timeout-aware
+// checksum/decrypt steps. A blockingFS whose Open never returns simulates the dead
+// mount; reverting copyFileBounded to the unbounded copyFile (or dropping the
+// threaded timeout) hangs here and trips the watchdog.
+func TestCopyRawArtifactsToWorkdirBoundsLocalSourceOpen(t *testing.T) {
+	park := make(chan struct{})
+	t.Cleanup(func() { close(park) }) // release the abandoned source-open worker
+	useRestoreFS(t, &blockingFS{blockOpen: true, park: park})
+
+	cand := &backupCandidate{
+		Source:          sourceRaw,
+		RawArchivePath:  "/mnt/dead/backup.tar.xz",
+		RawMetadataPath: "/mnt/dead/backup.metadata",
+	}
+	workDir := t.TempDir()
+	logger := logging.New(types.LogLevelError, false)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := copyRawArtifactsToWorkdirWithLogger(context.Background(), cand, workDir, logger, time.Second)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, safefs.ErrTimeout) {
+			t.Fatalf("want safefs.ErrTimeout from a bounded source open, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("staging hung: the local raw source open is not bounded")
+	}
+}
+
 // preparePlainBundleCommon must thread its timeout into the plain-archive hash
 // (backup.GenerateChecksumBounded). The decrypt callback writes the plain archive,
 // so we make it a FIFO: the bounded hash then wedges on the read and the threaded

--- a/internal/orchestrator/decrypt_test.go
+++ b/internal/orchestrator/decrypt_test.go
@@ -2681,7 +2681,7 @@ func TestCopyRawArtifactsToWorkdir_ContextWorks(t *testing.T) {
 	useRestoreFS(t, osFS{})
 
 	fixture := createRawArtifactFixture(t, true, "")
-	staged, err := copyRawArtifactsToWorkdirWithLogger(context.TODO(), fixture.candidate, fixture.workDir, nil)
+	staged, err := copyRawArtifactsToWorkdirWithLogger(context.TODO(), fixture.candidate, fixture.workDir, nil, 0)
 	if err != nil {
 		t.Fatalf("copyRawArtifactsToWorkdirWithLogger error: %v", err)
 	}
@@ -2691,7 +2691,7 @@ func TestCopyRawArtifactsToWorkdir_ContextWorks(t *testing.T) {
 }
 
 func TestCopyRawArtifactsToWorkdirWithLogger_NilCandidate(t *testing.T) {
-	_, err := copyRawArtifactsToWorkdirWithLogger(context.Background(), nil, t.TempDir(), nil)
+	_, err := copyRawArtifactsToWorkdirWithLogger(context.Background(), nil, t.TempDir(), nil, 0)
 	if err == nil {
 		t.Fatal("expected error for nil candidate")
 	}
@@ -2715,7 +2715,7 @@ func TestCopyRawArtifactsToWorkdir_InvalidRclonePaths(t *testing.T) {
 		RawChecksumPath: "",
 	}
 
-	_, err := copyRawArtifactsToWorkdirWithLogger(context.Background(), cand, workDir, nil)
+	_, err := copyRawArtifactsToWorkdirWithLogger(context.Background(), cand, workDir, nil, 0)
 	if err == nil {
 		t.Fatal("expected error for invalid rclone paths")
 	}
@@ -3533,7 +3533,7 @@ func TestCopyRawArtifactsToWorkdir_WithChecksum(t *testing.T) {
 	useRestoreFS(t, osFS{})
 
 	fixture := createRawArtifactFixture(t, true, "checksum backup.tar.xz")
-	staged, err := copyRawArtifactsToWorkdirWithLogger(context.Background(), fixture.candidate, fixture.workDir, nil)
+	staged, err := copyRawArtifactsToWorkdirWithLogger(context.Background(), fixture.candidate, fixture.workDir, nil, 0)
 	if err != nil {
 		t.Fatalf("copyRawArtifactsToWorkdirWithLogger error: %v", err)
 	}
@@ -3853,7 +3853,7 @@ exit 0
 	ctx := context.Background()
 	logger := logging.New(types.LogLevelError, false)
 
-	_, err := copyRawArtifactsToWorkdirWithLogger(ctx, cand, workDir, logger)
+	_, err := copyRawArtifactsToWorkdirWithLogger(ctx, cand, workDir, logger, 0)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -3909,7 +3909,7 @@ fi
 	ctx := context.Background()
 	logger := logging.New(types.LogLevelError, false)
 
-	_, err := copyRawArtifactsToWorkdirWithLogger(ctx, cand, workDir, logger)
+	_, err := copyRawArtifactsToWorkdirWithLogger(ctx, cand, workDir, logger, 0)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}

--- a/internal/orchestrator/decrypt_test.go
+++ b/internal/orchestrator/decrypt_test.go
@@ -1664,7 +1664,7 @@ func TestPreparePlainBundle_UnsupportedSource(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(""))
 	logger := logging.New(types.LogLevelError, false)
 
-	_, err := preparePlainBundle(context.Background(), reader, cand, "", logger)
+	_, err := preparePlainBundle(context.Background(), reader, cand, "", logger, 0)
 	if err == nil {
 		t.Fatal("expected error for unsupported source")
 	}
@@ -1702,7 +1702,7 @@ func TestPreparePlainBundle_SourceBundleSuccess(t *testing.T) {
 	logger := logging.New(types.LogLevelError, false)
 	logger.SetOutput(io.Discard)
 
-	prepared, err := preparePlainBundle(context.Background(), reader, cand, "1.0.0", logger)
+	prepared, err := preparePlainBundle(context.Background(), reader, cand, "1.0.0", logger, 0)
 	if err != nil {
 		t.Fatalf("preparePlainBundle error: %v", err)
 	}
@@ -1734,7 +1734,7 @@ func TestPreparePlainBundle_ExtractError(t *testing.T) {
 	logger := logging.New(types.LogLevelError, false)
 	logger.SetOutput(io.Discard)
 
-	_, err := preparePlainBundle(context.Background(), reader, cand, "", logger)
+	_, err := preparePlainBundle(context.Background(), reader, cand, "", logger, 0)
 	if err == nil {
 		t.Fatal("expected error for nonexistent bundle")
 	}
@@ -2922,7 +2922,7 @@ func TestPreparePlainBundle_CopyFileSamePath(t *testing.T) {
 	logger := logging.New(types.LogLevelError, false)
 	logger.SetOutput(io.Discard)
 
-	prepared, err := preparePlainBundle(context.Background(), reader, cand, "1.0.0", logger)
+	prepared, err := preparePlainBundle(context.Background(), reader, cand, "1.0.0", logger, 0)
 	if err != nil {
 		t.Fatalf("preparePlainBundle error: %v", err)
 	}
@@ -3041,7 +3041,7 @@ esac
 	logger := logging.New(types.LogLevelError, false)
 	logger.SetOutput(io.Discard)
 
-	prepared, err := preparePlainBundle(context.Background(), reader, cand, "1.0.0", logger)
+	prepared, err := preparePlainBundle(context.Background(), reader, cand, "1.0.0", logger, 0)
 	if err != nil {
 		t.Fatalf("preparePlainBundle error: %v", err)
 	}
@@ -3097,7 +3097,7 @@ func TestPreparePlainBundleCommon_TrimmedAgeEncryptionTriggersDecrypt(t *testing
 			t.Fatalf("displayName=%q; want %q", displayName, "backup.tar.xz.age")
 		}
 		return os.WriteFile(outputPath, []byte("plaintext"), 0o600)
-	})
+	}, 0)
 	if err != nil {
 		t.Fatalf("preparePlainBundleCommon error: %v", err)
 	}
@@ -3157,7 +3157,7 @@ func TestPreparePlainBundleCommon_AgeModeRequiresAgeSuffix(t *testing.T) {
 	_, err := preparePlainBundleCommon(context.Background(), cand, "1.0.0", logger, func(ctx context.Context, encryptedPath, outputPath, displayName string) error {
 		decryptCalled = true
 		return nil
-	})
+	}, 0)
 	if err == nil {
 		t.Fatal("preparePlainBundleCommon error = nil; want missing .age suffix error")
 	}
@@ -3207,7 +3207,7 @@ func TestPreparePlainBundleCommon_NonAgeRejectsAgeSuffix(t *testing.T) {
 	_, err := preparePlainBundleCommon(context.Background(), cand, "1.0.0", logger, func(ctx context.Context, encryptedPath, outputPath, displayName string) error {
 		t.Fatal("decrypt callback should not be called for non-age archive handling")
 		return nil
-	})
+	}, 0)
 	if err == nil {
 		t.Fatal("preparePlainBundleCommon error = nil; want .age suffix mismatch error")
 	}
@@ -3377,7 +3377,7 @@ func TestPreparePlainBundle_SourceBundleAdditional(t *testing.T) {
 	logger := logging.New(types.LogLevelError, false)
 	logger.SetOutput(io.Discard)
 
-	prepared, err := preparePlainBundle(context.Background(), reader, cand, "1.0.0", logger)
+	prepared, err := preparePlainBundle(context.Background(), reader, cand, "1.0.0", logger, 0)
 	if err != nil {
 		t.Fatalf("preparePlainBundle error: %v", err)
 	}
@@ -3654,7 +3654,7 @@ func TestPreparePlainBundle_MkdirAllError(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(""))
 	logger := logging.New(types.LogLevelError, false)
 
-	_, err := preparePlainBundle(ctx, reader, cand, "", logger)
+	_, err := preparePlainBundle(ctx, reader, cand, "", logger, 0)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -3680,7 +3680,7 @@ func TestPreparePlainBundle_MkdirTempError(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(""))
 	logger := logging.New(types.LogLevelError, false)
 
-	_, err := preparePlainBundle(ctx, reader, cand, "", logger)
+	_, err := preparePlainBundle(ctx, reader, cand, "", logger, 0)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -4087,7 +4087,7 @@ func TestPreparePlainBundle_StatErrorAfterExtract(t *testing.T) {
 
 	// The test shows that with proper setup, stat error would be triggered
 	// For now, run with FakeFS to cover the MkdirAll/MkdirTemp paths
-	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger)
+	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger, 0)
 	if err != nil {
 		// This is expected for stat errors
 		if strings.Contains(err.Error(), "stat") {
@@ -4125,7 +4125,7 @@ exit 1
 	reader := bufio.NewReader(strings.NewReader(""))
 	logger := logging.New(types.LogLevelError, false)
 
-	_, err := preparePlainBundle(ctx, reader, cand, "", logger)
+	_, err := preparePlainBundle(ctx, reader, cand, "", logger, 0)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -4179,7 +4179,7 @@ exit 1
 
 	// This test verifies the rclone download + cleanup path works
 	// The MkdirAllErr would affect downloadRcloneBackup first, so we test separately
-	bundle, err := preparePlainBundle(ctx, reader, cand, "", logger)
+	bundle, err := preparePlainBundle(ctx, reader, cand, "", logger, 0)
 	restoreFS = orig // Restore FS
 
 	if err != nil {
@@ -4362,7 +4362,7 @@ func TestPreparePlainBundle_CopyFileError(t *testing.T) {
 		&backup.Manifest{EncryptionMode: "none", Hostname: "test"},
 	)
 
-	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger)
+	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger, 0)
 	// This test verifies that the path goes through successfully for plain archives
 	// The actual copy error would require more complex mocking
 	if err != nil {
@@ -4453,7 +4453,7 @@ func TestPreparePlainBundle_StatErrorOnPlainArchive(t *testing.T) {
 		&backup.Manifest{EncryptionMode: "none", Hostname: "test"},
 	)
 
-	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger)
+	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger, 0)
 	if err == nil {
 		if bundle != nil {
 			bundle.Cleanup()
@@ -4513,7 +4513,7 @@ exit 0
 	logger := logging.New(types.LogLevelError, false)
 
 	// This test verifies the flow works - checking rclone cleanup is called on error
-	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger)
+	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger, 0)
 	if bundle != nil {
 		bundle.Cleanup()
 	}
@@ -4558,7 +4558,7 @@ func TestPreparePlainBundle_GenerateChecksumErrorPath(t *testing.T) {
 		&backup.Manifest{EncryptionMode: "none", Hostname: "test"},
 	)
 
-	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger)
+	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger, 0)
 	if err == nil {
 		if bundle != nil {
 			bundle.Cleanup()
@@ -4633,7 +4633,7 @@ exit 0
 	reader := bufio.NewReader(strings.NewReader(""))
 	logger := logging.New(types.LogLevelError, false)
 
-	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger)
+	bundle, err := preparePlainBundle(ctx, reader, cand, "1.0.0", logger, 0)
 	if err == nil {
 		if bundle != nil {
 			bundle.Cleanup()

--- a/internal/orchestrator/decrypt_workflow_test.go
+++ b/internal/orchestrator/decrypt_workflow_test.go
@@ -102,7 +102,7 @@ func TestPreparePlainBundle_AllowsMissingRawChecksumSidecar(t *testing.T) {
 	restoreFS = osFS{}
 	t.Cleanup(func() { restoreFS = osFS{} })
 
-	if _, err := preparePlainBundle(context.Background(), reader, cand, "", logging.New(types.LogLevelInfo, false)); err != nil {
+	if _, err := preparePlainBundle(context.Background(), reader, cand, "", logging.New(types.LogLevelInfo, false), 0); err != nil {
 		t.Fatalf("expected manifest checksum to cover missing sidecar, got error: %v", err)
 	}
 }

--- a/internal/orchestrator/decrypt_workflow_ui.go
+++ b/internal/orchestrator/decrypt_workflow_ui.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"filippo.io/age"
 	"github.com/tis24dev/proxsave/internal/backup"
@@ -199,7 +200,7 @@ func decryptArchiveWithSecretPrompt(ctx context.Context, encryptedPath, outputPa
 
 func preparePlainBundleWithUI(ctx context.Context, cand *backupCandidate, version string, logger *logging.Logger, ui interface {
 	PromptDecryptSecret(ctx context.Context, displayName, previousError string) (string, error)
-}) (bundle *preparedBundle, err error) {
+}, timeout time.Duration) (bundle *preparedBundle, err error) {
 	if cand == nil || cand.Manifest == nil {
 		return nil, fmt.Errorf("invalid backup candidate")
 	}
@@ -212,7 +213,7 @@ func preparePlainBundleWithUI(ctx context.Context, cand *backupCandidate, versio
 	extraSalts := manifestPassphraseSalts(cand.Manifest)
 	return preparePlainBundleCommon(ctx, cand, version, logger, func(ctx context.Context, encryptedPath, outputPath, displayName string) error {
 		return decryptArchiveWithSecretPrompt(ctx, encryptedPath, outputPath, displayName, ui.PromptDecryptSecret, extraSalts)
-	})
+	}, timeout)
 }
 
 func runDecryptWorkflowWithUI(ctx context.Context, cfg *config.Config, logger *logging.Logger, version string, ui DecryptWorkflowUI) (err error) {
@@ -241,7 +242,7 @@ func runDecryptWorkflowWithUI(ctx context.Context, cfg *config.Config, logger *l
 		return err
 	}
 
-	prepared, err := preparePlainBundleWithUI(ctx, candidate, version, logger, ui)
+	prepared, err := preparePlainBundleWithUI(ctx, candidate, version, logger, ui, fsIoTimeoutFromConfig(cfg))
 	if err != nil {
 		return err
 	}

--- a/internal/orchestrator/decrypt_workflow_ui_test.go
+++ b/internal/orchestrator/decrypt_workflow_ui_test.go
@@ -202,7 +202,7 @@ func TestPreparePlainBundleWithUICopiesRawArtifacts(t *testing.T) {
 
 	ctx := context.Background()
 	prompter := &countingSecretPrompter{}
-	prepared, err := preparePlainBundleWithUI(ctx, cand, "1.0.0", logger, prompter)
+	prepared, err := preparePlainBundleWithUI(ctx, cand, "1.0.0", logger, prompter, 0)
 	if err != nil {
 		t.Fatalf("preparePlainBundleWithUI error: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestPreparePlainBundleWithUIRejectsInvalidCandidate(t *testing.T) {
 	logger := logging.New(types.LogLevelError, false)
 	ctx := context.Background()
 	prompter := &countingSecretPrompter{}
-	if _, err := preparePlainBundleWithUI(ctx, nil, "", logger, prompter); err == nil {
+	if _, err := preparePlainBundleWithUI(ctx, nil, "", logger, prompter, 0); err == nil {
 		t.Fatalf("expected error for nil candidate")
 	}
 }
@@ -268,7 +268,7 @@ func TestPreparePlainBundleWithUIRejectsMissingUI(t *testing.T) {
 		DisplayBase:     "test-backup",
 	}
 
-	if _, err := preparePlainBundleWithUI(context.Background(), cand, "1.0.0", logger, nil); err == nil {
+	if _, err := preparePlainBundleWithUI(context.Background(), cand, "1.0.0", logger, nil, 0); err == nil {
 		t.Fatalf("expected error for missing UI")
 	}
 }
@@ -335,7 +335,7 @@ func TestPreparePlainBundleWithUIRejectsTypedNilUI(t *testing.T) {
 
 	var typedNil *countingSecretPrompter
 
-	if _, err := preparePlainBundleWithUI(context.Background(), cand, "1.0.0", logger, typedNil); err == nil {
+	if _, err := preparePlainBundleWithUI(context.Background(), cand, "1.0.0", logger, typedNil, 0); err == nil {
 		t.Fatal("expected error for typed-nil UI")
 	}
 }

--- a/internal/orchestrator/dispatch_log_timeout_test.go
+++ b/internal/orchestrator/dispatch_log_timeout_test.go
@@ -133,6 +133,45 @@ func TestDispatchLogFileCloudSourceProbeTimeout(t *testing.T) {
 	}
 }
 
+// The cloud log upload must be dispatched on a context DETACHED from the run
+// ctx: at shutdown the log must still ship even when the run was cancelled
+// (Ctrl+C). If the run ctx is threaded into the upload, a cancelled run skips
+// the cloud copy with context.Canceled and the operator loses the log of the
+// very run they interrupted. This pins the upload to context.Background():
+// reverting extensions.go to copyLogToCloud(ctx, ...) turns this test red.
+func TestDispatchLogFileCloudUploadDetachesFromCancelledRunCtx(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logging.New(types.LogLevelInfo, false)
+	logger.SetOutput(&buf)
+	cfg := &config.Config{CloudEnabled: true, CloudLogPath: "/logs", CloudRemote: "remote", FsIoTimeoutSeconds: 30}
+	o := &Orchestrator{logger: logger, cfg: cfg}
+
+	var uploaded bool
+	var uploadCtxErr error
+	o.copyLogToCloudFn = func(ctx context.Context, _, _ string) error {
+		uploaded = true
+		uploadCtxErr = ctx.Err() // the upload must NOT see a cancelled context
+		return nil
+	}
+
+	src := writeSrcLog(t)
+	runCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate Ctrl+C before the finalize/dispatch step
+
+	if err := o.dispatchLogFile(runCtx, src); err != nil {
+		t.Fatalf("dispatchLogFile: %v", err)
+	}
+	if !uploaded {
+		t.Fatalf("cloud upload was not attempted; the source probe must pass for a healthy local log:\n%s", buf.String())
+	}
+	if uploadCtxErr != nil {
+		t.Fatalf("cloud upload received a cancelled context (%v); it must run on a context detached from the run ctx so the log still ships after Ctrl+C", uploadCtxErr)
+	}
+	if !strings.Contains(buf.String(), "Log copied to cloud") {
+		t.Fatalf("expected a success log for the dispatched cloud upload; got:\n%s", buf.String())
+	}
+}
+
 func TestDispatchLogFileHealthyBoundedCopies(t *testing.T) {
 	var buf bytes.Buffer
 	logger := logging.New(types.LogLevelInfo, false)

--- a/internal/orchestrator/dispatch_log_timeout_test.go
+++ b/internal/orchestrator/dispatch_log_timeout_test.go
@@ -1,0 +1,159 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+var errBlockReleased = errors.New("blocked op released")
+
+// blockingFS wraps osFS and blocks a chosen operation on a channel (simulating a
+// dead/stale mount whose syscall never returns) until park is closed in cleanup.
+type blockingFS struct {
+	osFS
+	blockOpen, blockMkdir, blockStat bool
+	park                             chan struct{}
+}
+
+func (f *blockingFS) Open(p string) (*os.File, error) {
+	if f.blockOpen {
+		<-f.park
+		return nil, errBlockReleased
+	}
+	return f.osFS.Open(p)
+}
+
+func (f *blockingFS) MkdirAll(p string, m os.FileMode) error {
+	if f.blockMkdir {
+		<-f.park
+		return errBlockReleased
+	}
+	return f.osFS.MkdirAll(p, m)
+}
+
+func (f *blockingFS) Stat(p string) (os.FileInfo, error) {
+	if f.blockStat {
+		<-f.park
+		return nil, errBlockReleased
+	}
+	return f.osFS.Stat(p)
+}
+
+func runDispatchWithWatchdog(t *testing.T, o *Orchestrator, src string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		_ = o.dispatchLogFile(context.Background(), src)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatchLogFile hung on a dead mount")
+	}
+}
+
+func writeSrcLog(t *testing.T) string {
+	t.Helper()
+	src := filepath.Join(t.TempDir(), "backup.log")
+	if err := os.WriteFile(src, []byte("logdata"), 0o640); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	return src
+}
+
+func TestDispatchLogFileSecondaryCopyTimeout(t *testing.T) {
+	park := make(chan struct{})
+	t.Cleanup(func() { close(park) })
+
+	var buf bytes.Buffer
+	logger := logging.New(types.LogLevelInfo, false)
+	logger.SetOutput(&buf)
+	secondary := t.TempDir()
+	cfg := &config.Config{SecondaryEnabled: true, SecondaryLogPath: secondary, FsIoTimeoutSeconds: 1}
+	o := &Orchestrator{logger: logger, cfg: cfg, fs: &blockingFS{blockOpen: true, park: park}}
+
+	src := writeSrcLog(t)
+	runDispatchWithWatchdog(t, o, src)
+
+	if !strings.Contains(buf.String(), "timed out") {
+		t.Fatalf("expected a timeout warning, got:\n%s", buf.String())
+	}
+	if _, err := os.Stat(filepath.Join(secondary, "backup.log")); !os.IsNotExist(err) {
+		t.Fatalf("secondary copy must be skipped on timeout; stat err = %v", err)
+	}
+}
+
+func TestDispatchLogFileSecondaryMkdirTimeout(t *testing.T) {
+	park := make(chan struct{})
+	t.Cleanup(func() { close(park) })
+
+	var buf bytes.Buffer
+	logger := logging.New(types.LogLevelInfo, false)
+	logger.SetOutput(&buf)
+	cfg := &config.Config{SecondaryEnabled: true, SecondaryLogPath: filepath.Join(t.TempDir(), "sub"), FsIoTimeoutSeconds: 1}
+	o := &Orchestrator{logger: logger, cfg: cfg, fs: &blockingFS{blockMkdir: true, park: park}}
+
+	src := writeSrcLog(t)
+	runDispatchWithWatchdog(t, o, src)
+
+	if !strings.Contains(buf.String(), "creating") || !strings.Contains(buf.String(), "timed out") {
+		t.Fatalf("expected a mkdir-timeout warning, got:\n%s", buf.String())
+	}
+}
+
+func TestDispatchLogFileCloudSourceProbeTimeout(t *testing.T) {
+	park := make(chan struct{})
+	t.Cleanup(func() { close(park) })
+
+	var buf bytes.Buffer
+	logger := logging.New(types.LogLevelInfo, false)
+	logger.SetOutput(&buf)
+	cfg := &config.Config{CloudEnabled: true, CloudLogPath: "/logs", CloudRemote: "remote", FsIoTimeoutSeconds: 1}
+	o := &Orchestrator{logger: logger, cfg: cfg, fs: &blockingFS{blockStat: true, park: park}}
+
+	src := writeSrcLog(t)
+	runDispatchWithWatchdog(t, o, src)
+
+	if !strings.Contains(buf.String(), "unreachable") {
+		t.Fatalf("expected a cloud source-probe timeout warning, got:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), "Failed to copy log to cloud") {
+		t.Fatalf("cloud upload must not be attempted after a source-probe timeout:\n%s", buf.String())
+	}
+}
+
+func TestDispatchLogFileHealthyBoundedCopies(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logging.New(types.LogLevelInfo, false)
+	logger.SetOutput(&buf)
+	secondary := t.TempDir()
+	cfg := &config.Config{SecondaryEnabled: true, SecondaryLogPath: secondary, FsIoTimeoutSeconds: 30}
+	o := &Orchestrator{logger: logger, cfg: cfg}
+
+	src := writeSrcLog(t)
+	if err := o.dispatchLogFile(context.Background(), src); err != nil {
+		t.Fatalf("dispatchLogFile: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(secondary, "backup.log"))
+	if err != nil {
+		t.Fatalf("expected copied log: %v", err)
+	}
+	if string(data) != "logdata" {
+		t.Fatalf("content mismatch: %q", string(data))
+	}
+	if strings.Contains(buf.String(), "timed out") || strings.Contains(buf.String(), "Failed") {
+		t.Fatalf("healthy bounded copy must not warn:\n%s", buf.String())
+	}
+}

--- a/internal/orchestrator/extensions.go
+++ b/internal/orchestrator/extensions.go
@@ -433,7 +433,15 @@ func (o *Orchestrator) dispatchLogFile(ctx context.Context, logFilePath string) 
 				o.logger.Warning("Skipping cloud log copy: cannot stat source log %s: %v", logFilePath, probeErr)
 			default:
 				o.logger.Debug("Copying log to cloud: %s", destination)
-				if err := o.copyLogToCloud(ctx, logFilePath, destination); err != nil {
+				// Detach the upload from the (possibly cancelled) run ctx: like the
+				// secondary copy above, the log must still ship at shutdown after a
+				// Ctrl+C. UploadToRemotePath bounds a deadline-less ctx itself, so a
+				// stalled rclone cannot hang here.
+				upload := o.copyLogToCloud
+				if o.copyLogToCloudFn != nil {
+					upload = o.copyLogToCloudFn
+				}
+				if err := upload(context.Background(), logFilePath, destination); err != nil {
 					o.logger.Warning("Failed to copy log to cloud: %v", err)
 				} else {
 					o.logger.Info("✓ Log copied to cloud: %s", destination)

--- a/internal/orchestrator/extensions.go
+++ b/internal/orchestrator/extensions.go
@@ -2,14 +2,45 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/internal/storage"
 	"github.com/tis24dev/proxsave/internal/types"
 )
+
+// fsIoTimeout converts the configured FS_IO_TIMEOUT into a per-operation safefs
+// budget. A non-positive value (the explicit FS_IO_TIMEOUT=0 opt-out, or an unset
+// cfg) yields 0, which safefs treats as unbounded (legacy behaviour).
+func (o *Orchestrator) fsIoTimeout() time.Duration {
+	if o == nil || o.cfg == nil || o.cfg.FsIoTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(o.cfg.FsIoTimeoutSeconds) * time.Second
+}
+
+// boundedCopyFile copies src to dest, bounding the whole open(src)+open(dest)+
+// io.Copy+Sync as a single unit via safefs so a dead/stale mount on EITHER endpoint
+// cannot wedge the caller. It delegates to the shared copyFile (preserving the FS
+// seam) and leaves that generic helper untouched. timeout<=0 means unbounded
+// (FS_IO_TIMEOUT=0 opt-out). On timeout safefs abandons the worker goroutine (the
+// kernel call is not cancelled; fds are reclaimed at process exit) and returns a
+// *safefs.TimeoutError wrapping safefs.ErrTimeout. Intended for best-effort
+// shipping of the (small) run log, not for completeness-critical restore copies.
+func boundedCopyFile(ctx context.Context, fs FS, src, dest string, timeout time.Duration) error {
+	if timeout <= 0 {
+		return copyFile(fs, src, dest)
+	}
+	_, err := safefs.Run(ctx, "logcopy", dest, timeout, func() (struct{}, error) {
+		return struct{}{}, copyFile(fs, src, dest)
+	})
+	return err
+}
 
 // StorageTarget represents an external destination (e.g., secondary storage, cloud).
 type StorageTarget interface {
@@ -349,32 +380,64 @@ func (o *Orchestrator) dispatchLogFile(ctx context.Context, logFilePath string) 
 	logFileName := filepath.Base(logFilePath)
 	o.logger.Info("Dispatching log file: %s", logFileName)
 
-	// Copy to secondary storage
+	// All log-dispatch FS ops are bounded by FS_IO_TIMEOUT so a dead/stale mount on
+	// the source (LOG_PATH), the secondary destination (SecondaryLogPath), or the
+	// cloud local source cannot wedge the finalize in an uninterruptible (D-state)
+	// syscall. On timeout: warn and skip that destination (best-effort). Background
+	// ctx (not the run ctx): the log must ship at shutdown even when the run was
+	// cancelled (Ctrl+C); FS_IO_TIMEOUT alone bounds it.
+	timeout := o.fsIoTimeout()
+
+	// Copy to secondary storage. Bound the dir-create and the copy: both the source
+	// read (LOG_PATH) and the destination write (SecondaryLogPath) may be dead mounts.
 	if o.cfg.SecondaryEnabled && o.cfg.SecondaryLogPath != "" {
 		secondaryLogPath := filepath.Join(o.cfg.SecondaryLogPath, logFileName)
 		o.logger.Debug("Copying log to secondary: %s", secondaryLogPath)
 
-		if err := fs.MkdirAll(o.cfg.SecondaryLogPath, 0755); err != nil {
-			o.logger.Warning("Failed to create secondary log directory: %v", err)
-		} else {
-			if err := copyFile(fs, logFilePath, secondaryLogPath); err != nil {
-				o.logger.Warning("Failed to copy log to secondary: %v", err)
-			} else {
+		_, mkErr := safefs.Run(context.Background(), "logmkdir", o.cfg.SecondaryLogPath, timeout, func() (struct{}, error) {
+			return struct{}{}, fs.MkdirAll(o.cfg.SecondaryLogPath, 0755)
+		})
+		switch {
+		case mkErr != nil && errors.Is(mkErr, safefs.ErrTimeout):
+			o.logger.Warning("Skipping secondary log copy: creating %s timed out after %s (dead/stale mount?)", o.cfg.SecondaryLogPath, timeout)
+		case mkErr != nil:
+			o.logger.Warning("Failed to create secondary log directory: %v", mkErr)
+		default:
+			switch err := boundedCopyFile(context.Background(), fs, logFilePath, secondaryLogPath, timeout); {
+			case err == nil:
 				o.logger.Info("✓ Log copied to secondary: %s", secondaryLogPath)
+			case errors.Is(err, safefs.ErrTimeout):
+				o.logger.Warning("Skipping secondary log copy: copy to %s timed out after %s (dead/stale mount?)", secondaryLogPath, timeout)
+			default:
+				o.logger.Warning("Failed to copy log to secondary: %v", err)
 			}
 		}
 	}
 
-	// Copy to cloud storage
+	// Copy to cloud storage. rclone reads the LOCAL source log; a dead/stale LOG_PATH
+	// mount can wedge that read in an uninterruptible syscall that rclone's own
+	// --timeout (remote IO) and the deadline-less ctx do not bound. Probe the source
+	// with a bounded stat first and skip the cloud copy if it is unreachable.
 	if o.cfg.CloudEnabled {
 		if cloudBase := strings.TrimSpace(o.cfg.CloudLogPath); cloudBase != "" {
 			destination := buildCloudLogDestination(cloudBase, logFileName, o.cfg.CloudRemote)
-			o.logger.Debug("Copying log to cloud: %s", destination)
 
-			if err := o.copyLogToCloud(ctx, logFilePath, destination); err != nil {
-				o.logger.Warning("Failed to copy log to cloud: %v", err)
-			} else {
-				o.logger.Info("✓ Log copied to cloud: %s", destination)
+			_, probeErr := safefs.Run(context.Background(), "logstat", logFilePath, timeout, func() (struct{}, error) {
+				_, e := fs.Stat(logFilePath)
+				return struct{}{}, e
+			})
+			switch {
+			case probeErr != nil && errors.Is(probeErr, safefs.ErrTimeout):
+				o.logger.Warning("Skipping cloud log copy: source log %s unreachable after %s (dead/stale mount?)", logFilePath, timeout)
+			case probeErr != nil:
+				o.logger.Warning("Skipping cloud log copy: cannot stat source log %s: %v", logFilePath, probeErr)
+			default:
+				o.logger.Debug("Copying log to cloud: %s", destination)
+				if err := o.copyLogToCloud(ctx, logFilePath, destination); err != nil {
+					o.logger.Warning("Failed to copy log to cloud: %v", err)
+				} else {
+					o.logger.Info("✓ Log copied to cloud: %s", destination)
+				}
 			}
 		}
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -951,6 +951,13 @@ func (o *Orchestrator) cleanupPreviousExecutionArtifacts(ctx context.Context) *T
 		_, err := safefs.Run(ctx, "cleanup-remove", file, timeout, func() (struct{}, error) {
 			return struct{}{}, fs.Remove(file)
 		})
+		// already gone == success: covers both the inherent glob->remove TOCTOU race
+		// and the duplicate cpu-*.pprof entry when LOG_PATH itself is /tmp/proxsave
+		// (the legacy and the /tmp/proxsave globs match the same file). A dead-mount
+		// timeout is *TimeoutError (never os.ErrNotExist), so it still counts as failed.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 		return err
 	}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -215,6 +215,11 @@ type Orchestrator struct {
 
 	// Unprivileged container context (computed once by CLI and injected into collectors).
 	unprivilegedContainerDetector func() (bool, string)
+
+	// copyLogToCloudFn overrides the cloud log upload (test-only seam); nil uses
+	// the real o.copyLogToCloud. Lets tests assert the upload is dispatched on a
+	// detached context even when the run ctx was cancelled (Ctrl+C).
+	copyLogToCloudFn func(ctx context.Context, sourcePath, destPath string) error
 }
 
 const tempDirCleanupAge = 24 * time.Hour

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/metrics"
 	"github.com/tis24dev/proxsave/internal/notify"
+	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/internal/storage"
 	"github.com/tis24dev/proxsave/internal/types"
 )
@@ -520,7 +521,7 @@ func (o *Orchestrator) RunGoBackup(ctx context.Context, envInfo *environment.Env
 	o.logger.Info("Starting Go-based backup orchestration for %s", run.proxmoxType)
 
 	workspace := &backupWorkspace{
-		registry: o.cleanupPreviousExecutionArtifacts(),
+		registry: o.cleanupPreviousExecutionArtifacts(ctx),
 		fs:       o.filesystem(),
 	}
 	stats = o.initBackupRun(run)
@@ -936,23 +937,41 @@ func (o *Orchestrator) SaveStatsReport(stats *BackupStats) (err error) {
 
 // cleanupPreviousExecutionArtifacts performs unified cleanup of old JSON stats, pprof files,
 // and orphaned temp directories. Returns the TempDirRegistry for use by the caller.
-func (o *Orchestrator) cleanupPreviousExecutionArtifacts() *TempDirRegistry {
+func (o *Orchestrator) cleanupPreviousExecutionArtifacts(ctx context.Context) *TempDirRegistry {
 	fs := o.filesystem()
+	timeout := o.fsIoTimeout()
+	// boundedRemove bounds each fs.Remove so a dead/stale LOG_PATH mount cannot wedge
+	// the cleanup phase (timeout<=0 degrades to a direct call; /tmp removes are local).
+	boundedRemove := func(file string) error {
+		_, err := safefs.Run(ctx, "cleanup-remove", file, timeout, func() (struct{}, error) {
+			return struct{}{}, fs.Remove(file)
+		})
+		return err
+	}
 
-	// Discover JSON stats files and pprof profiles from previous runs
+	// Discover JSON stats files and pprof profiles from previous runs. The LOG_PATH
+	// globs are bounded: filepath.Glob does a raw lstat+readdir that a dead/stale mount
+	// would wedge. The /tmp/proxsave globs below are local and stay raw.
 	var statsFiles []string
 	var cpuProfiles []string
 	var heapProfiles []string
 	if o.logPath != "" {
-		if matches, err := filepath.Glob(filepath.Join(o.logPath, "backup-stats-*.json")); err == nil {
+		if matches, err := safefs.Run(ctx, "cleanup-glob", o.logPath, timeout, func() ([]string, error) {
+			return filepath.Glob(filepath.Join(o.logPath, "backup-stats-*.json"))
+		}); err == nil {
 			statsFiles = matches
+		} else if errors.Is(err, safefs.ErrTimeout) {
+			o.logger.Debug("Cleanup: globbing stats files under %s timed out after %s; skipping (dead/stale mount?)", o.logPath, timeout)
 		}
 
 		// Legacy: pre-fix versions wrote cpu-*.pprof under LOG_PATH; sweep them so an
-		// upgrade does not orphan them (this block already globs LOG_PATH for stats,
-		// so it adds no new dead-mount surface to cleanup).
-		if matches, err := filepath.Glob(filepath.Join(o.logPath, "cpu-*.pprof")); err == nil {
+		// upgrade does not orphan them.
+		if matches, err := safefs.Run(ctx, "cleanup-glob", o.logPath, timeout, func() ([]string, error) {
+			return filepath.Glob(filepath.Join(o.logPath, "cpu-*.pprof"))
+		}); err == nil {
 			cpuProfiles = matches
+		} else if errors.Is(err, safefs.ErrTimeout) {
+			o.logger.Debug("Cleanup: globbing legacy cpu profiles under %s timed out after %s; skipping (dead/stale mount?)", o.logPath, timeout)
 		}
 	}
 
@@ -982,7 +1001,7 @@ func (o *Orchestrator) cleanupPreviousExecutionArtifacts() *TempDirRegistry {
 
 		for _, file := range statsFiles {
 			filename := filepath.Base(file)
-			if err := fs.Remove(file); err != nil {
+			if err := boundedRemove(file); err != nil {
 				o.logger.Debug("Failed to remove file %s: %v", filename, err)
 				failedFiles++
 			} else {
@@ -1002,7 +1021,7 @@ func (o *Orchestrator) cleanupPreviousExecutionArtifacts() *TempDirRegistry {
 
 		for _, file := range cpuProfiles {
 			filename := filepath.Base(file)
-			if err := fs.Remove(file); err != nil {
+			if err := boundedRemove(file); err != nil {
 				o.logger.Debug("Failed to remove CPU profile %s: %v", filename, err)
 				failedFiles++
 			} else {
@@ -1022,7 +1041,7 @@ func (o *Orchestrator) cleanupPreviousExecutionArtifacts() *TempDirRegistry {
 
 		for _, file := range heapProfiles {
 			filename := filepath.Base(file)
-			if err := fs.Remove(file); err != nil {
+			if err := boundedRemove(file); err != nil {
 				o.logger.Debug("Failed to remove heap profile %s: %v", filename, err)
 				failedFiles++
 			} else {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1246,3 +1246,62 @@ func copyFile(fs FS, src, dest string) (err error) {
 	}
 	return out.Sync()
 }
+
+// copyFileBounded is copyFile with an FS_IO_TIMEOUT bound on the dead-mount-prone
+// source read: a stalled source Open or a mid-stream read on a dead/stale mount
+// (e.g. a network BACKUP_PATH/SECONDARY_PATH) cannot wedge the copy in an
+// uninterruptible (D-state) syscall. The source Open goes through the FS
+// abstraction (so an injected fs is honored) wrapped in safefs.Run, and the byte
+// stream uses safefs.CopyBounded's per-chunk stall budget. timeout<=0 falls back
+// to the unbounded copyFile (the FS_IO_TIMEOUT opt-out). On abandonment the worker
+// may still hold the handles, so they are dropped (not closed) and reclaimed by
+// the os.File finalizer. The dest is the local workDir, so its open stays raw.
+func copyFileBounded(ctx context.Context, fs FS, src, dest string, timeout time.Duration) (err error) {
+	if fs == nil {
+		fs = osFS{}
+	}
+	if timeout <= 0 {
+		return copyFile(fs, src, dest)
+	}
+
+	in, err := safefs.Run(ctx, "copy source open", src, timeout, func() (*os.File, error) {
+		return fs.Open(src)
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// Best-effort, bounded read-side close. An abandoned copy worker may still
+		// hold this fd (in==nil below) -> skip it; the finalizer reclaims it. A close
+		// error on the read-only source does not invalidate the already-written
+		// staged copy, so it must not fail the staging.
+		if in == nil {
+			return
+		}
+		_, _ = safefs.Run(ctx, "copy source close", src, timeout, func() (struct{}, error) {
+			return struct{}{}, in.Close()
+		})
+	}()
+
+	out, err := fs.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if out == nil { // abandoned worker may still hold this fd
+			return
+		}
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	if _, err = safefs.CopyBounded(ctx, out, in, 1<<20, timeout, "copy source", src); err != nil {
+		if safefs.IsAbandoned(err) {
+			in = nil // the abandoned worker may still touch both handles: skip the closes
+			out = nil
+		}
+		return err
+	}
+	return out.Sync()
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -948,12 +948,18 @@ func (o *Orchestrator) cleanupPreviousExecutionArtifacts() *TempDirRegistry {
 			statsFiles = matches
 		}
 
+		// Legacy: pre-fix versions wrote cpu-*.pprof under LOG_PATH; sweep them so an
+		// upgrade does not orphan them (this block already globs LOG_PATH for stats,
+		// so it adds no new dead-mount surface to cleanup).
 		if matches, err := filepath.Glob(filepath.Join(o.logPath, "cpu-*.pprof")); err == nil {
 			cpuProfiles = matches
 		}
 	}
 
-	// Heap profiles are written under /tmp/proxsave
+	// Profiles (cpu + heap) are now written under /tmp/proxsave.
+	if matches, err := filepath.Glob(filepath.Join("/tmp", "proxsave", "cpu-*.pprof")); err == nil {
+		cpuProfiles = append(cpuProfiles, matches...)
+	}
 	if matches, err := filepath.Glob(filepath.Join("/tmp", "proxsave", "heap-*.pprof")); err == nil {
 		heapProfiles = matches
 	}
@@ -986,7 +992,7 @@ func (o *Orchestrator) cleanupPreviousExecutionArtifacts() *TempDirRegistry {
 		}
 	}
 
-	// Phase 2: Cleanup CPU pprof files under log path
+	// Phase 2: Cleanup CPU pprof files (under /tmp/proxsave, plus any legacy ones under log path)
 	if len(cpuProfiles) > 0 {
 		if !cleanupStarted {
 			o.logger.Debug("Starting cleanup of previous execution files...")

--- a/internal/orchestrator/restore_workflow_ui.go
+++ b/internal/orchestrator/restore_workflow_ui.go
@@ -35,7 +35,7 @@ func prepareRestoreBundleWithUI(ctx context.Context, cfg *config.Config, logger 
 		return nil, nil, err
 	}
 
-	prepared, err := preparePlainBundleWithUI(ctx, candidate, version, logger, ui)
+	prepared, err := preparePlainBundleWithUI(ctx, candidate, version, logger, ui, fsIoTimeoutFromConfig(cfg))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/safefs/copy.go
+++ b/internal/safefs/copy.go
@@ -1,0 +1,88 @@
+package safefs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+// defaultCopyChunk is the streaming buffer size used when CopyBounded is called
+// with bufSize <= 0. With the default FS_IO_TIMEOUT this only requires a few tens
+// of KB/s of progress per chunk before a stall is declared, so it never penalises
+// a large copy over a slow-but-healthy link.
+const defaultCopyChunk = 1 << 20 // 1 MiB
+
+// IsAbandoned reports whether err came from a bounded operation whose worker
+// goroutine was abandoned (it timed out or its context was cancelled) and may
+// therefore still be touching its file handles and copy buffer. A caller that
+// owns those handles must NOT close them after an abandoned op: it should drop
+// its references and let the os.File finalizer reclaim the fd once the stuck
+// kernel call eventually returns.
+func IsAbandoned(err error) bool {
+	return errors.Is(err, ErrTimeout) || errors.Is(err, context.Canceled)
+}
+
+type copyChunk struct {
+	written int
+	eof     bool
+}
+
+// CopyBounded streams src into dst in fixed-size chunks, bounding each chunk's
+// read+write round-trip with timeout as a per-chunk no-progress (stall) budget,
+// NOT a whole-file deadline: every chunk that makes progress re-arms the budget,
+// so an arbitrarily large copy over a slow-but-alive link still succeeds. On a
+// stalled chunk the in-flight Read/Write worker is abandoned (the kernel call is
+// not cancelled) and a *TimeoutError (wrapping ErrTimeout) is returned.
+//
+// The copy deliberately runs limiter-free (see runBounded): the loop is
+// sequential, so it keeps at most one worker in flight and self-throttles its
+// spawn rate; routing it through the shared fsOpLimiter would let a long-lived
+// best-effort stream contend for, or on a wedge erode, the slot budget the
+// critical paths depend on. timeout <= 0 degrades to a direct synchronous copy
+// identical to a plain read/write loop (the FS_IO_TIMEOUT opt-out).
+//
+// The internal buffer is owned by CopyBounded and never escapes, so on an
+// abandoned chunk the worker is its sole remaining accessor; the caller must
+// still honour IsAbandoned for the src/dst handles it owns (do not close them).
+func CopyBounded(ctx context.Context, dst io.Writer, src io.Reader, bufSize int, timeout time.Duration, op, path string) (int64, error) {
+	if bufSize <= 0 {
+		bufSize = defaultCopyChunk
+	}
+	buf := make([]byte, bufSize)
+	var written int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, normalizeContextErr(ctx, &TimeoutError{Op: op, Path: path, Timeout: timeout})
+		}
+
+		te := &TimeoutError{Op: op, Path: path, Timeout: effectiveTimeout(ctx, timeout)}
+		chunk, err := runBounded(ctx, nil, timeout, te, func() (copyChunk, error) {
+			nr, rerr := src.Read(buf)
+			if nr > 0 {
+				nw, werr := dst.Write(buf[:nr])
+				if werr != nil {
+					return copyChunk{written: nw}, werr
+				}
+				if nw != nr {
+					return copyChunk{written: nw}, io.ErrShortWrite
+				}
+			}
+			if rerr != nil {
+				if rerr == io.EOF {
+					return copyChunk{written: nr, eof: true}, nil
+				}
+				return copyChunk{written: nr}, rerr
+			}
+			return copyChunk{written: nr}, nil
+		})
+
+		written += int64(chunk.written)
+		if err != nil {
+			return written, err
+		}
+		if chunk.eof {
+			return written, nil
+		}
+	}
+}

--- a/internal/safefs/copy_test.go
+++ b/internal/safefs/copy_test.go
@@ -1,0 +1,316 @@
+package safefs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// blockingReader delivers prefix on its first Read, then blocks on unblock for
+// every subsequent Read (a mount that hands over some bytes, then wedges).
+type blockingReader struct {
+	prefix  []byte
+	unblock <-chan struct{}
+	reads   atomic.Int32
+}
+
+func (r *blockingReader) Read(p []byte) (int, error) {
+	if r.reads.Add(1) == 1 && len(r.prefix) > 0 {
+		return copy(p, r.prefix), nil
+	}
+	<-r.unblock
+	return 0, io.EOF
+}
+
+// slowReader sleeps before each Read; used to prove the per-chunk budget fires
+// (small timeout) and the opt-out does not (timeout<=0).
+type slowReader struct {
+	data  []byte
+	off   int
+	delay time.Duration
+}
+
+func (r *slowReader) Read(p []byte) (int, error) {
+	time.Sleep(r.delay)
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	return n, nil
+}
+
+func TestCopyBounded_StallReturnsTimeout(t *testing.T) {
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+	r := &blockingReader{prefix: []byte("hello"), unblock: unblock}
+	var dst bytes.Buffer
+
+	type res struct {
+		n   int64
+		err error
+	}
+	// Run in a goroutine guarded by a deadline so an unbounded-loop regression
+	// fails fast here instead of hanging until the package test timeout.
+	done := make(chan res, 1)
+	go func() {
+		n, err := CopyBounded(context.Background(), &dst, r, 64, 25*time.Millisecond, "copy", "/x")
+		done <- res{n, err}
+	}()
+	select {
+	case got := <-done:
+		if got.err == nil || !errors.Is(got.err, ErrTimeout) {
+			t.Fatalf("CopyBounded err = %v; want timeout", got.err)
+		}
+		if got.n != int64(len("hello")) {
+			t.Fatalf("written = %d; want 5 (the chunk delivered before the stall)", got.n)
+		}
+		if dst.String() != "hello" {
+			t.Fatalf("dst = %q; want %q", dst.String(), "hello")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CopyBounded hung on a stalled reader")
+	}
+}
+
+func TestCopyBounded_HealthyMultiChunk(t *testing.T) {
+	data := make([]byte, 5*1024+123) // not a multiple of the chunk size
+	for i := range data {
+		data[i] = byte(i * 7)
+	}
+	var dst bytes.Buffer
+	n, err := CopyBounded(context.Background(), &dst, bytes.NewReader(data), 1024, time.Second, "copy", "/x")
+	if err != nil {
+		t.Fatalf("CopyBounded err = %v", err)
+	}
+	if n != int64(len(data)) {
+		t.Fatalf("written = %d; want %d", n, len(data))
+	}
+	if !bytes.Equal(dst.Bytes(), data) {
+		t.Fatalf("content mismatch")
+	}
+}
+
+// CopyBounded must run limiter-free: with the global pool saturated, a copy that
+// (wrongly) acquired a slot would block on acquire and time out. This one must
+// still succeed.
+func TestCopyBounded_BypassesLimiter(t *testing.T) {
+	prevStat := osStat
+	prevLimiter := fsOpLimiter
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "saturating stat", unblock, finished, func() {
+		osStat = prevStat
+		fsOpLimiter = prevLimiter
+	})
+
+	fsOpLimiter = newOperationLimiter(1)
+	osStat = func(string) (os.FileInfo, error) {
+		<-unblock
+		close(finished)
+		return nil, os.ErrNotExist
+	}
+	if _, err := Stat(context.Background(), "/blocked", 25*time.Millisecond); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("priming Stat err = %v; want timeout", err)
+	}
+	if got := fsOpLimiter.inflight(); got != 1 {
+		t.Fatalf("inflight after saturation = %d; want 1", got)
+	}
+
+	data := []byte("the limiter is saturated but this copy must still complete")
+	var dst bytes.Buffer
+	n, err := CopyBounded(context.Background(), &dst, bytes.NewReader(data), 8, time.Second, "copy", "/x")
+	if err != nil {
+		t.Fatalf("CopyBounded err = %v; want success despite a saturated limiter", err)
+	}
+	if n != int64(len(data)) || !bytes.Equal(dst.Bytes(), data) {
+		t.Fatalf("copy incorrect: n=%d content=%q", n, dst.String())
+	}
+}
+
+// timeout<=0 must degrade to a plain unbounded copy: a slow reader completes with
+// the opt-out, but the same reader trips a tiny per-chunk budget.
+func TestCopyBounded_ZeroTimeoutIsDirect(t *testing.T) {
+	data := []byte("zero timeout means a plain synchronous copy with no stall budget")
+
+	var dst bytes.Buffer
+	n, err := CopyBounded(context.Background(), &dst, &slowReader{data: data, delay: 15 * time.Millisecond}, 8, 0, "copy", "/x")
+	if err != nil {
+		t.Fatalf("opt-out CopyBounded err = %v; want success", err)
+	}
+	if n != int64(len(data)) || !bytes.Equal(dst.Bytes(), data) {
+		t.Fatalf("opt-out copy incorrect: n=%d", n)
+	}
+
+	_, err = CopyBounded(context.Background(), &bytes.Buffer{}, &slowReader{data: data, delay: 15 * time.Millisecond}, 8, time.Millisecond, "copy", "/x")
+	if err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("tiny-budget CopyBounded err = %v; want timeout", err)
+	}
+}
+
+// blockingWriter accepts its first Write, then blocks on every subsequent one
+// (a destination mount that wedges mid-stream — the realistic #242 direction).
+type blockingWriter struct {
+	writes  atomic.Int32
+	unblock <-chan struct{}
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	if w.writes.Add(1) == 1 {
+		return len(p), nil
+	}
+	<-w.unblock
+	return 0, io.EOF
+}
+
+type errReader struct{ err error }
+
+func (r *errReader) Read(p []byte) (int, error) { return 0, r.err }
+
+type shortWriter struct{}
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return len(p) - 1, nil
+}
+
+// eofWithDataReader returns data AND io.EOF in a single Read (the nr>0 && EOF
+// branch that real os.File/bytes.Reader never exercise).
+type eofWithDataReader struct {
+	data []byte
+	done bool
+}
+
+func (r *eofWithDataReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	return copy(p, r.data), io.EOF
+}
+
+// The budget is per-chunk, not a whole-file deadline: a copy whose cumulative
+// time far exceeds the budget, but whose every chunk is well under it, must
+// still succeed. A WithTimeout-style whole-file mutation fails this.
+func TestCopyBounded_PerChunkBudgetReArms(t *testing.T) {
+	const chunks = 30
+	data := make([]byte, chunks*8)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	r := &slowReader{data: data, delay: 10 * time.Millisecond} // ~300ms cumulative
+	var dst bytes.Buffer
+	n, err := CopyBounded(context.Background(), &dst, r, 8, 150*time.Millisecond, "copy", "/x")
+	if err != nil {
+		t.Fatalf("CopyBounded err = %v; a per-chunk budget must not accumulate across chunks", err)
+	}
+	if n != int64(len(data)) || !bytes.Equal(dst.Bytes(), data) {
+		t.Fatalf("copy incorrect: n=%d want %d", n, len(data))
+	}
+}
+
+// A destination that wedges mid-stream must time out, not hang. Only the read
+// side is covered by the FIFO storage test; this covers the write side.
+func TestCopyBounded_WriteStallReturnsTimeout(t *testing.T) {
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+	w := &blockingWriter{unblock: unblock}
+	src := bytes.NewReader(make([]byte, 64)) // several 8-byte chunks
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := CopyBounded(context.Background(), w, src, 8, 25*time.Millisecond, "copy", "/x")
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !errors.Is(err, ErrTimeout) {
+			t.Fatalf("CopyBounded err = %v; want timeout on a stalled writer", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CopyBounded hung on a stalled writer")
+	}
+}
+
+// A context cancel mid-copy must surface as context.Canceled AND be classified
+// abandoned (so the caller drops, never closes, the still-held handles).
+func TestCopyBounded_ContextCancelIsAbandoned(t *testing.T) {
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+	r := &blockingReader{unblock: unblock} // blocks on the first Read
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := CopyBounded(ctx, &bytes.Buffer{}, r, 8, time.Second, "copy", "/x")
+		done <- err
+	}()
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v; want context.Canceled", err)
+		}
+		if !IsAbandoned(err) {
+			t.Fatalf("IsAbandoned(%v) = false; a cancel must be treated as abandoned", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CopyBounded did not return after ctx cancel")
+	}
+}
+
+// A genuine (non-timeout, non-cancel) I/O error must propagate and must NOT be
+// classified abandoned, so the caller DOES close its handles afterwards.
+func TestCopyBounded_RealErrorsNotAbandoned(t *testing.T) {
+	sentinel := errors.New("disk exploded")
+	if _, err := CopyBounded(context.Background(), &bytes.Buffer{}, &errReader{err: sentinel}, 8, time.Second, "copy", "/x"); !errors.Is(err, sentinel) || IsAbandoned(err) {
+		t.Fatalf("read error: got %v (abandoned=%v); want sentinel, not abandoned", err, IsAbandoned(err))
+	}
+
+	if _, err := CopyBounded(context.Background(), &shortWriter{}, bytes.NewReader(make([]byte, 16)), 8, time.Second, "copy", "/x"); !errors.Is(err, io.ErrShortWrite) || IsAbandoned(err) {
+		t.Fatalf("short write: got %v (abandoned=%v); want io.ErrShortWrite, not abandoned", err, IsAbandoned(err))
+	}
+}
+
+func TestCopyBounded_DataWithEOFCountsBytes(t *testing.T) {
+	data := []byte("delivered together with EOF")
+	var dst bytes.Buffer
+	n, err := CopyBounded(context.Background(), &dst, &eofWithDataReader{data: data}, 1024, time.Second, "copy", "/x")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if n != int64(len(data)) || !bytes.Equal(dst.Bytes(), data) {
+		t.Fatalf("n=%d dst=%q; want %d bytes %q", n, dst.String(), len(data), data)
+	}
+}
+
+func TestIsAbandoned(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"ErrTimeout", ErrTimeout, true},
+		{"TimeoutError", &TimeoutError{Op: "x"}, true},
+		{"wrapped timeout", fmt.Errorf("outer: %w", ErrTimeout), true},
+		{"canceled", context.Canceled, true},
+		{"wrapped canceled", fmt.Errorf("outer: %w", context.Canceled), true},
+		{"short write", io.ErrShortWrite, false},
+		{"permission", os.ErrPermission, false},
+	}
+	for _, c := range cases {
+		if got := IsAbandoned(c.err); got != c.want {
+			t.Errorf("IsAbandoned(%s) = %v; want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/safefs/safefs.go
+++ b/internal/safefs/safefs.go
@@ -13,7 +13,11 @@ import (
 
 var (
 	osStat        = os.Stat
+	osLstat       = os.Lstat
 	osReadDir     = os.ReadDir
+	osMkdirAll    = os.MkdirAll
+	osChmod       = os.Chmod
+	osLchown      = os.Lchown
 	syscallStatfs = syscall.Statfs
 	fsOpLimiter   = newOperationLimiter(32)
 )
@@ -172,6 +176,52 @@ func Statfs(ctx context.Context, path string, timeout time.Duration) (syscall.St
 		err := statfs(path, &stat)
 		return stat, err
 	})
+}
+
+// Lstat is the bounded, non-symlink-following counterpart to Stat.
+func Lstat(ctx context.Context, path string, timeout time.Duration) (fs.FileInfo, error) {
+	lstat := osLstat
+	return runLimited(ctx, timeout, &TimeoutError{Op: "lstat", Path: path, Timeout: effectiveTimeout(ctx, timeout)}, func() (fs.FileInfo, error) {
+		return lstat(path)
+	})
+}
+
+// MkdirAll is the bounded counterpart to os.MkdirAll.
+func MkdirAll(ctx context.Context, path string, perm os.FileMode, timeout time.Duration) error {
+	mkdirAll := osMkdirAll
+	_, err := runLimited(ctx, timeout, &TimeoutError{Op: "mkdirall", Path: path, Timeout: effectiveTimeout(ctx, timeout)}, func() (struct{}, error) {
+		return struct{}{}, mkdirAll(path, perm)
+	})
+	return err
+}
+
+// Chmod is the bounded counterpart to os.Chmod (for permission-only modes it is
+// equivalent to syscall.Chmod).
+func Chmod(ctx context.Context, path string, mode os.FileMode, timeout time.Duration) error {
+	chmod := osChmod
+	_, err := runLimited(ctx, timeout, &TimeoutError{Op: "chmod", Path: path, Timeout: effectiveTimeout(ctx, timeout)}, func() (struct{}, error) {
+		return struct{}{}, chmod(path, mode)
+	})
+	return err
+}
+
+// Lchown is the bounded counterpart to os.Lchown (equivalent to syscall.Lchown).
+func Lchown(ctx context.Context, path string, uid, gid int, timeout time.Duration) error {
+	lchown := osLchown
+	_, err := runLimited(ctx, timeout, &TimeoutError{Op: "lchown", Path: path, Timeout: effectiveTimeout(ctx, timeout)}, func() (struct{}, error) {
+		return struct{}{}, lchown(path, uid, gid)
+	})
+	return err
+}
+
+// Run bounds an arbitrary composite filesystem operation with the same
+// goroutine+timer+limiter path used by the typed helpers above. Use it when a
+// single logical probe performs several syscalls that must all be bounded as a
+// unit (for example a create+chown+chmod+stat ownership probe). On timeout the
+// worker goroutine is abandoned (the kernel call is not cancelled) and a
+// *TimeoutError (wrapping ErrTimeout) is returned.
+func Run[T any](ctx context.Context, op, path string, timeout time.Duration, fn func() (T, error)) (T, error) {
+	return runLimited(ctx, timeout, &TimeoutError{Op: op, Path: path, Timeout: effectiveTimeout(ctx, timeout)}, fn)
 }
 
 // SpaceUsageFromStatfs converts statfs counters into total, user-available, and

--- a/internal/safefs/safefs.go
+++ b/internal/safefs/safefs.go
@@ -26,6 +26,17 @@ var (
 	fsOpLimiter   = newOperationLimiter(32)
 )
 
+// SetOsStatForTest overrides the os.Stat seam used by Stat and returns a restore
+// func. Test-only (cross-package): lets callers that bound their stat probes via
+// safefs.Stat prove a dead/stale mount cannot wedge them, by simulating a stat
+// syscall that never returns. Not safe for concurrent use; restore before the
+// test ends.
+func SetOsStatForTest(fn func(string) (os.FileInfo, error)) (restore func()) {
+	prev := osStat
+	osStat = fn
+	return func() { osStat = prev }
+}
+
 // ErrTimeout is a sentinel error used to classify filesystem operations that did not
 // complete within the configured timeout.
 var ErrTimeout = errors.New("filesystem operation timed out")

--- a/internal/safefs/safefs.go
+++ b/internal/safefs/safefs.go
@@ -115,6 +115,18 @@ func (l *operationLimiter) inflight() int {
 }
 
 func runLimited[T any](ctx context.Context, timeout time.Duration, timeoutErr *TimeoutError, run func() (T, error)) (T, error) {
+	return runBounded(ctx, fsOpLimiter, timeout, timeoutErr, run)
+}
+
+// runBounded is runLimited with an explicit limiter. A nil limiter skips the
+// shared-pool acquire/release entirely: it is safe only for callers that
+// self-throttle their spawn rate (for example a sequential per-chunk copy that
+// keeps at most one worker in flight at a time). Such a long-lived best-effort
+// stream must not contend for, nor on a wedge permanently erode, the global slot
+// budget the critical paths rely on, so it runs limiter-free. Do NOT pass nil
+// from a caller that fans many concurrent workers out, or a wedge would leak
+// abandoned goroutines without the 32-slot backstop.
+func runBounded[T any](ctx context.Context, limiter *operationLimiter, timeout time.Duration, timeoutErr *TimeoutError, run func() (T, error)) (T, error) {
 	var zero T
 	if err := normalizeContextErr(ctx, timeoutErr); err != nil {
 		return zero, err
@@ -130,12 +142,13 @@ func runLimited[T any](ctx context.Context, timeout time.Duration, timeoutErr *T
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
-	limiter := fsOpLimiter
-	if err := limiter.acquire(ctx, timer.C); err != nil {
-		if errors.Is(err, ErrTimeout) {
-			return zero, timeoutErr
+	if limiter != nil {
+		if err := limiter.acquire(ctx, timer.C); err != nil {
+			if errors.Is(err, ErrTimeout) {
+				return zero, timeoutErr
+			}
+			return zero, err
 		}
-		return zero, err
 	}
 
 	type result struct {
@@ -144,7 +157,9 @@ func runLimited[T any](ctx context.Context, timeout time.Duration, timeoutErr *T
 	}
 	ch := make(chan result, 1)
 	go func() {
-		defer limiter.release()
+		if limiter != nil {
+			defer limiter.release()
+		}
 		value, err := run()
 		ch <- result{value: value, err: err}
 	}()

--- a/internal/safefs/safefs.go
+++ b/internal/safefs/safefs.go
@@ -18,6 +18,10 @@ var (
 	osMkdirAll    = os.MkdirAll
 	osChmod       = os.Chmod
 	osLchown      = os.Lchown
+	osOpen        = os.Open
+	osRemove      = os.Remove
+	osRename      = os.Rename
+	osCreateTemp  = os.CreateTemp
 	syscallStatfs = syscall.Statfs
 	fsOpLimiter   = newOperationLimiter(32)
 )
@@ -222,6 +226,43 @@ func Lchown(ctx context.Context, path string, uid, gid int, timeout time.Duratio
 // *TimeoutError (wrapping ErrTimeout) is returned.
 func Run[T any](ctx context.Context, op, path string, timeout time.Duration, fn func() (T, error)) (T, error) {
 	return runLimited(ctx, timeout, &TimeoutError{Op: op, Path: path, Timeout: effectiveTimeout(ctx, timeout)}, fn)
+}
+
+// Open is the bounded counterpart to os.Open. On timeout the worker is abandoned;
+// a late-completing *os.File is dropped and its fd reclaimed by the os.File finalizer.
+func Open(ctx context.Context, path string, timeout time.Duration) (*os.File, error) {
+	open := osOpen
+	return runLimited(ctx, timeout, &TimeoutError{Op: "open", Path: path, Timeout: effectiveTimeout(ctx, timeout)}, func() (*os.File, error) {
+		return open(path)
+	})
+}
+
+// Remove is the bounded counterpart to os.Remove.
+func Remove(ctx context.Context, path string, timeout time.Duration) error {
+	remove := osRemove
+	_, err := runLimited(ctx, timeout, &TimeoutError{Op: "remove", Path: path, Timeout: effectiveTimeout(ctx, timeout)}, func() (struct{}, error) {
+		return struct{}{}, remove(path)
+	})
+	return err
+}
+
+// Rename is the bounded counterpart to os.Rename (oldpath is reported as Path).
+func Rename(ctx context.Context, oldpath, newpath string, timeout time.Duration) error {
+	rename := osRename
+	_, err := runLimited(ctx, timeout, &TimeoutError{Op: "rename", Path: oldpath, Timeout: effectiveTimeout(ctx, timeout)}, func() (struct{}, error) {
+		return struct{}{}, rename(oldpath, newpath)
+	})
+	return err
+}
+
+// CreateTemp is the bounded counterpart to os.CreateTemp. On timeout the worker is
+// abandoned; a late-created temp file may be orphaned in dir (temp+rename callers
+// clean it best-effort).
+func CreateTemp(ctx context.Context, dir, pattern string, timeout time.Duration) (*os.File, error) {
+	createTemp := osCreateTemp
+	return runLimited(ctx, timeout, &TimeoutError{Op: "createtemp", Path: dir, Timeout: effectiveTimeout(ctx, timeout)}, func() (*os.File, error) {
+		return createTemp(dir, pattern)
+	})
 }
 
 // SpaceUsageFromStatfs converts statfs counters into total, user-available, and

--- a/internal/safefs/safefs_primitives_test.go
+++ b/internal/safefs/safefs_primitives_test.go
@@ -1,0 +1,148 @@
+package safefs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLstat_ReturnsTimeoutError(t *testing.T) {
+	prev := osLstat
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "lstat completion", unblock, finished, func() {
+		osLstat = prev
+	})
+
+	osLstat = func(string) (os.FileInfo, error) {
+		<-unblock
+		close(finished)
+		return nil, os.ErrNotExist
+	}
+
+	start := time.Now()
+	_, err := Lstat(context.Background(), "/does/not/matter", 25*time.Millisecond)
+	if err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Lstat err = %v; want timeout", err)
+	}
+	if time.Since(start) > 250*time.Millisecond {
+		t.Fatalf("Lstat took too long: %s", time.Since(start))
+	}
+}
+
+func TestMkdirAll_ReturnsTimeoutError(t *testing.T) {
+	prev := osMkdirAll
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "mkdirall completion", unblock, finished, func() {
+		osMkdirAll = prev
+	})
+
+	osMkdirAll = func(string, os.FileMode) error {
+		<-unblock
+		close(finished)
+		return nil
+	}
+
+	if err := MkdirAll(context.Background(), "/does/not/matter", 0o755, 25*time.Millisecond); err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("MkdirAll err = %v; want timeout", err)
+	}
+}
+
+func TestChmod_ReturnsTimeoutError(t *testing.T) {
+	prev := osChmod
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "chmod completion", unblock, finished, func() {
+		osChmod = prev
+	})
+
+	osChmod = func(string, os.FileMode) error {
+		<-unblock
+		close(finished)
+		return nil
+	}
+
+	if err := Chmod(context.Background(), "/does/not/matter", 0o600, 25*time.Millisecond); err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Chmod err = %v; want timeout", err)
+	}
+}
+
+func TestLchown_ReturnsTimeoutError(t *testing.T) {
+	prev := osLchown
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "lchown completion", unblock, finished, func() {
+		osLchown = prev
+	})
+
+	osLchown = func(string, int, int) error {
+		<-unblock
+		close(finished)
+		return nil
+	}
+
+	if err := Lchown(context.Background(), "/does/not/matter", 0, 0, 25*time.Millisecond); err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Lchown err = %v; want timeout", err)
+	}
+}
+
+func TestRun_ReturnsTimeoutError(t *testing.T) {
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	t.Cleanup(func() {
+		close(unblock)
+		waitForSignal(t, finished, "run completion")
+	})
+
+	start := time.Now()
+	_, err := Run(context.Background(), "probe", "/does/not/matter", 25*time.Millisecond, func() (bool, error) {
+		<-unblock
+		close(finished)
+		return true, nil
+	})
+	if err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Run err = %v; want timeout", err)
+	}
+	if time.Since(start) > 250*time.Millisecond {
+		t.Fatalf("Run took too long: %s", time.Since(start))
+	}
+}
+
+// TestPrimitives_SucceedOnHealthyFS verifies the new wrappers behave like their
+// raw os counterparts on a responsive filesystem (parity guard for the
+// syscall.Chmod->safefs.Chmod / syscall.Lchown->safefs.Lchown swaps).
+func TestPrimitives_SucceedOnHealthyFS(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "a", "b")
+	ctx := context.Background()
+
+	if err := MkdirAll(ctx, dir, 0o755, time.Second); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	info, err := Lstat(ctx, dir, time.Second)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("Lstat dir = (%v, %v); want a directory", info, err)
+	}
+
+	file := filepath.Join(dir, "f")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := Chmod(ctx, file, 0o600, time.Second); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	fi, err := Lstat(ctx, file, time.Second)
+	if err != nil {
+		t.Fatalf("Lstat file: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("Chmod perm = %o; want 600", fi.Mode().Perm())
+	}
+	if err := Lchown(ctx, file, os.Getuid(), os.Getgid(), time.Second); err != nil {
+		t.Fatalf("Lchown: %v", err)
+	}
+}

--- a/internal/safefs/safefs_primitives_test.go
+++ b/internal/safefs/safefs_primitives_test.go
@@ -112,6 +112,66 @@ func TestRun_ReturnsTimeoutError(t *testing.T) {
 	}
 }
 
+func TestOpen_ReturnsTimeoutError(t *testing.T) {
+	prev := osOpen
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "open completion", unblock, finished, func() { osOpen = prev })
+	osOpen = func(string) (*os.File, error) {
+		<-unblock
+		close(finished)
+		return nil, os.ErrNotExist
+	}
+	if _, err := Open(context.Background(), "/does/not/matter", 25*time.Millisecond); err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Open err = %v; want timeout", err)
+	}
+}
+
+func TestRemove_ReturnsTimeoutError(t *testing.T) {
+	prev := osRemove
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "remove completion", unblock, finished, func() { osRemove = prev })
+	osRemove = func(string) error {
+		<-unblock
+		close(finished)
+		return nil
+	}
+	if err := Remove(context.Background(), "/does/not/matter", 25*time.Millisecond); err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Remove err = %v; want timeout", err)
+	}
+}
+
+func TestRename_ReturnsTimeoutError(t *testing.T) {
+	prev := osRename
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "rename completion", unblock, finished, func() { osRename = prev })
+	osRename = func(string, string) error {
+		<-unblock
+		close(finished)
+		return nil
+	}
+	if err := Rename(context.Background(), "/a", "/b", 25*time.Millisecond); err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Rename err = %v; want timeout", err)
+	}
+}
+
+func TestCreateTemp_ReturnsTimeoutError(t *testing.T) {
+	prev := osCreateTemp
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "createtemp completion", unblock, finished, func() { osCreateTemp = prev })
+	osCreateTemp = func(string, string) (*os.File, error) {
+		<-unblock
+		close(finished)
+		return nil, os.ErrNotExist
+	}
+	if _, err := CreateTemp(context.Background(), "/dir", ".tmp-", 25*time.Millisecond); err == nil || !errors.Is(err, ErrTimeout) {
+		t.Fatalf("CreateTemp err = %v; want timeout", err)
+	}
+}
+
 // TestPrimitives_SucceedOnHealthyFS verifies the new wrappers behave like their
 // raw os counterparts on a responsive filesystem (parity guard for the
 // syscall.Chmod->safefs.Chmod / syscall.Lchown->safefs.Lchown swaps).

--- a/internal/safefs/walk.go
+++ b/internal/safefs/walk.go
@@ -1,0 +1,88 @@
+package safefs
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+	"time"
+)
+
+// WalkBounded is the FS_IO_TIMEOUT-bounded analogue of filepath.WalkDir. It walks
+// the tree rooted at root depth-first, invoking fn for the root and every
+// descendant, with three deliberate properties for safe operation over
+// dead/stale mounts:
+//
+//   - Every blocking syscall is bounded: the root probe goes through Lstat and
+//     each directory read through ReadDir, both with the supplied timeout, so no
+//     single getdents/lstat can wedge the walk in an uninterruptible (D-state)
+//     kernel call. ReadDir also absorbs the per-entry lstat that os.ReadDir
+//     performs for filesystems reporting DT_UNKNOWN, so DirEntry.IsDir() in the
+//     loop never triggers a further unbounded syscall. A bounded op that does not
+//     return in time yields *TimeoutError (wrapping ErrTimeout); the worker
+//     goroutine is abandoned (see runLimited). When timeout <= 0 every op degrades
+//     to a direct syscall (legacy unbounded behaviour, no goroutine/limiter cost).
+//
+//   - Symlinks are never followed: descent is decided from DirEntry.IsDir(), which
+//     is false for a symlink, so a symlink is reported to fn as a leaf and never
+//     traversed. This also makes the walk loop-free.
+//
+//   - Read/timeout errors are reported, not fatal by default: when a directory
+//     cannot be read, fn is called a second time as fn(dir, d, err), exactly like
+//     filepath.WalkDir. Returning nil (or fs.SkipDir) skips that subtree and the
+//     walk continues; any other error aborts. fs.SkipDir and fs.SkipAll are
+//     honoured.
+//
+// WalkBounded itself never mutates the filesystem. A mutating callback must bound
+// its own syscalls (Lchown/Chmod with the same timeout) so a per-entry write
+// cannot wedge after a mount goes stale mid-walk.
+func WalkBounded(ctx context.Context, root string, timeout time.Duration, fn fs.WalkDirFunc) error {
+	info, err := Lstat(ctx, root, timeout)
+	if err != nil {
+		// Mirror filepath.WalkDir: report the root error to fn and let it decide.
+		err = fn(root, nil, err)
+		if err == fs.SkipDir || err == fs.SkipAll {
+			return nil
+		}
+		return err
+	}
+	err = walkBounded(ctx, root, fs.FileInfoToDirEntry(info), timeout, fn)
+	if err == fs.SkipDir || err == fs.SkipAll {
+		return nil
+	}
+	return err
+}
+
+func walkBounded(ctx context.Context, path string, d fs.DirEntry, timeout time.Duration, fn fs.WalkDirFunc) error {
+	if err := fn(path, d, nil); err != nil {
+		if err == fs.SkipDir && d.IsDir() {
+			return nil // skip this directory's contents, keep walking siblings
+		}
+		return err // SkipDir on a file, SkipAll, or a real error -> bubble up
+	}
+	if !d.IsDir() {
+		return nil
+	}
+
+	entries, err := ReadDir(ctx, path, timeout)
+	if err != nil {
+		// Second-call convention: surface the read/timeout error against this dir.
+		if cbErr := fn(path, d, err); cbErr != nil && cbErr != fs.SkipDir {
+			return cbErr
+		}
+		return nil // fn chose to skip the unreadable/timed-out subtree
+	}
+
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return normalizeContextErr(ctx, &TimeoutError{Op: "walk", Path: path, Timeout: effectiveTimeout(ctx, timeout)})
+		}
+		child := filepath.Join(path, entry.Name())
+		if err := walkBounded(ctx, child, entry, timeout, fn); err != nil {
+			if err == fs.SkipDir {
+				break // SkipDir bubbling up from a file: skip the rest of THIS dir
+			}
+			return err // SkipAll or a real error aborts the whole walk
+		}
+	}
+	return nil
+}

--- a/internal/safefs/walk_test.go
+++ b/internal/safefs/walk_test.go
@@ -1,0 +1,232 @@
+package safefs
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func mkTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "f1"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a", "f2"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestWalkBounded_VisitsRootThenDFS(t *testing.T) {
+	root := mkTree(t)
+	var visited []string
+	err := WalkBounded(context.Background(), root, time.Second, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			t.Fatalf("unexpected callback err for %s: %v", path, err)
+		}
+		visited = append(visited, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkBounded: %v", err)
+	}
+	want := []string{
+		root,
+		filepath.Join(root, "a"),
+		filepath.Join(root, "a", "b"),
+		filepath.Join(root, "a", "f2"),
+		filepath.Join(root, "f1"),
+	}
+	if len(visited) != len(want) {
+		t.Fatalf("visited %v; want %v", visited, want)
+	}
+	for i := range want {
+		if visited[i] != want[i] {
+			t.Fatalf("visited[%d]=%s; want %s (full: %v)", i, visited[i], want[i], visited)
+		}
+	}
+}
+
+func TestWalkBounded_TimeoutZeroRunsInline(t *testing.T) {
+	root := mkTree(t)
+	count := 0
+	err := WalkBounded(context.Background(), root, 0, func(string, fs.DirEntry, error) error {
+		count++
+		return nil
+	})
+	if err != nil || count != 5 {
+		t.Fatalf("unbounded walk: err=%v count=%d, want 5", err, count)
+	}
+}
+
+func TestWalkBounded_DoesNotFollowSymlinks(t *testing.T) {
+	ext := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ext, "secret"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(ext, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	var visited []string
+	var linkIsDir bool
+	err := WalkBounded(context.Background(), root, time.Second, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			t.Fatalf("unexpected err for %s: %v", path, err)
+		}
+		visited = append(visited, path)
+		if path == link {
+			linkIsDir = d.IsDir()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkBounded: %v", err)
+	}
+	if linkIsDir {
+		t.Fatal("symlink must be reported as a leaf (IsDir=false)")
+	}
+	for _, p := range visited {
+		if p == filepath.Join(link, "secret") {
+			t.Fatalf("must not descend into a symlinked directory; visited %s", p)
+		}
+	}
+}
+
+func TestWalkBounded_RootLstatTimeoutReportedToCallback(t *testing.T) {
+	root := t.TempDir()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+
+	calls := 0
+	var gotErr error
+	var gotEntry fs.DirEntry
+	err := WalkBounded(ctx, root, 30*time.Second, func(path string, d fs.DirEntry, e error) error {
+		calls++
+		gotErr = e
+		gotEntry = d
+		return nil // skip
+	})
+	if err != nil {
+		t.Fatalf("WalkBounded should swallow a root error the callback ignored, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("callback calls = %d; want 1", calls)
+	}
+	if !errors.Is(gotErr, ErrTimeout) {
+		t.Fatalf("callback err = %v; want ErrTimeout", gotErr)
+	}
+	if gotEntry != nil {
+		t.Fatalf("root-error callback must pass a nil DirEntry, got %v", gotEntry)
+	}
+}
+
+func TestWalkBounded_ReadDirTimeoutSkipsSubtree(t *testing.T) {
+	prev := osReadDir
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "readdir completion", unblock, finished, func() { osReadDir = prev })
+	osReadDir = func(string) ([]os.DirEntry, error) {
+		<-unblock
+		close(finished)
+		return nil, nil
+	}
+
+	root := t.TempDir() // real dir: root Lstat (unstubbed) succeeds, ReadDir blocks
+	var sawTimeout bool
+	err := WalkBounded(context.Background(), root, 25*time.Millisecond, func(path string, d fs.DirEntry, e error) error {
+		if e != nil {
+			if errors.Is(e, ErrTimeout) {
+				sawTimeout = true
+			}
+			return nil // skip the timed-out subtree
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkBounded should return nil when callback skips the timeout, got %v", err)
+	}
+	if !sawTimeout {
+		t.Fatal("callback never received the ReadDir timeout error")
+	}
+}
+
+func TestWalkBounded_ReadDirTimeoutAbortsWhenCallbackReturnsErr(t *testing.T) {
+	prev := osReadDir
+	unblock := make(chan struct{})
+	finished := make(chan struct{})
+	registerBlockedOpCleanup(t, "readdir completion", unblock, finished, func() { osReadDir = prev })
+	osReadDir = func(string) ([]os.DirEntry, error) {
+		<-unblock
+		close(finished)
+		return nil, nil
+	}
+
+	root := t.TempDir()
+	err := WalkBounded(context.Background(), root, 25*time.Millisecond, func(path string, d fs.DirEntry, e error) error {
+		return e // propagate -> abort
+	})
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("WalkBounded err = %v; want ErrTimeout", err)
+	}
+}
+
+func TestWalkBounded_SkipDirSkipsContents(t *testing.T) {
+	root := mkTree(t)
+	skip := filepath.Join(root, "a")
+	var visited []string
+	err := WalkBounded(context.Background(), root, time.Second, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		visited = append(visited, path)
+		if path == skip {
+			return fs.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkBounded: %v", err)
+	}
+	for _, p := range visited {
+		if p == filepath.Join(root, "a", "b") || p == filepath.Join(root, "a", "f2") {
+			t.Fatalf("SkipDir must skip contents of %s; visited %s", skip, p)
+		}
+	}
+	// Sibling f1 must still be visited.
+	found := false
+	for _, p := range visited {
+		if p == filepath.Join(root, "f1") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("SkipDir must not skip siblings; f1 missing from %v", visited)
+	}
+}
+
+func TestWalkBounded_ContextCancelAborts(t *testing.T) {
+	root := mkTree(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := WalkBounded(ctx, root, time.Second, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		cancel() // cancel during the first callback; the next loop iteration must abort
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WalkBounded err = %v; want context.Canceled", err)
+	}
+}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -396,7 +396,9 @@ func (c *Checker) verifyBinaryIntegrity() {
 
 	if _, err := os.Stat(hashFile); errors.Is(err, os.ErrNotExist) {
 		if c.cfg.AutoUpdateHashes {
-			if err := os.WriteFile(hashFile, []byte(currentHash), 0o600); err != nil {
+			if c.cfg.DryRun {
+				c.logger.Info("DRY RUN: would create hash file for executable: %s", hashFile)
+			} else if err := os.WriteFile(hashFile, []byte(currentHash), 0o600); err != nil {
 				c.addWarning("Failed to create hash file %s: %v", hashFile, err)
 			} else {
 				c.logger.Info("Created new hash file for executable: %s", hashFile)
@@ -417,7 +419,9 @@ func (c *Checker) verifyBinaryIntegrity() {
 	if strings.TrimSpace(string(stored)) != currentHash {
 		c.bannerWarning(fmt.Sprintf("executable hash mismatch for %s", c.execPath))
 		if c.cfg.AutoUpdateHashes {
-			if err := os.WriteFile(hashFile, []byte(currentHash), 0o600); err != nil {
+			if c.cfg.DryRun {
+				c.logger.Info("DRY RUN: would regenerate hash file: %s", hashFile)
+			} else if err := os.WriteFile(hashFile, []byte(currentHash), 0o600); err != nil {
 				c.addWarning("Failed to update hash file %s: %v", hashFile, err)
 			} else {
 				c.logger.Info("Regenerated hash file: %s", hashFile)
@@ -941,11 +945,15 @@ func (c *Checker) detectFilesystemInfo(ctx context.Context, path string) (*stora
 	}
 	logger := (*logging.Logger)(nil)
 	timeout := time.Duration(0)
+	dryRun := false
 	if c != nil {
 		logger = c.logger
 		timeout = c.fsTimeout
+		if c.cfg != nil {
+			dryRun = c.cfg.DryRun
+		}
 	}
-	return storage.NewFilesystemDetector(logger, storage.WithIOTimeout(timeout)).DetectFilesystem(ctx, path)
+	return storage.NewFilesystemDetector(logger, storage.WithIOTimeout(timeout), storage.WithDryRun(dryRun)).DetectFilesystem(ctx, path)
 }
 
 type ssEntry struct {
@@ -1193,6 +1201,8 @@ func (c *Checker) ensureOwnershipAndPerm(ctx context.Context, path string, info 
 			if c.cfg.AutoFixPermissions {
 				if isSymlink {
 					c.addError("Security: refusing to chmod symlink %s", path)
+				} else if c.cfg.DryRun {
+					c.logger.Info("DRY RUN: would adjust permissions on %s to %o (current %o)", path, expectedPerm, perm)
 				} else if err := safefs.Chmod(ctx, path, expectedPerm, c.fsTimeout); err != nil {
 					if errors.Is(err, safefs.ErrTimeout) {
 						c.addWarning("Security check: chmod on %s timed out after %s; leaving permissions unchanged (dead/stale mount?)", path, c.fsTimeout)
@@ -1219,6 +1229,8 @@ func (c *Checker) ensureOwnershipAndPerm(ctx context.Context, path string, info 
 		if c.cfg.AutoFixPermissions {
 			if isSymlink {
 				c.addError("Security: refusing to chown symlink %s", path)
+			} else if c.cfg.DryRun {
+				c.logger.Info("DRY RUN: would adjust ownership on %s to root:root", path)
 			} else if err := safefs.Lchown(ctx, path, 0, 0, c.fsTimeout); err != nil {
 				if errors.Is(err, safefs.ErrTimeout) {
 					c.addWarning("Security check: chown on %s timed out after %s; leaving ownership unchanged (dead/stale mount?)", path, c.fsTimeout)
@@ -1260,7 +1272,9 @@ func (c *Checker) ensureOwnershipAndPermFromFD(f *os.File, info os.FileInfo, exp
 		if perm := info.Mode().Perm(); perm != expectedPerm {
 			c.bannerWarning(fmt.Sprintf("incorrect permissions on %s (current %o, expected %o)", path, perm, expectedPerm))
 			if c.cfg.AutoFixPermissions {
-				if err := syscall.Fchmod(int(f.Fd()), uint32(expectedPerm)); err != nil {
+				if c.cfg.DryRun {
+					c.logger.Info("DRY RUN: would adjust permissions on %s to %o (current %o)", path, expectedPerm, perm)
+				} else if err := syscall.Fchmod(int(f.Fd()), uint32(expectedPerm)); err != nil {
 					c.addWarning("Failed to adjust permissions on %s: %v", path, err)
 				} else {
 					c.logger.Info("Adjusted permissions on %s to %o", path, expectedPerm)
@@ -1275,7 +1289,9 @@ func (c *Checker) ensureOwnershipAndPermFromFD(f *os.File, info os.FileInfo, exp
 	if info != nil && !isOwnedByRoot(info) {
 		c.bannerWarning(fmt.Sprintf("incorrect ownership on %s (required root:root)", path))
 		if c.cfg.AutoFixPermissions {
-			if err := syscall.Fchown(int(f.Fd()), 0, 0); err != nil {
+			if c.cfg.DryRun {
+				c.logger.Info("DRY RUN: would adjust ownership on %s to root:root", path)
+			} else if err := syscall.Fchown(int(f.Fd()), 0, 0); err != nil {
 				c.addWarning("Failed to set ownership root:root on %s: %v", path, err)
 			} else {
 				c.logger.Info("Adjusted ownership on %s to root:root", path)

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -17,11 +17,13 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/environment"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/safeexec"
+	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/internal/storage"
 	"github.com/tis24dev/proxsave/internal/types"
 )
@@ -87,6 +89,10 @@ type Checker struct {
 	envInfo    *environment.EnvironmentInfo
 	result     *Result
 	lookPath   func(string) (string, error)
+	// fsTimeout bounds each filesystem syscall the preflight performs on a
+	// configured path. Zero means unbounded. Sourced from FS_IO_TIMEOUT so a
+	// dead/stale mount cannot wedge the preflight in an uninterruptible syscall.
+	fsTimeout time.Duration
 
 	filesystemInfoLookup func(context.Context, string) (*storage.FilesystemInfo, error)
 }
@@ -120,6 +126,7 @@ func Run(ctx context.Context, logger *logging.Logger, cfg *config.Config, config
 		envInfo:    envInfo,
 		result:     &Result{},
 		lookPath:   exec.LookPath,
+		fsTimeout:  fsIoTimeout(cfg),
 	}
 
 	logger.Step("Security preflight checks")
@@ -128,10 +135,10 @@ func Run(ctx context.Context, logger *logging.Logger, cfg *config.Config, config
 		len(cfg.SuspiciousProcesses), len(cfg.SafeBracketProcesses))
 	checker.checkDependencies()
 	checker.verifyBinaryIntegrity()
-	checker.verifyConfigFile()
-	checker.verifySensitiveFiles()
+	checker.verifyConfigFile(ctx)
+	checker.verifySensitiveFiles(ctx)
 	checker.verifyDirectories(ctx)
-	checker.verifySecureAccountFiles()
+	checker.verifySecureAccountFiles(ctx)
 	checker.detectPrivateAgeKeys()
 
 	if cfg.CheckNetworkSecurity {
@@ -156,6 +163,16 @@ func Run(ctx context.Context, logger *logging.Logger, cfg *config.Config, config
 	}
 
 	return checker.result, nil
+}
+
+// fsIoTimeout converts the configured FS_IO_TIMEOUT into a duration. A
+// non-positive value (the explicit FS_IO_TIMEOUT=0 opt-out) yields 0, which
+// safefs treats as unbounded; the config default is 30s.
+func fsIoTimeout(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.FsIoTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.FsIoTimeoutSeconds) * time.Second
 }
 
 func (c *Checker) checkDependencies() {
@@ -411,22 +428,26 @@ func (c *Checker) verifyBinaryIntegrity() {
 	}
 }
 
-func (c *Checker) verifyConfigFile() {
+func (c *Checker) verifyConfigFile(ctx context.Context) {
 	if c.configPath == "" {
 		c.addWarning("Configuration path not provided")
 		return
 	}
 
-	info, err := os.Stat(c.configPath)
+	info, err := safefs.Stat(ctx, c.configPath, c.fsTimeout)
 	if err != nil {
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.addWarning("Security check: stat of configuration file %s timed out after %s; skipping its checks (dead/stale mount?)", c.configPath, c.fsTimeout)
+			return
+		}
 		c.addError("Cannot stat configuration file %s: %v", c.configPath, err)
 		return
 	}
 
-	c.ensureOwnershipAndPerm(c.configPath, info, 0o600, fmt.Sprintf("Config file %s", c.configPath))
+	c.ensureOwnershipAndPerm(ctx, c.configPath, info, 0o600, fmt.Sprintf("Config file %s", c.configPath))
 }
 
-func (c *Checker) verifySensitiveFiles() {
+func (c *Checker) verifySensitiveFiles(ctx context.Context) {
 	files := []struct {
 		path        string
 		perm        os.FileMode
@@ -455,39 +476,60 @@ func (c *Checker) verifySensitiveFiles() {
 	}
 
 	for _, entry := range files {
-		info, err := os.Stat(entry.path)
+		info, err := safefs.Stat(ctx, entry.path, c.fsTimeout)
 		if errors.Is(err, os.ErrNotExist) && entry.optional {
 			if entry.description == "AGE recipient file" && c.cfg.EncryptArchive {
 				c.logger.Debug("Security check: AGE recipient file %s not present yet (wizard will create it)", entry.path)
 			}
 			continue
 		}
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.addWarning("Security check: stat of %s (%s) timed out after %s; skipping (dead/stale mount?)", entry.path, entry.description, c.fsTimeout)
+			continue
+		}
 		if err != nil {
 			c.addWarning("Cannot stat %s (%s): %v", entry.path, entry.description, err)
 			continue
 		}
-		c.ensureOwnershipAndPerm(entry.path, info, entry.perm, entry.description)
+		c.ensureOwnershipAndPerm(ctx, entry.path, info, entry.perm, entry.description)
 	}
 }
 
-func (c *Checker) verifySecureAccountFiles() {
+func (c *Checker) verifySecureAccountFiles(ctx context.Context) {
 	if c.cfg.SecureAccount == "" {
 		return
 	}
 
-	matches, err := filepath.Glob(filepath.Join(c.cfg.SecureAccount, "*.json"))
+	// Bounded directory read so a dead/stale SecureAccount mount cannot wedge the
+	// preflight in an uninterruptible syscall (filepath.Glob is unbounded).
+	entries, err := safefs.ReadDir(ctx, c.cfg.SecureAccount, c.fsTimeout)
 	if err != nil {
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.addWarning("Security check: listing secure account dir %s timed out after %s; skipping (dead/stale mount?)", c.cfg.SecureAccount, c.fsTimeout)
+			return
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
 		c.addWarning("Failed to enumerate secure account files: %v", err)
 		return
 	}
 
-	for _, file := range matches {
-		info, err := os.Stat(file)
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		file := filepath.Join(c.cfg.SecureAccount, entry.Name())
+		info, err := safefs.Stat(ctx, file, c.fsTimeout)
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.addWarning("Security check: stat of secure account file %s timed out after %s; skipping (dead/stale mount?)", file, c.fsTimeout)
+			continue
+		}
 		if err != nil {
 			c.addWarning("Cannot stat secure account file %s: %v", file, err)
 			continue
 		}
-		c.ensureOwnershipAndPerm(file, info, 0o600, fmt.Sprintf("Secure account file %s", file))
+		c.ensureOwnershipAndPerm(ctx, file, info, 0o600, fmt.Sprintf("Secure account file %s", file))
 	}
 }
 
@@ -511,19 +553,35 @@ func (c *Checker) verifyDirectories(ctx context.Context) {
 		if dir.path == "" {
 			continue
 		}
-		info, err := os.Stat(dir.path)
-		if errors.Is(err, os.ErrNotExist) {
-			if err := os.MkdirAll(dir.path, dir.perm); err != nil {
-				c.addError("Failed to create directory %s: %v", dir.path, err)
+		info, err := safefs.Stat(ctx, dir.path, c.fsTimeout)
+		switch {
+		case errors.Is(err, safefs.ErrTimeout):
+			c.addWarning("Security check: stat of directory %s timed out after %s; skipping its checks (dead/stale mount?)", dir.path, c.fsTimeout)
+			continue
+		case errors.Is(err, os.ErrNotExist):
+			if c.cfg.DryRun {
+				c.logger.Info("DRY RUN: directory %s is missing; would create it with mode %o (skipping creation and permission checks)", dir.path, dir.perm)
+				continue
+			}
+			if mkErr := safefs.MkdirAll(ctx, dir.path, dir.perm, c.fsTimeout); mkErr != nil {
+				if errors.Is(mkErr, safefs.ErrTimeout) {
+					c.addWarning("Security check: creating directory %s timed out after %s; skipping (dead/stale mount?)", dir.path, c.fsTimeout)
+				} else {
+					c.addError("Failed to create directory %s: %v", dir.path, mkErr)
+				}
 				continue
 			}
 			c.logger.Info("Created missing directory: %s", dir.path)
-			info, err = os.Stat(dir.path)
+			info, err = safefs.Stat(ctx, dir.path, c.fsTimeout)
 			if err != nil {
-				c.addWarning("Cannot verify permissions for %s: %v", dir.path, err)
+				if errors.Is(err, safefs.ErrTimeout) {
+					c.addWarning("Security check: re-stat of %s timed out after %s; skipping its checks", dir.path, c.fsTimeout)
+				} else {
+					c.addWarning("Cannot verify permissions for %s: %v", dir.path, err)
+				}
 				continue
 			}
-		} else if err != nil {
+		case err != nil:
 			c.addWarning("Cannot stat directory %s: %v", dir.path, err)
 			continue
 		}
@@ -537,7 +595,7 @@ func (c *Checker) verifyDirectories(ctx context.Context) {
 			continue
 		}
 
-		c.ensureOwnershipAndPerm(dir.path, info, dir.perm, fmt.Sprintf("Directory %s", dir.path))
+		c.ensureOwnershipAndPerm(ctx, dir.path, info, dir.perm, fmt.Sprintf("Directory %s", dir.path))
 	}
 }
 
@@ -856,6 +914,10 @@ func (c *Checker) shouldSkipPOSIXDirectoryChecks(ctx context.Context, path strin
 
 	fsInfo, err := c.detectFilesystemInfo(ctx, path)
 	if err != nil {
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.addWarning("Security check: filesystem detection timed out on %s after %s; skipping POSIX permission checks (dead/stale mount?)", path, c.fsTimeout)
+			return true
+		}
 		if c.logger != nil {
 			c.logger.Debug("Security check: filesystem detection failed for %s; continuing with POSIX permission checks: %v", path, err)
 		}
@@ -878,10 +940,12 @@ func (c *Checker) detectFilesystemInfo(ctx context.Context, path string) (*stora
 		return c.filesystemInfoLookup(ctx, path)
 	}
 	logger := (*logging.Logger)(nil)
+	timeout := time.Duration(0)
 	if c != nil {
 		logger = c.logger
+		timeout = c.fsTimeout
 	}
-	return storage.NewFilesystemDetector(logger).DetectFilesystem(ctx, path)
+	return storage.NewFilesystemDetector(logger, storage.WithIOTimeout(timeout)).DetectFilesystem(ctx, path)
 }
 
 type ssEntry struct {
@@ -1096,11 +1160,15 @@ func (c *Checker) isSafeKernelProcess(name string) bool {
 	return false
 }
 
-func (c *Checker) ensureOwnershipAndPerm(path string, info os.FileInfo, expectedPerm os.FileMode, description string) os.FileInfo {
+func (c *Checker) ensureOwnershipAndPerm(ctx context.Context, path string, info os.FileInfo, expectedPerm os.FileMode, description string) os.FileInfo {
 	var err error
 	if info == nil {
-		info, err = os.Lstat(path)
+		info, err = safefs.Lstat(ctx, path, c.fsTimeout)
 		if err != nil {
+			if errors.Is(err, safefs.ErrTimeout) {
+				c.addWarning("Security check: stat of %s timed out after %s; skipping permission/ownership checks (dead/stale mount?)", path, c.fsTimeout)
+				return nil
+			}
 			c.addWarning("Cannot stat %s: %v", path, err)
 			return nil
 		}
@@ -1112,8 +1180,11 @@ func (c *Checker) ensureOwnershipAndPerm(path string, info os.FileInfo, expected
 	// refusal guards below and let syscall.Chmod follow the link to an arbitrary
 	// target.
 	isSymlink := info.Mode()&os.ModeSymlink != 0
-	if li, lerr := os.Lstat(path); lerr == nil {
+	if li, lerr := safefs.Lstat(ctx, path, c.fsTimeout); lerr == nil {
 		isSymlink = li.Mode()&os.ModeSymlink != 0
+	} else if errors.Is(lerr, safefs.ErrTimeout) {
+		c.addWarning("Security check: stat of %s timed out after %s; skipping permission/ownership checks (dead/stale mount?)", path, c.fsTimeout)
+		return info
 	}
 
 	if expectedPerm != 0 {
@@ -1122,11 +1193,15 @@ func (c *Checker) ensureOwnershipAndPerm(path string, info os.FileInfo, expected
 			if c.cfg.AutoFixPermissions {
 				if isSymlink {
 					c.addError("Security: refusing to chmod symlink %s", path)
-				} else if err := syscall.Chmod(path, uint32(expectedPerm)); err != nil {
-					c.addWarning("Failed to adjust permissions on %s: %v", path, err)
+				} else if err := safefs.Chmod(ctx, path, expectedPerm, c.fsTimeout); err != nil {
+					if errors.Is(err, safefs.ErrTimeout) {
+						c.addWarning("Security check: chmod on %s timed out after %s; leaving permissions unchanged (dead/stale mount?)", path, c.fsTimeout)
+					} else {
+						c.addWarning("Failed to adjust permissions on %s: %v", path, err)
+					}
 				} else {
 					c.logger.Info("Adjusted permissions on %s to %o", path, expectedPerm)
-					if reInfo, statErr := os.Lstat(path); statErr == nil {
+					if reInfo, statErr := safefs.Lstat(ctx, path, c.fsTimeout); statErr == nil {
 						info = reInfo
 						isSymlink = info.Mode()&os.ModeSymlink != 0
 					} else {
@@ -1144,11 +1219,15 @@ func (c *Checker) ensureOwnershipAndPerm(path string, info os.FileInfo, expected
 		if c.cfg.AutoFixPermissions {
 			if isSymlink {
 				c.addError("Security: refusing to chown symlink %s", path)
-			} else if err := syscall.Lchown(path, 0, 0); err != nil {
-				c.addWarning("Failed to set ownership root:root on %s: %v", path, err)
+			} else if err := safefs.Lchown(ctx, path, 0, 0, c.fsTimeout); err != nil {
+				if errors.Is(err, safefs.ErrTimeout) {
+					c.addWarning("Security check: chown on %s timed out after %s; leaving ownership unchanged (dead/stale mount?)", path, c.fsTimeout)
+				} else {
+					c.addWarning("Failed to set ownership root:root on %s: %v", path, err)
+				}
 			} else {
 				c.logger.Info("Adjusted ownership on %s to root:root", path)
-				info, _ = os.Lstat(path)
+				info, _ = safefs.Lstat(ctx, path, c.fsTimeout)
 			}
 		} else {
 			c.addWarning("%s should be owned by root:root", description)

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -134,12 +134,12 @@ func Run(ctx context.Context, logger *logging.Logger, cfg *config.Config, config
 		cfg.AutoFixPermissions, cfg.AutoUpdateHashes, cfg.ContinueOnSecurityIssues, cfg.CheckNetworkSecurity, cfg.CheckFirewall, cfg.CheckOpenPorts,
 		len(cfg.SuspiciousProcesses), len(cfg.SafeBracketProcesses))
 	checker.checkDependencies()
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(ctx)
 	checker.verifyConfigFile(ctx)
 	checker.verifySensitiveFiles(ctx)
 	checker.verifyDirectories(ctx)
 	checker.verifySecureAccountFiles(ctx)
-	checker.detectPrivateAgeKeys()
+	checker.detectPrivateAgeKeys(ctx)
 
 	if cfg.CheckNetworkSecurity {
 		if cfg.CheckFirewall {
@@ -352,14 +352,18 @@ func (c *Checker) bannerWarning(message string) {
 	c.logger.Warning("Security warning: %s", message)
 }
 
-func (c *Checker) verifyBinaryIntegrity() {
+func (c *Checker) verifyBinaryIntegrity(ctx context.Context) {
 	if c.execPath == "" {
 		c.addWarning("Executable path not available for integrity check")
 		return
 	}
 
-	info, err := os.Lstat(c.execPath)
+	info, err := safefs.Lstat(ctx, c.execPath, c.fsTimeout)
 	if err != nil {
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.addWarning("Security check: stat of executable %s timed out after %s; skipping integrity check (dead/stale mount?)", c.execPath, c.fsTimeout)
+			return
+		}
 		c.addError("Cannot stat executable %s: %v", c.execPath, err)
 		return
 	}
@@ -370,8 +374,13 @@ func (c *Checker) verifyBinaryIntegrity() {
 	}
 
 	hashFile := c.execPath + ".md5"
-	f, err := os.Open(c.execPath)
+	f, err := safefs.Open(ctx, c.execPath, c.fsTimeout)
 	if err != nil {
+		if errors.Is(err, safefs.ErrTimeout) {
+			// safefs.Open abandoned its worker on timeout; f is nil, nothing to close.
+			c.addWarning("Security check: opening executable %s timed out after %s; skipping integrity check (dead/stale mount?)", c.execPath, c.fsTimeout)
+			return
+		}
 		c.addError("Cannot open executable %s: %v", c.execPath, err)
 		return
 	}
@@ -603,20 +612,27 @@ func (c *Checker) verifyDirectories(ctx context.Context) {
 	}
 }
 
-func (c *Checker) detectPrivateAgeKeys() {
+func (c *Checker) detectPrivateAgeKeys(ctx context.Context) {
 	identityDir := filepath.Join(c.cfg.BaseDir, "identity")
 	if identityDir == "" {
 		return
 	}
 
-	if _, err := os.Stat(identityDir); err != nil {
+	if _, err := safefs.Stat(ctx, identityDir, c.fsTimeout); err != nil {
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.addWarning("Security check: stat of identity directory %s timed out after %s; skipping private-key scan (dead/stale mount?)", identityDir, c.fsTimeout)
+		}
 		return
 	}
 
 	privateKeyMarkers := []string{"AGE-SECRET-KEY-", "BEGIN AGE PRIVATE KEY", "OPENSSH PRIVATE KEY"}
-	if err := filepath.WalkDir(identityDir, func(path string, d fs.DirEntry, err error) error {
+	if err := safefs.WalkBounded(ctx, identityDir, c.fsTimeout, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			c.logger.Debug("Security: cannot access %s: %v", path, err)
+			if errors.Is(err, safefs.ErrTimeout) {
+				c.addWarning("Security check: scanning %s timed out after %s; skipping subtree (dead/stale mount?)", path, c.fsTimeout)
+			} else {
+				c.logger.Debug("Security: cannot access %s: %v", path, err)
+			}
 			return nil
 		}
 		if d.IsDir() {

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -403,24 +403,49 @@ func (c *Checker) verifyBinaryIntegrity(ctx context.Context) {
 		return
 	}
 
-	if _, err := os.Stat(hashFile); errors.Is(err, os.ErrNotExist) {
-		if c.cfg.AutoUpdateHashes {
-			if c.cfg.DryRun {
-				c.logger.Info("DRY RUN: would create hash file for executable: %s", hashFile)
-			} else if err := os.WriteFile(hashFile, []byte(currentHash), 0o600); err != nil {
-				c.addWarning("Failed to create hash file %s: %v", hashFile, err)
-			} else {
-				c.logger.Info("Created new hash file for executable: %s", hashFile)
-			}
-		} else {
-			c.bannerWarning(fmt.Sprintf("hash file %s missing", hashFile))
-			c.addWarning("Hash file %s missing (AUTO_UPDATE_HASHES=false)", hashFile)
+	// The .md5 hash-file path is bounded with the same fs timeout as the
+	// executable above: a dead/stale mount must not wedge the integrity check
+	// here either. safefs.Stat is the bounded counterpart of os.Stat. Its
+	// outcomes are mapped explicitly:
+	//   safefs.ErrTimeout -> dead/stale mount: warn + skip (like the exec path).
+	//     Handled FIRST, because a *TimeoutError is never os.ErrNotExist and
+	//     would otherwise fall through to the (also bounded) read and time out
+	//     a second time.
+	//   os.ErrNotExist    -> genuinely missing: create (AUTO_UPDATE_HASHES) or warn.
+	//   other error / nil -> fall through to the bounded read+compare, exactly
+	//     as the original raw os.Stat fall-through did.
+	if _, statErr := safefs.Stat(ctx, hashFile, c.fsTimeout); statErr != nil {
+		if errors.Is(statErr, safefs.ErrTimeout) {
+			c.addWarning("Security check: stat of hash file %s timed out after %s; skipping integrity check (dead/stale mount?)", hashFile, c.fsTimeout)
+			return
 		}
-		return
+		if errors.Is(statErr, os.ErrNotExist) {
+			if c.cfg.AutoUpdateHashes {
+				if c.cfg.DryRun {
+					c.logger.Info("DRY RUN: would create hash file for executable: %s", hashFile)
+				} else if werr := c.writeHashFile(ctx, hashFile, currentHash); werr != nil {
+					c.addWarning("Failed to create hash file %s: %v", hashFile, werr)
+				} else {
+					c.logger.Info("Created new hash file for executable: %s", hashFile)
+				}
+			} else {
+				c.bannerWarning(fmt.Sprintf("hash file %s missing", hashFile))
+				c.addWarning("Hash file %s missing (AUTO_UPDATE_HASHES=false)", hashFile)
+			}
+			return
+		}
+		// Any other stat error (e.g. EACCES): preserve the original behavior and
+		// fall through to the read below, which surfaces the concrete failure.
 	}
 
-	stored, err := os.ReadFile(hashFile)
+	stored, err := safefs.Run(ctx, "readfile", hashFile, c.fsTimeout, func() ([]byte, error) {
+		return os.ReadFile(hashFile)
+	})
 	if err != nil {
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.addWarning("Security check: reading hash file %s timed out after %s; skipping integrity check (dead/stale mount?)", hashFile, c.fsTimeout)
+			return
+		}
 		c.addWarning("Unable to read hash file %s: %v", hashFile, err)
 		return
 	}
@@ -430,8 +455,8 @@ func (c *Checker) verifyBinaryIntegrity(ctx context.Context) {
 		if c.cfg.AutoUpdateHashes {
 			if c.cfg.DryRun {
 				c.logger.Info("DRY RUN: would regenerate hash file: %s", hashFile)
-			} else if err := os.WriteFile(hashFile, []byte(currentHash), 0o600); err != nil {
-				c.addWarning("Failed to update hash file %s: %v", hashFile, err)
+			} else if werr := c.writeHashFile(ctx, hashFile, currentHash); werr != nil {
+				c.addWarning("Failed to update hash file %s: %v", hashFile, werr)
 			} else {
 				c.logger.Info("Regenerated hash file: %s", hashFile)
 			}
@@ -439,6 +464,19 @@ func (c *Checker) verifyBinaryIntegrity(ctx context.Context) {
 			c.addWarning("Executable hash mismatch for %s (expected %s, current %s)", c.execPath, strings.TrimSpace(string(stored)), currentHash)
 		}
 	}
+}
+
+// writeHashFile writes currentHash to hashFile under the fs timeout. os.WriteFile
+// opens the path, which a dead/stale mount can wedge, so the write is bounded
+// with safefs.Run; on timeout a *TimeoutError (wrapping safefs.ErrTimeout) is
+// returned and the caller surfaces it through its best-effort
+// "Failed to create/update hash file" warning. With c.fsTimeout <= 0 (legacy /
+// FS_IO_TIMEOUT unset) safefs.Run is a direct synchronous os.WriteFile.
+func (c *Checker) writeHashFile(ctx context.Context, hashFile, currentHash string) error {
+	_, err := safefs.Run(ctx, "writefile", hashFile, c.fsTimeout, func() (struct{}, error) {
+		return struct{}{}, os.WriteFile(hashFile, []byte(currentHash), 0o600)
+	})
+	return err
 }
 
 func (c *Checker) verifyConfigFile(ctx context.Context) {

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -439,7 +439,16 @@ func (c *Checker) verifyBinaryIntegrity(ctx context.Context) {
 	}
 
 	stored, err := safefs.Run(ctx, "readfile", hashFile, c.fsTimeout, func() ([]byte, error) {
-		return os.ReadFile(hashFile)
+		// Read the .md5 confined to the executable's directory via os.Root: the
+		// read carries a bare basename, so this is structurally free of gosec G304
+		// (file inclusion via a variable) without a #nosec, consistent with the
+		// ownership-probe fix in storage/filesystem.go.
+		root, rerr := os.OpenRoot(filepath.Dir(hashFile))
+		if rerr != nil {
+			return nil, rerr
+		}
+		defer func() { _ = root.Close() }()
+		return root.ReadFile(filepath.Base(hashFile))
 	})
 	if err != nil {
 		if errors.Is(err, safefs.ErrTimeout) {

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -130,7 +130,7 @@ func Run(ctx context.Context, logger *logging.Logger, cfg *config.Config, config
 	checker.verifyBinaryIntegrity()
 	checker.verifyConfigFile()
 	checker.verifySensitiveFiles()
-	checker.verifyDirectories()
+	checker.verifyDirectories(ctx)
 	checker.verifySecureAccountFiles()
 	checker.detectPrivateAgeKeys()
 
@@ -491,7 +491,7 @@ func (c *Checker) verifySecureAccountFiles() {
 	}
 }
 
-func (c *Checker) verifyDirectories() {
+func (c *Checker) verifyDirectories(ctx context.Context) {
 	dirs := []struct {
 		path        string
 		perm        os.FileMode
@@ -528,7 +528,7 @@ func (c *Checker) verifyDirectories() {
 			continue
 		}
 
-		if dir.allowBackup && c.shouldSkipPOSIXDirectoryChecks(dir.path) {
+		if dir.allowBackup && c.shouldSkipPOSIXDirectoryChecks(ctx, dir.path) {
 			continue
 		}
 
@@ -848,13 +848,13 @@ func (c *Checker) shouldSkipOwnershipChecks(path string) bool {
 	return false
 }
 
-func (c *Checker) shouldSkipPOSIXDirectoryChecks(path string) bool {
+func (c *Checker) shouldSkipPOSIXDirectoryChecks(ctx context.Context, path string) bool {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return false
 	}
 
-	fsInfo, err := c.detectFilesystemInfo(context.Background(), path)
+	fsInfo, err := c.detectFilesystemInfo(ctx, path)
 	if err != nil {
 		if c.logger != nil {
 			c.logger.Debug("Security check: filesystem detection failed for %s; continuing with POSIX permission checks: %v", path, err)

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -651,10 +651,14 @@ func (c *Checker) verifyDirectories(ctx context.Context) {
 }
 
 func (c *Checker) detectPrivateAgeKeys(ctx context.Context) {
-	identityDir := filepath.Join(c.cfg.BaseDir, "identity")
-	if identityDir == "" {
+	// Guard on BaseDir, not on the joined path: filepath.Join("", "identity")
+	// yields the relative "identity", so guarding the join never fires and an
+	// empty BaseDir would scan ./identity from the process CWD. BaseDir is a
+	// runtime-defaulted local dir, so empty means "nothing configured" -> skip.
+	if c.cfg.BaseDir == "" {
 		return
 	}
+	identityDir := filepath.Join(c.cfg.BaseDir, "identity")
 
 	if _, err := safefs.Stat(ctx, identityDir, c.fsTimeout); err != nil {
 		if errors.Is(err, safefs.ErrTimeout) {

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -625,7 +625,7 @@ func TestVerifyBinaryIntegrityCreatesHash(t *testing.T) {
 	}
 	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: true}, execPath)
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	hashPath := execPath + ".md5"
 	data, err := os.ReadFile(hashPath)
@@ -649,7 +649,7 @@ func TestVerifyBinaryIntegrityWarnsWhenHashMissing(t *testing.T) {
 	}
 	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: false}, execPath)
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	if !containsIssue(checker.result, "Hash file") {
 		t.Fatalf("expected warning about missing hash file, issues=%+v", checker.result.Issues)
@@ -674,7 +674,7 @@ func TestVerifyBinaryIntegrityHashMismatch(t *testing.T) {
 	}
 	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: false}, execPath)
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	if !containsIssue(checker.result, "Executable hash mismatch") {
 		t.Fatalf("expected hash mismatch warning, issues=%+v", checker.result.Issues)
@@ -697,7 +697,7 @@ func TestDetectPrivateAgeKeysAddsWarning(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.detectPrivateAgeKeys()
+	checker.detectPrivateAgeKeys(context.Background())
 
 	if !containsIssue(checker.result, "AGE/SSH key") {
 		t.Fatalf("expected warning about private key, issues=%+v", checker.result.Issues)
@@ -1649,7 +1649,7 @@ func TestVerifyBinaryIntegrityEmptyPath(t *testing.T) {
 		execPath: "",
 	}
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	if !containsIssue(checker.result, "Executable path not available") {
 		t.Errorf("expected warning about empty exec path, got %+v", checker.result.Issues)
@@ -1675,7 +1675,7 @@ func TestVerifyBinaryIntegritySymlinkError(t *testing.T) {
 		execPath: symlinkFile,
 	}
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	if !containsIssue(checker.result, "is a symlink") {
 		t.Fatalf("expected symlink error, issues=%+v", checker.result.Issues)
@@ -1693,7 +1693,7 @@ func TestVerifyBinaryIntegrityOpenError(t *testing.T) {
 		execPath: "/nonexistent/binary/path",
 	}
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	if !containsIssue(checker.result, "Cannot stat executable") {
 		t.Errorf("expected error about cannot stat executable, got %+v", checker.result.Issues)
@@ -1777,7 +1777,7 @@ func TestDetectPrivateAgeKeysSkipsExtensions(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.detectPrivateAgeKeys()
+	checker.detectPrivateAgeKeys(context.Background())
 
 	// Should not detect keys in files with .md, .txt, .example extensions
 	if checker.result.TotalIssues() != 0 {
@@ -1792,7 +1792,7 @@ func TestDetectPrivateAgeKeysEmptyBaseDir(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.detectPrivateAgeKeys()
+	checker.detectPrivateAgeKeys(context.Background())
 
 	// Should not crash and should not add issues
 	if checker.result.TotalIssues() != 0 {
@@ -1807,7 +1807,7 @@ func TestDetectPrivateAgeKeysNonExistentDir(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.detectPrivateAgeKeys()
+	checker.detectPrivateAgeKeys(context.Background())
 
 	// Should not crash and should not add issues
 	if checker.result.TotalIssues() != 0 {
@@ -2023,7 +2023,7 @@ func TestVerifyBinaryIntegrityHashFileReadError(t *testing.T) {
 		execPath: execPath,
 	}
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	if !containsIssue(checker.result, "Unable to read hash file") {
 		t.Errorf("expected warning about reading hash file, got %+v", checker.result.Issues)
@@ -2050,7 +2050,7 @@ func TestVerifyBinaryIntegrityHashMismatchAutoUpdate(t *testing.T) {
 		execPath: execPath,
 	}
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	// Hash should be updated
 	newHash, err := os.ReadFile(hashPath)
@@ -2282,7 +2282,7 @@ func TestDetectPrivateAgeKeysWithUnreadableFile(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.detectPrivateAgeKeys()
+	checker.detectPrivateAgeKeys(context.Background())
 
 	// Should not crash, the unreadable file should be skipped
 }
@@ -2306,7 +2306,7 @@ func TestDetectPrivateAgeKeysWithSSHKey(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.detectPrivateAgeKeys()
+	checker.detectPrivateAgeKeys(context.Background())
 
 	// Should detect the SSH key
 	if !containsIssue(checker.result, "AGE/SSH key") {
@@ -2512,7 +2512,7 @@ func TestVerifyBinaryIntegrityMatchingHash(t *testing.T) {
 		execPath: execPath,
 	}
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	// Should not have hash-related warnings
 	for _, issue := range checker.result.Issues {
@@ -2672,7 +2672,7 @@ func TestDetectPrivateAgeKeysWithSubdirectory(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.detectPrivateAgeKeys()
+	checker.detectPrivateAgeKeys(context.Background())
 
 	// Should find the key in subdirectory
 	if !containsIssue(checker.result, "AGE/SSH key") {
@@ -2706,7 +2706,7 @@ func TestVerifyBinaryIntegrityCreateHashErrorReadOnly(t *testing.T) {
 		execPath: execPath,
 	}
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	// Should have warning about failing to create hash file
 	if !containsIssue(checker.result, "Failed to create hash file") {
@@ -2746,7 +2746,7 @@ func TestVerifyBinaryIntegrityUpdateHashError(t *testing.T) {
 		execPath: execPath,
 	}
 
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	// Should have warning about failing to update hash file
 	if !containsIssue(checker.result, "Failed to update hash file") {

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -1786,6 +1786,21 @@ func TestDetectPrivateAgeKeysSkipsExtensions(t *testing.T) {
 }
 
 func TestDetectPrivateAgeKeysEmptyBaseDir(t *testing.T) {
+	// With an empty BaseDir the scan must be skipped entirely. Plant a
+	// CWD-relative ./identity holding a fake private key: if the guard regressed
+	// to checking the joined path (which is never "" since
+	// filepath.Join("", "identity") == "identity"), the function would walk
+	// ./identity from the process CWD and flag this file.
+	dir := t.TempDir()
+	rel := filepath.Join(dir, "identity")
+	if err := os.MkdirAll(rel, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rel, "leaked.key"), []byte("AGE-SECRET-KEY-1ABC"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir) // auto-restored; the planted ./identity is what a dead guard would scan
+
 	checker := &Checker{
 		logger: newSecurityTestLogger(),
 		cfg:    &config.Config{BaseDir: ""},
@@ -1794,9 +1809,9 @@ func TestDetectPrivateAgeKeysEmptyBaseDir(t *testing.T) {
 
 	checker.detectPrivateAgeKeys(context.Background())
 
-	// Should not crash and should not add issues
+	// Empty BaseDir must skip the scan: no crash, and no walk of ./identity.
 	if checker.result.TotalIssues() != 0 {
-		t.Errorf("expected no issues for empty base dir, got %+v", checker.result.Issues)
+		t.Fatalf("empty BaseDir must skip the scan, got %+v", checker.result.Issues)
 	}
 }
 

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -311,7 +311,7 @@ func TestVerifyDirectoriesCreatesMissing(t *testing.T) {
 		SecureAccount: filepath.Join(baseDir, "secure_account"),
 	}
 	checker := newChecker(t, cfg)
-	checker.verifyDirectories()
+	checker.verifyDirectories(context.Background())
 
 	paths := []string{
 		cfg.BackupPath,
@@ -1721,7 +1721,7 @@ func TestVerifyDirectoriesSkipOwnership(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifyDirectories()
+	checker.verifyDirectories(context.Background())
 
 	// Should not have ownership warnings for backup dir when SetBackupPermissions=true
 	// The function should skip ownership checks for this path
@@ -1742,7 +1742,7 @@ func TestVerifyDirectoriesEmptyPath(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifyDirectories()
+	checker.verifyDirectories(context.Background())
 
 	// Should not create directories for empty paths
 	// Only identity dirs should be checked
@@ -2083,7 +2083,7 @@ func TestVerifyDirectoriesWithAllPaths(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifyDirectories()
+	checker.verifyDirectories(context.Background())
 
 	// All directories should be created
 	paths := []string{
@@ -2337,7 +2337,7 @@ func TestVerifyDirectoriesWithExistingDir(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifyDirectories()
+	checker.verifyDirectories(context.Background())
 
 	// Should have warning about wrong permissions
 	hasPermWarning := false
@@ -2369,7 +2369,7 @@ func TestVerifyDirectoriesSkipOwnershipForBackup(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifyDirectories()
+	checker.verifyDirectories(context.Background())
 
 	// The backup directory should have ownership check skipped
 	// Ownership warnings for backup path should not appear
@@ -2412,7 +2412,7 @@ func TestVerifyDirectoriesSkipsPOSIXChecksOnCIFSBackupPath(t *testing.T) {
 		},
 	}
 
-	checker.verifyDirectories()
+	checker.verifyDirectories(context.Background())
 
 	for _, issue := range checker.result.Issues {
 		if strings.Contains(issue.Message, backupDir) &&
@@ -2647,7 +2647,7 @@ func TestVerifyDirectoriesStatOtherError(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifyDirectories()
+	checker.verifyDirectories(context.Background())
 
 	// The function should handle this case (file exists but is not a directory)
 }

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -238,7 +238,7 @@ func TestParseSSLineVariants(t *testing.T) {
 
 func TestVerifyConfigFileMissingPath(t *testing.T) {
 	checker := newChecker(t, &config.Config{})
-	checker.verifyConfigFile()
+	checker.verifyConfigFile(context.Background())
 	if !containsIssue(checker.result, "Configuration path not provided") {
 		t.Fatalf("expected warning about missing configuration path, got %+v", checker.result.Issues)
 	}
@@ -247,7 +247,7 @@ func TestVerifyConfigFileMissingPath(t *testing.T) {
 func TestVerifyConfigFileStatError(t *testing.T) {
 	checker := newChecker(t, &config.Config{})
 	checker.configPath = filepath.Join(t.TempDir(), "does-not-exist.conf")
-	checker.verifyConfigFile()
+	checker.verifyConfigFile(context.Background())
 	if !containsIssue(checker.result, "Cannot stat configuration file") {
 		t.Fatalf("expected error about missing configuration file, got %+v", checker.result.Issues)
 	}
@@ -256,7 +256,7 @@ func TestVerifyConfigFileStatError(t *testing.T) {
 func TestVerifySensitiveFilesOptionalSkip(t *testing.T) {
 	cfg := &config.Config{BaseDir: t.TempDir()}
 	checker := newChecker(t, cfg)
-	checker.verifySensitiveFiles()
+	checker.verifySensitiveFiles(context.Background())
 	if checker.result.TotalIssues() != 0 {
 		t.Fatalf("expected no issues for optional sensitive files, got %+v", checker.result.Issues)
 	}
@@ -278,7 +278,7 @@ func TestVerifySensitiveFilesAgeRecipientPermissions(t *testing.T) {
 		EncryptArchive: true,
 	}
 	checker := newChecker(t, cfg)
-	checker.verifySensitiveFiles()
+	checker.verifySensitiveFiles(context.Background())
 
 	if !containsIssue(checker.result, "AGE recipient file") {
 		t.Fatalf("expected warning mentioning AGE recipient file, got %+v", checker.result.Issues)
@@ -294,7 +294,7 @@ func TestVerifySecureAccountFiles(t *testing.T) {
 
 	cfg := &config.Config{SecureAccount: secureDir}
 	checker := newChecker(t, cfg)
-	checker.verifySecureAccountFiles()
+	checker.verifySecureAccountFiles(context.Background())
 
 	if !containsIssue(checker.result, "Secure account file") {
 		t.Fatalf("expected issue referencing secure account file, got %+v", checker.result.Issues)
@@ -1238,7 +1238,7 @@ func TestEnsureOwnershipAndPermNilInfo(t *testing.T) {
 	}
 
 	// Pass nil info - function should call Lstat internally
-	info := checker.ensureOwnershipAndPerm(testFile, nil, 0600, "test file")
+	info := checker.ensureOwnershipAndPerm(context.Background(), testFile, nil, 0600, "test file")
 	if info == nil {
 		t.Error("ensureOwnershipAndPerm should return FileInfo when nil info passed")
 	}
@@ -1251,7 +1251,7 @@ func TestEnsureOwnershipAndPermNonExistentFile(t *testing.T) {
 		result: &Result{},
 	}
 
-	info := checker.ensureOwnershipAndPerm("/nonexistent/file/path", nil, 0600, "test")
+	info := checker.ensureOwnershipAndPerm(context.Background(), "/nonexistent/file/path", nil, 0600, "test")
 	if info != nil {
 		t.Error("ensureOwnershipAndPerm should return nil for non-existent file")
 	}
@@ -1273,7 +1273,7 @@ func TestEnsureOwnershipAndPermWrongPermissions(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.ensureOwnershipAndPerm(testFile, nil, 0600, "test file")
+	checker.ensureOwnershipAndPerm(context.Background(), testFile, nil, 0600, "test file")
 
 	// Should have a warning about wrong permissions
 	if !containsIssue(checker.result, "should have permissions") {
@@ -1312,7 +1312,7 @@ func TestEnsureOwnershipAndPermRefusesSymlinkTarget(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.ensureOwnershipAndPerm(link, info, 0o600, "test file via symlink")
+	checker.ensureOwnershipAndPerm(context.Background(), link, info, 0o600, "test file via symlink")
 
 	// The target must NOT have been chmod'd through the link.
 	ti, err := os.Lstat(target)
@@ -1340,7 +1340,7 @@ func TestEnsureOwnershipAndPermAutoFix(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.ensureOwnershipAndPerm(testFile, nil, 0600, "test file")
+	checker.ensureOwnershipAndPerm(context.Background(), testFile, nil, 0600, "test file")
 
 	// Check if permissions were fixed
 	info, err := os.Stat(testFile)
@@ -1406,7 +1406,7 @@ func TestEnsureOwnershipAndPermSymlink(t *testing.T) {
 	}
 
 	info, _ := os.Lstat(symlinkFile)
-	checker.ensureOwnershipAndPerm(symlinkFile, info, 0600, "symlink test")
+	checker.ensureOwnershipAndPerm(context.Background(), symlinkFile, info, 0600, "symlink test")
 
 	// Should refuse to chmod symlink
 	if !containsIssue(checker.result, "refusing to chmod symlink") {
@@ -1826,7 +1826,7 @@ func TestVerifySecureAccountFilesEmptyPath(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifySecureAccountFiles()
+	checker.verifySecureAccountFiles(context.Background())
 
 	// Should return early with no issues
 	if checker.result.TotalIssues() != 0 {
@@ -1843,7 +1843,7 @@ func TestVerifySecureAccountFilesNoJsonFiles(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifySecureAccountFiles()
+	checker.verifySecureAccountFiles(context.Background())
 
 	// Should not add issues when no JSON files exist
 	if checker.result.TotalIssues() != 0 {
@@ -1957,7 +1957,7 @@ func TestEnsureOwnershipAndPermNotOwnedByRoot(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.ensureOwnershipAndPerm(testFile, nil, 0600, "test file")
+	checker.ensureOwnershipAndPerm(context.Background(), testFile, nil, 0600, "test file")
 
 	// Should have warning about ownership (not root:root)
 	if !containsIssue(checker.result, "should be owned by root:root") {
@@ -1990,7 +1990,7 @@ func TestEnsureOwnershipAndPermSymlinkOwnership(t *testing.T) {
 
 	info, _ := os.Lstat(symlinkFile)
 	// Force the symlink path through ownership check
-	checker.ensureOwnershipAndPerm(symlinkFile, info, 0, "symlink test")
+	checker.ensureOwnershipAndPerm(context.Background(), symlinkFile, info, 0, "symlink test")
 
 	// Should refuse to chown symlink
 	if !containsIssue(checker.result, "refusing to chown symlink") {
@@ -2126,7 +2126,7 @@ func TestVerifySensitiveFilesServerIdentity(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifySensitiveFiles()
+	checker.verifySensitiveFiles(context.Background())
 
 	// Should have warning about permissions (0644 instead of 0600)
 	if !containsIssue(checker.result, "server identity") {
@@ -2444,7 +2444,7 @@ func TestVerifySecureAccountFilesStatError(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifySecureAccountFiles()
+	checker.verifySecureAccountFiles(context.Background())
 
 	// Function should complete without panic
 }
@@ -2467,7 +2467,7 @@ func TestEnsureOwnershipAndPermExpectedPermZero(t *testing.T) {
 	}
 
 	// When expectedPerm is 0, skip permission check
-	checker.ensureOwnershipAndPerm(testFile, nil, 0, "test file")
+	checker.ensureOwnershipAndPerm(context.Background(), testFile, nil, 0, "test file")
 
 	// Should not have permission-related warnings (only ownership if not root)
 	hasPermWarning := false
@@ -2791,7 +2791,7 @@ func TestVerifySensitiveFilesCustomAgeRecipient(t *testing.T) {
 		result: &Result{},
 	}
 
-	checker.verifySensitiveFiles()
+	checker.verifySensitiveFiles(context.Background())
 
 	// Should warn about wrong permissions on custom recipient file
 	if !containsIssue(checker.result, "AGE recipient") {

--- a/internal/security/security_timeout_test.go
+++ b/internal/security/security_timeout_test.go
@@ -89,3 +89,99 @@ func TestShouldSkipPOSIXDirectoryChecksOnDetectionTimeout(t *testing.T) {
 		t.Fatalf("expected a timeout warning, got %+v", checker.result.Issues)
 	}
 }
+
+// TestEnsureOwnershipAndPermDryRunIsReadOnly verifies that, in dry-run, the
+// preflight does not chmod an existing file with wrong permissions (it only
+// reports what it would do).
+func TestEnsureOwnershipAndPermDryRunIsReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg := &config.Config{
+		BaseDir:            dir,
+		AutoFixPermissions: true,
+		DryRun:             true,
+	}
+	checker := newChecker(t, cfg)
+	checker.fsTimeout = 30 * time.Second
+
+	checker.ensureOwnershipAndPerm(context.Background(), file, nil, 0o600, "test file")
+
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("dry-run must not chmod existing file; perm = %o, want 644", info.Mode().Perm())
+	}
+}
+
+// TestVerifyBinaryIntegrityDryRunDoesNotRegenerateHash verifies that a dry-run
+// does not rewrite the .md5 hash file on mismatch (the "Regenerated hash file"
+// write from issue #242).
+func TestVerifyBinaryIntegrityDryRunDoesNotRegenerateHash(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "binary")
+	if err := os.WriteFile(execPath, []byte("real content"), 0o700); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+	hashPath := execPath + ".md5"
+	if err := os.WriteFile(hashPath, []byte("stale-hash"), 0o600); err != nil {
+		t.Fatalf("write stale hash: %v", err)
+	}
+
+	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: true, DryRun: true}, execPath)
+	checker.verifyBinaryIntegrity()
+
+	data, err := os.ReadFile(hashPath)
+	if err != nil {
+		t.Fatalf("read hash: %v", err)
+	}
+	if string(data) != "stale-hash" {
+		t.Fatalf("dry-run must not regenerate hash file; got %q, want %q", string(data), "stale-hash")
+	}
+}
+
+// TestVerifyBinaryIntegrityDryRunDoesNotCreateHash verifies that a dry-run does
+// not create a missing .md5 hash file.
+func TestVerifyBinaryIntegrityDryRunDoesNotCreateHash(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "binary")
+	if err := os.WriteFile(execPath, []byte("content"), 0o700); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+
+	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: true, DryRun: true}, execPath)
+	checker.verifyBinaryIntegrity()
+
+	if _, err := os.Stat(execPath + ".md5"); !os.IsNotExist(err) {
+		t.Fatalf("dry-run must not create hash file; stat err = %v", err)
+	}
+}
+
+// TestVerifyBinaryIntegrityFromFDDryRunDoesNotChmod verifies that a dry-run does
+// not fchmod the executable (ensureOwnershipAndPermFromFD) when its mode differs
+// from the expected 0o700.
+func TestVerifyBinaryIntegrityFromFDDryRunDoesNotChmod(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "binary")
+	if err := os.WriteFile(execPath, []byte("content"), 0o700); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+	if err := os.Chmod(execPath, 0o755); err != nil { // wrong perm vs expected 0o700
+		t.Fatalf("chmod: %v", err)
+	}
+
+	checker := newCheckerWithExec(t, &config.Config{AutoFixPermissions: true, AutoUpdateHashes: false, DryRun: true}, execPath)
+	checker.verifyBinaryIntegrity()
+
+	info, err := os.Stat(execPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("dry-run must not fchmod the executable; perm = %o, want 755", info.Mode().Perm())
+	}
+}

--- a/internal/security/security_timeout_test.go
+++ b/internal/security/security_timeout_test.go
@@ -326,8 +326,10 @@ func TestVerifyBinaryIntegrityHashReadTimeoutSkips(t *testing.T) {
 		t.Skipf("mkfifo unsupported: %v", err)
 	}
 	t.Cleanup(func() {
-		// Unblock the abandoned os.ReadFile(FIFO) worker by opening the write end.
-		if w, e := os.OpenFile(hashPath, os.O_WRONLY, 0); e == nil {
+		// Unblock the abandoned FIFO-read worker by opening the write end. O_NONBLOCK
+		// so a regression where the read was never attempted (no reader) returns ENXIO
+		// immediately (e != nil -> skip) instead of wedging the cleanup forever.
+		if w, e := os.OpenFile(hashPath, os.O_WRONLY|syscall.O_NONBLOCK, 0); e == nil {
 			_ = w.Close()
 		}
 	})
@@ -376,12 +378,20 @@ func TestVerifyBinaryIntegrityHashWriteTimeoutWarns(t *testing.T) {
 		_ = w.Close()
 	}()
 	t.Cleanup(func() {
-		<-writerDone
-		// Unblock the abandoned regenerate os.WriteFile(FIFO) worker by draining
-		// the read end.
-		if r, e := os.OpenFile(hashPath, os.O_RDONLY, 0); e == nil {
+		// Drain the read end FIRST (O_NONBLOCK open never wedges): providing a reader
+		// rendezvouses and releases both the feed goroutine's O_WRONLY open and the
+		// abandoned regenerate-write worker's O_WRONLY open, even on a regression where
+		// verifyBinaryIntegrity never touched the FIFO. io.Copy terminates because both
+		// writers close once unblocked.
+		if r, e := os.OpenFile(hashPath, os.O_RDONLY|syscall.O_NONBLOCK, 0); e == nil {
 			_, _ = io.Copy(io.Discard, r)
 			_ = r.Close()
+		}
+		// Then bound the join so a stuck feed goroutine cannot wedge the suite.
+		select {
+		case <-writerDone:
+		case <-time.After(time.Second):
+			t.Error("timed out waiting for the FIFO writer goroutine to finish")
 		}
 	})
 

--- a/internal/security/security_timeout_test.go
+++ b/internal/security/security_timeout_test.go
@@ -2,8 +2,11 @@ package security
 
 import (
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -238,5 +241,159 @@ func TestDetectPrivateAgeKeysSkipsOnTimeout(t *testing.T) {
 	}
 	if containsIssue(checker.result, "Possible private AGE/SSH key") {
 		t.Fatalf("must not scan/flag keys on timeout; got %+v", checker.result.Issues)
+	}
+}
+
+// runVerifyBinaryIntegrityGuarded runs verifyBinaryIntegrity in a goroutine and
+// fails the test if it does not return within 5s. A reverted bound on any .md5
+// op manifests as a hang on a wedged FIFO / blocked stat seam, so this watchdog
+// is the mutation property: drop a bound -> the op blocks forever -> Fatal.
+func runVerifyBinaryIntegrityGuarded(t *testing.T, checker *Checker, ctx context.Context) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		checker.verifyBinaryIntegrity(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("verifyBinaryIntegrity hung: a .md5 op is not timeout-bounded")
+	}
+}
+
+// TestVerifyBinaryIntegrityHashStatTimeoutSkips proves the existence-stat bound
+// on the .md5 path AND the explicit safefs.ErrTimeout branch (the control-flow
+// trap): a wedged stat must warn+skip, never fall through to the read.
+// Mutation: revert safefs.Stat -> os.Stat (the seam swaps safefs's osStat, not
+// the package's os.Stat, so a raw os.Stat returns ErrNotExist instantly and the
+// "timed out" warning never appears); OR delete the ErrTimeout branch (falls
+// through to the bounded read and emits a different message) -> this test fails.
+func TestVerifyBinaryIntegrityHashStatTimeoutSkips(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "binary")
+	if err := os.WriteFile(execPath, []byte("real content"), 0o700); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+	// A real, readable .md5 with stale content: if the stat were NOT bounded the
+	// code would fall through, read this file, and warn "Executable hash mismatch"
+	// (never "timed out").
+	if err := os.WriteFile(execPath+".md5", []byte("stale-hash"), 0o600); err != nil {
+		t.Fatalf("write hash: %v", err)
+	}
+
+	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: false}, execPath)
+	checker.fsTimeout = 300 * time.Millisecond
+
+	// Install the blocking osStat seam AFTER setup (setup used raw os.WriteFile,
+	// not safefs.Stat). The lone safefs.Stat call in verifyBinaryIntegrity is the
+	// hashFile existence check; the executable path uses osLstat/osOpen and the
+	// FD-based ownership/checksum helpers, none of which route through osStat.
+	park := make(chan struct{})
+	t.Cleanup(func() { close(park) }) // release the abandoned osStat worker
+	restore := safefs.SetOsStatForTest(func(string) (os.FileInfo, error) {
+		<-park
+		return nil, errors.New("released")
+	})
+	t.Cleanup(restore)
+
+	runVerifyBinaryIntegrityGuarded(t, checker, context.Background())
+
+	if checker.result.ErrorCount() != 0 {
+		t.Fatalf("stat timeout must not error, got %d: %+v", checker.result.ErrorCount(), checker.result.Issues)
+	}
+	if !containsIssue(checker.result, "stat of hash file") || !containsIssue(checker.result, "timed out") {
+		t.Fatalf("expected a stat-of-hash-file timeout warning, got %+v", checker.result.Issues)
+	}
+	if containsIssue(checker.result, "Unable to read hash file") || containsIssue(checker.result, "Executable hash mismatch") {
+		t.Fatalf("stat timeout must not fall through to read/compare, got %+v", checker.result.Issues)
+	}
+}
+
+// TestVerifyBinaryIntegrityHashReadTimeoutSkips proves the ReadFile bound. The
+// .md5 is a FIFO with no writer: os.Stat(FIFO) succeeds (exists) so the code
+// falls through to the bounded read, which blocks on the writer-less FIFO until
+// the fs timeout fires. Mutation: revert safefs.Run -> raw os.ReadFile -> the
+// read blocks forever -> the watchdog Fatals.
+func TestVerifyBinaryIntegrityHashReadTimeoutSkips(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "binary")
+	if err := os.WriteFile(execPath, []byte("content"), 0o700); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+	hashPath := execPath + ".md5"
+	if err := syscall.Mkfifo(hashPath, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+	t.Cleanup(func() {
+		// Unblock the abandoned os.ReadFile(FIFO) worker by opening the write end.
+		if w, e := os.OpenFile(hashPath, os.O_WRONLY, 0); e == nil {
+			_ = w.Close()
+		}
+	})
+
+	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: false}, execPath)
+	checker.fsTimeout = 300 * time.Millisecond
+
+	runVerifyBinaryIntegrityGuarded(t, checker, context.Background())
+
+	if checker.result.ErrorCount() != 0 {
+		t.Fatalf("read timeout must not error, got %d: %+v", checker.result.ErrorCount(), checker.result.Issues)
+	}
+	if !containsIssue(checker.result, "reading hash file") || !containsIssue(checker.result, "timed out") {
+		t.Fatalf("expected a reading-hash-file timeout warning, got %+v", checker.result.Issues)
+	}
+}
+
+// TestVerifyBinaryIntegrityHashWriteTimeoutWarns proves the WriteFile bound via
+// the regenerate path (which shares c.writeHashFile with the create path, so a
+// single revert point covers both writes). A feed goroutine writes a wrong hash
+// to the FIFO then closes it, so the bounded read returns a mismatch; the
+// subsequent regenerate write opens the now reader/writer-less FIFO O_WRONLY and
+// blocks until the fs timeout fires. Mutation: revert writeHashFile's safefs.Run
+// -> raw os.WriteFile -> the write blocks forever -> the watchdog Fatals.
+func TestVerifyBinaryIntegrityHashWriteTimeoutWarns(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "binary")
+	if err := os.WriteFile(execPath, []byte("content"), 0o700); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+	hashPath := execPath + ".md5"
+	if err := syscall.Mkfifo(hashPath, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+
+	// Feed a wrong hash then EOF so the bounded read yields a mismatch and the
+	// code proceeds to the regenerate write.
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		w, e := os.OpenFile(hashPath, os.O_WRONLY, 0)
+		if e != nil {
+			return
+		}
+		_, _ = w.Write([]byte("stale-hash\n"))
+		_ = w.Close()
+	}()
+	t.Cleanup(func() {
+		<-writerDone
+		// Unblock the abandoned regenerate os.WriteFile(FIFO) worker by draining
+		// the read end.
+		if r, e := os.OpenFile(hashPath, os.O_RDONLY, 0); e == nil {
+			_, _ = io.Copy(io.Discard, r)
+			_ = r.Close()
+		}
+	})
+
+	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: true, DryRun: false}, execPath)
+	checker.fsTimeout = 300 * time.Millisecond
+
+	runVerifyBinaryIntegrityGuarded(t, checker, context.Background())
+
+	if checker.result.ErrorCount() != 0 {
+		t.Fatalf("write timeout must not error, got %d: %+v", checker.result.ErrorCount(), checker.result.Issues)
+	}
+	if !containsIssue(checker.result, "Failed to update hash file") {
+		t.Fatalf("expected a failed-to-update-hash-file warning, got %+v", checker.result.Issues)
 	}
 }

--- a/internal/security/security_timeout_test.go
+++ b/internal/security/security_timeout_test.go
@@ -133,7 +133,7 @@ func TestVerifyBinaryIntegrityDryRunDoesNotRegenerateHash(t *testing.T) {
 	}
 
 	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: true, DryRun: true}, execPath)
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	data, err := os.ReadFile(hashPath)
 	if err != nil {
@@ -154,7 +154,7 @@ func TestVerifyBinaryIntegrityDryRunDoesNotCreateHash(t *testing.T) {
 	}
 
 	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: true, DryRun: true}, execPath)
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	if _, err := os.Stat(execPath + ".md5"); !os.IsNotExist(err) {
 		t.Fatalf("dry-run must not create hash file; stat err = %v", err)
@@ -175,7 +175,7 @@ func TestVerifyBinaryIntegrityFromFDDryRunDoesNotChmod(t *testing.T) {
 	}
 
 	checker := newCheckerWithExec(t, &config.Config{AutoFixPermissions: true, AutoUpdateHashes: false, DryRun: true}, execPath)
-	checker.verifyBinaryIntegrity()
+	checker.verifyBinaryIntegrity(context.Background())
 
 	info, err := os.Stat(execPath)
 	if err != nil {
@@ -183,5 +183,60 @@ func TestVerifyBinaryIntegrityFromFDDryRunDoesNotChmod(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o755 {
 		t.Fatalf("dry-run must not fchmod the executable; perm = %o, want 755", info.Mode().Perm())
+	}
+}
+
+// TestVerifyBinaryIntegritySkipsOnTimeout simulates a dead/stale mount under the
+// executable: the bounded Lstat times out, so the integrity check warns and skips
+// without erroring and without creating the .md5 hash file.
+func TestVerifyBinaryIntegritySkipsOnTimeout(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "binary")
+	if err := os.WriteFile(execPath, []byte("content"), 0o700); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+
+	checker := newCheckerWithExec(t, &config.Config{AutoUpdateHashes: true}, execPath)
+	checker.fsTimeout = 30 * time.Second
+
+	checker.verifyBinaryIntegrity(expiredContext(t))
+
+	if checker.result.ErrorCount() != 0 {
+		t.Fatalf("timeout must not error, got %d: %+v", checker.result.ErrorCount(), checker.result.Issues)
+	}
+	if !containsIssue(checker.result, "timed out") {
+		t.Fatalf("expected a timeout warning, got %+v", checker.result.Issues)
+	}
+	if _, err := os.Stat(execPath + ".md5"); !os.IsNotExist(err) {
+		t.Fatalf("must not create hash file on timeout; stat err = %v", err)
+	}
+}
+
+// TestDetectPrivateAgeKeysSkipsOnTimeout simulates a dead/stale mount under the
+// identity directory: the bounded stat times out, so the private-key scan warns and
+// skips without erroring and without scanning/flagging the planted key.
+func TestDetectPrivateAgeKeysSkipsOnTimeout(t *testing.T) {
+	baseDir := t.TempDir()
+	identityDir := filepath.Join(baseDir, "identity")
+	if err := os.MkdirAll(identityDir, 0o700); err != nil {
+		t.Fatalf("mkdir identity: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(identityDir, "key"), []byte("AGE-SECRET-KEY-1EXAMPLE"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	checker := newChecker(t, &config.Config{BaseDir: baseDir})
+	checker.fsTimeout = 30 * time.Second
+
+	checker.detectPrivateAgeKeys(expiredContext(t))
+
+	if checker.result.ErrorCount() != 0 {
+		t.Fatalf("timeout must not error, got %d: %+v", checker.result.ErrorCount(), checker.result.Issues)
+	}
+	if !containsIssue(checker.result, "timed out") {
+		t.Fatalf("expected a timeout warning, got %+v", checker.result.Issues)
+	}
+	if containsIssue(checker.result, "Possible private AGE/SSH key") {
+		t.Fatalf("must not scan/flag keys on timeout; got %+v", checker.result.Issues)
 	}
 }

--- a/internal/security/security_timeout_test.go
+++ b/internal/security/security_timeout_test.go
@@ -1,0 +1,91 @@
+package security
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/safefs"
+	"github.com/tis24dev/proxsave/internal/storage"
+)
+
+// expiredContext returns a context whose deadline is already in the past, so any
+// safefs operation returns ErrTimeout at entry without a real blocking mount.
+func expiredContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestVerifyDirectoriesSkipsOnTimeout simulates a dead/stale mount: every stat
+// times out, so verifyDirectories must warn and skip each path without erroring
+// and without creating anything.
+func TestVerifyDirectoriesSkipsOnTimeout(t *testing.T) {
+	baseDir := t.TempDir()
+	cfg := &config.Config{
+		BaseDir:    baseDir,
+		BackupPath: filepath.Join(baseDir, "backup"),
+		LogPath:    filepath.Join(baseDir, "log"),
+	}
+	checker := newChecker(t, cfg)
+	checker.fsTimeout = 30 * time.Second
+
+	checker.verifyDirectories(expiredContext(t))
+
+	if checker.result.ErrorCount() != 0 {
+		t.Fatalf("expected no errors on timeout, got %d: %+v", checker.result.ErrorCount(), checker.result.Issues)
+	}
+	if !containsIssue(checker.result, "timed out") {
+		t.Fatalf("expected a timeout warning, got %+v", checker.result.Issues)
+	}
+	if _, err := os.Stat(cfg.BackupPath); !os.IsNotExist(err) {
+		t.Fatalf("backup dir must not be created on timeout; stat err = %v", err)
+	}
+}
+
+// TestVerifyDirectoriesDryRunSkipsCreate verifies a dry-run never materializes a
+// missing directory.
+func TestVerifyDirectoriesDryRunSkipsCreate(t *testing.T) {
+	baseDir := t.TempDir()
+	cfg := &config.Config{
+		BaseDir:    baseDir,
+		BackupPath: filepath.Join(baseDir, "backup"),
+		LogPath:    filepath.Join(baseDir, "log"),
+		DryRun:     true,
+	}
+	checker := newChecker(t, cfg)
+	checker.fsTimeout = 30 * time.Second
+
+	checker.verifyDirectories(context.Background())
+
+	if checker.result.ErrorCount() != 0 {
+		t.Fatalf("dry-run should not error, got %d: %+v", checker.result.ErrorCount(), checker.result.Issues)
+	}
+	for _, p := range []string{cfg.BackupPath, cfg.LogPath, filepath.Join(baseDir, "identity")} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("dry-run must not create %s; stat err = %v", p, err)
+		}
+	}
+}
+
+// TestShouldSkipPOSIXDirectoryChecksOnDetectionTimeout verifies a filesystem
+// detection timeout is treated as "skip the path" (warning), not "proceed".
+func TestShouldSkipPOSIXDirectoryChecksOnDetectionTimeout(t *testing.T) {
+	cfg := &config.Config{BaseDir: t.TempDir()}
+	checker := newChecker(t, cfg)
+	checker.fsTimeout = 30 * time.Second
+	checker.filesystemInfoLookup = func(context.Context, string) (*storage.FilesystemInfo, error) {
+		return nil, &safefs.TimeoutError{Op: "statfs", Path: "/mnt/dead", Timeout: 30 * time.Second}
+	}
+
+	if !checker.shouldSkipPOSIXDirectoryChecks(context.Background(), "/mnt/dead") {
+		t.Fatal("expected shouldSkipPOSIXDirectoryChecks to return true on detection timeout")
+	}
+	if !containsIssue(checker.result, "timed out") {
+		t.Fatalf("expected a timeout warning, got %+v", checker.result.Issues)
+	}
+}

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -1050,10 +1050,10 @@ func (c *CloudStorage) rcloneCopy(ctx context.Context, localFile, remoteFile str
 // uninterruptible read. Sourced from FS_IO_TIMEOUT; a non-positive value (the
 // FS_IO_TIMEOUT=0 opt-out) yields 0, which safefs treats as unbounded.
 func (c *CloudStorage) fsIoTimeout() time.Duration {
-	if c == nil || c.config == nil || c.config.FsIoTimeoutSeconds <= 0 {
+	if c == nil {
 		return 0
 	}
-	return time.Duration(c.config.FsIoTimeoutSeconds) * time.Second
+	return fsIoTimeout(c.config)
 }
 
 // VerifyUpload verifies that a file was successfully uploaded to cloud storage

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -31,6 +31,18 @@ import (
 // tests can shrink it; 3s mirrors orchestrator.defaultCommandWaitDelay.
 var cloudExecWaitDelay = 3 * time.Second
 
+// cloudManagementTimeoutFloor bounds the deadline-less management/query rclone ops
+// (List / Delete / countLogFiles, and the retention/stats paths that fan out through
+// them) so a wedged rclone metadata call on a dead/stale remote cannot run forever:
+// they run under the cancel-only run ctx, so without a floor a stall hangs the run.
+// It is applied ONLY to management ops, never to the upload path; an upload with
+// RCLONE_TIMEOUT_OPERATION=0 is deliberately unbounded and must stay so. This is the
+// management ceiling only when RCLONE_TIMEOUT_OPERATION<=0; when it is >0,
+// managementTimeout uses that value instead (so a tuned operation timeout also caps
+// management ops). 300s mirrors the RCLONE_TIMEOUT_OPERATION default; a var (not
+// const) so tests can shrink it.
+var cloudManagementTimeoutFloor = 300 * time.Second
+
 // CloudStorage implements the Storage interface for cloud storage using rclone
 // All errors from cloud storage are NON-FATAL - they log warnings but don't abort the backup
 // Uses comprehensible timeout names: CONNECTION (for remote check) and OPERATION (for upload/download)
@@ -728,9 +740,16 @@ func (c *CloudStorage) Store(ctx context.Context, backupFile string, metadata *t
 	c.logger.Debug("Cloud storage: upload retries=%d threads=%d bwlimit=%s",
 		c.config.RcloneRetries, c.config.RcloneTransfers, c.config.RcloneBandwidthLimit)
 
-	// Use OPERATION timeout for upload (long timeout)
-	uploadCtx, cancel := context.WithTimeout(ctx, time.Duration(c.config.RcloneTimeoutOperation)*time.Second)
-	defer cancel()
+	// Use OPERATION timeout for upload (long timeout). Guard >0 so
+	// RCLONE_TIMEOUT_OPERATION=0 means "unbounded upload" instead of
+	// WithTimeout(ctx, 0) (an already-expired ctx that fails every upload
+	// instantly). Consistent with UploadToRemotePath and remoteSHA256.
+	uploadCtx := ctx
+	if c.config.RcloneTimeoutOperation > 0 {
+		var cancel context.CancelFunc
+		uploadCtx, cancel = context.WithTimeout(ctx, time.Duration(c.config.RcloneTimeoutOperation)*time.Second)
+		defer cancel()
+	}
 
 	tasks := make([]uploadTask, 0, 4)
 	tasks = append(tasks, uploadTask{
@@ -910,8 +929,14 @@ func (c *CloudStorage) shouldUseParallelUpload() bool {
 }
 
 func (c *CloudStorage) runUploadTask(parentCtx context.Context, task uploadTask) error {
-	taskCtx, cancel := context.WithTimeout(parentCtx, time.Duration(c.config.RcloneTimeoutOperation)*time.Second)
-	defer cancel()
+	// Guard >0 so RCLONE_TIMEOUT_OPERATION=0 stays unbounded rather than collapsing
+	// to an already-expired WithTimeout(parentCtx, 0).
+	taskCtx := parentCtx
+	if c.config.RcloneTimeoutOperation > 0 {
+		var cancel context.CancelFunc
+		taskCtx, cancel = context.WithTimeout(parentCtx, time.Duration(c.config.RcloneTimeoutOperation)*time.Second)
+		defer cancel()
+	}
 
 	if err := c.uploadWithRetry(taskCtx, task.local, task.remote); err != nil {
 		return err
@@ -1323,6 +1348,9 @@ func (c *CloudStorage) List(ctx context.Context) (backups []*types.BackupMetadat
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	// Floor the deadline-less run ctx so a wedged rclone lsl cannot hang forever.
+	ctx, cancel := c.boundManagementCtx(ctx)
+	defer cancel()
 
 	// List files in remote
 	args := c.buildRcloneArgs("lsl")
@@ -1491,6 +1519,10 @@ func (c *CloudStorage) deleteBackupInternal(ctx context.Context, backupFile stri
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
+	// Floor the deadline-less run ctx (covers the snapshot List, the deletefile
+	// calls, and deleteAssociatedLog) so a wedged delete cannot hang the run.
+	ctx, cancel := c.boundManagementCtx(ctx)
+	defer cancel()
 
 	c.ensureRemoteSnapshot(ctx)
 
@@ -1573,6 +1605,10 @@ func (c *CloudStorage) deleteAssociatedLog(ctx context.Context, backupFile strin
 	if c == nil || c.config == nil {
 		return false
 	}
+	// No-op when called from deleteBackupInternal (ctx already floored); bounds
+	// standalone callers on the deadline-less run ctx.
+	ctx, cancel := c.boundManagementCtx(ctx)
+	defer cancel()
 
 	base := strings.TrimSpace(c.config.CloudLogPath)
 	if base == "" {
@@ -1628,6 +1664,8 @@ func (c *CloudStorage) countLogFiles(ctx context.Context) int {
 	if c == nil || c.config == nil {
 		return -1
 	}
+	ctx, cancel := c.boundManagementCtx(ctx)
+	defer cancel()
 	base := c.cloudLogBase(c.config.CloudLogPath)
 	if base == "" {
 		return 0
@@ -1997,6 +2035,28 @@ func (c *CloudStorage) markCloudLogPathAvailable() {
 	c.logPathMu.Lock()
 	c.logPathMissing = false
 	c.logPathMu.Unlock()
+}
+
+// managementTimeout is the per-op ceiling for deadline-less management/query rclone
+// calls: the operator's RCLONE_TIMEOUT_OPERATION when positive, else the floor. It is
+// never <=0, so it can never produce an already-expired WithTimeout.
+func (c *CloudStorage) managementTimeout() time.Duration {
+	if c != nil && c.config != nil && c.config.RcloneTimeoutOperation > 0 {
+		return time.Duration(c.config.RcloneTimeoutOperation) * time.Second
+	}
+	return cloudManagementTimeoutFloor
+}
+
+// boundManagementCtx floors a DEADLINE-LESS ctx with managementTimeout so a wedged
+// rclone metadata op cannot hang the run forever (issue #242). It NEVER shortens a
+// ctx that already carries a deadline, so nested management calls share one budget
+// and are not double-bounded. Apply it ONLY to management/query ops, never to the
+// upload/verify path (an RCLONE_TIMEOUT_OPERATION=0 upload must stay unbounded).
+func (c *CloudStorage) boundManagementCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, c.managementTimeout())
 }
 
 func (c *CloudStorage) exec(ctx context.Context, name string, args ...string) ([]byte, error) {

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -1146,23 +1146,21 @@ func (c *CloudStorage) verifyRemoteChecksum(ctx context.Context, localFile, remo
 		return true, nil
 	}
 
-	// Bound the local read: GenerateChecksum opens and streams the whole local file,
-	// which on a dead/stale mount blocks in an uninterruptible read its own per-chunk
-	// ctx check cannot break. safefs.Run abandons the worker on timeout. A timeout is
-	// treated like any other local-hash failure here: the size pre-check already
+	// Bound the local read per-chunk: GenerateChecksumBounded streams the whole local
+	// file but resets its stall budget on every chunk, so a healthy archive that is
+	// merely large (slow but steadily progressing) hashes to completion and is verified
+	// by content. Only a genuinely stalled read (no progress for FS_IO_TIMEOUT, e.g. a
+	// dead/stale mount whose uninterruptible read never returns) is abandoned. A stall
+	// is treated like any other local-hash failure here: the size pre-check already
 	// passed, so we keep the size-only verdict (best-effort, Debug) rather than fail a
 	// good upload, which would flip the run's exit code.
-	// Note: FS_IO_TIMEOUT also caps a *healthy* hash of a very large local file, so an
-	// oversized archive on slow local storage may degrade to size-only verification.
-	localHash, err := safefs.Run(ctx, "verify-local-hash", localFile, c.fsIoTimeout(), func() (string, error) {
-		return backup.GenerateChecksum(ctx, c.logger, localFile)
-	})
+	localHash, err := backup.GenerateChecksumBounded(ctx, c.logger, localFile, c.fsIoTimeout())
 	if err != nil {
 		if ctx.Err() != nil {
 			return false, err
 		}
 		if errors.Is(err, safefs.ErrTimeout) {
-			c.logger.Debug("Cloud verify: hashing local %s timed out (dead/stale mount?), kept size-only verification", filename)
+			c.logger.Debug("Cloud verify: hashing local %s stalled (dead/stale mount?), kept size-only verification", filename)
 			return true, nil
 		}
 		c.logger.Debug("Cloud verify: could not hash local %s, kept size-only verification: %v", filename, err)

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -17,9 +17,19 @@ import (
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/safeexec"
+	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/internal/types"
 	"github.com/tis24dev/proxsave/pkg/utils"
 )
+
+// cloudExecWaitDelay bounds how long defaultExecCommand waits, after ctx
+// cancellation/deadline, for a SIGKILLed rclone to be reaped and its stdout/stderr
+// pipes to drain before they are force-closed and Wait is released with
+// exec.ErrWaitDelay. It is the reaping half of the WithTimeout+WaitDelay pair: a
+// rclone interruptibly stalled on the network (or one whose child holds the pipe
+// open) would otherwise block CombinedOutput's Wait forever. A var (not const) so
+// tests can shrink it; 3s mirrors orchestrator.defaultCommandWaitDelay.
+var cloudExecWaitDelay = 3 * time.Second
 
 // CloudStorage implements the Storage interface for cloud storage using rclone
 // All errors from cloud storage are NON-FATAL - they log warnings but don't abort the backup
@@ -976,6 +986,17 @@ func (c *CloudStorage) wrapUploadError(localPath string, err error) error {
 // UploadToRemotePath uploads an arbitrary file to the provided remote path using
 // the same retry and verification logic used for backups.
 func (c *CloudStorage) UploadToRemotePath(ctx context.Context, localFile, remoteFile string, verify bool) error {
+	// Bound the whole operation (copy retries + verify) on one RcloneTimeoutOperation
+	// budget. This is the only upload entry point reachable with a deadline-less ctx:
+	// the cloud log dispatch passes the run ctx, which is cancel-only (no deadline),
+	// so without this a stalled rclone or dead/stale mount could hang shutdown. Like
+	// Store/runUploadTask (here one shared budget covers copy+verify); guarded >0 to
+	// avoid an already-expired WithTimeout(ctx, 0).
+	if c.config.RcloneTimeoutOperation > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(c.config.RcloneTimeoutOperation)*time.Second)
+		defer cancel()
+	}
 	if err := c.uploadWithRetry(ctx, localFile, remoteFile); err != nil {
 		return err
 	}
@@ -1024,13 +1045,24 @@ func (c *CloudStorage) rcloneCopy(ctx context.Context, localFile, remoteFile str
 	return nil
 }
 
+// fsIoTimeout bounds the in-process LOCAL file syscalls the verify path performs
+// (stat + checksum read) so a dead/stale local mount cannot wedge them in an
+// uninterruptible read. Sourced from FS_IO_TIMEOUT; a non-positive value (the
+// FS_IO_TIMEOUT=0 opt-out) yields 0, which safefs treats as unbounded.
+func (c *CloudStorage) fsIoTimeout() time.Duration {
+	if c == nil || c.config == nil || c.config.FsIoTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(c.config.FsIoTimeoutSeconds) * time.Second
+}
+
 // VerifyUpload verifies that a file was successfully uploaded to cloud storage
 // Uses two methods: primary (rclone lsl) and alternative (rclone ls + grep)
 func (c *CloudStorage) VerifyUpload(ctx context.Context, localFile, remoteFile string) (ok bool, err error) {
 	done := logging.DebugStart(c.logger, "cloud verify upload", "file=%s", filepath.Base(localFile))
 	defer func() { done(err) }()
-	// Get local file info
-	localStat, err := os.Stat(localFile)
+	// Get local file info (bounded: the local file may be on a dead/stale mount).
+	localStat, err := safefs.Stat(ctx, localFile, c.fsIoTimeout())
 	if err != nil {
 		return false, fmt.Errorf("cannot stat local file: %w", err)
 	}
@@ -1089,10 +1121,24 @@ func (c *CloudStorage) verifyRemoteChecksum(ctx context.Context, localFile, remo
 		return true, nil
 	}
 
-	localHash, err := backup.GenerateChecksum(ctx, c.logger, localFile)
+	// Bound the local read: GenerateChecksum opens and streams the whole local file,
+	// which on a dead/stale mount blocks in an uninterruptible read its own per-chunk
+	// ctx check cannot break. safefs.Run abandons the worker on timeout. A timeout is
+	// treated like any other local-hash failure here: the size pre-check already
+	// passed, so we keep the size-only verdict (best-effort, Debug) rather than fail a
+	// good upload, which would flip the run's exit code.
+	// Note: FS_IO_TIMEOUT also caps a *healthy* hash of a very large local file, so an
+	// oversized archive on slow local storage may degrade to size-only verification.
+	localHash, err := safefs.Run(ctx, "verify-local-hash", localFile, c.fsIoTimeout(), func() (string, error) {
+		return backup.GenerateChecksum(ctx, c.logger, localFile)
+	})
 	if err != nil {
 		if ctx.Err() != nil {
 			return false, err
+		}
+		if errors.Is(err, safefs.ErrTimeout) {
+			c.logger.Debug("Cloud verify: hashing local %s timed out (dead/stale mount?), kept size-only verification", filename)
+			return true, nil
 		}
 		c.logger.Debug("Cloud verify: could not hash local %s, kept size-only verification: %v", filename, err)
 		return true, nil
@@ -1978,6 +2024,14 @@ func defaultExecCommand(ctx context.Context, name string, args ...string) ([]byt
 	if err != nil {
 		return nil, err
 	}
+	// Once ctx is cancelled/expired the process is SIGKILLed; WaitDelay then bounds
+	// how long Wait blocks for it to be reaped / for orphaned pipes to drain before
+	// they are force-closed. Unlike osCommandRunner.Run (deps.go) we deliberately do
+	// NOT swallow exec.ErrWaitDelay to nil: a WaitDelay-killed rclone is an INCOMPLETE
+	// upload/op, and rcloneCopy/uploadWithRetry/verify rely on a non-nil error to
+	// retry or fail rather than record a phantom success. CombinedOutput already
+	// returns ErrWaitDelay as a non-nil error, so we propagate it unchanged.
+	cmd.WaitDelay = cloudExecWaitDelay
 	return cmd.CombinedOutput()
 }
 

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -1154,18 +1154,27 @@ func (c *CloudStorage) verifyRemoteChecksum(ctx context.Context, localFile, remo
 	// by content. Only a genuinely stalled read (no progress for FS_IO_TIMEOUT, e.g. a
 	// dead/stale mount whose uninterruptible read never returns) is abandoned. A stall
 	// is treated like any other local-hash failure here: the size pre-check already
-	// passed, so we keep the size-only verdict (best-effort, Debug) rather than fail a
-	// good upload, which would flip the run's exit code.
+	// passed, so we keep the size-only verdict (best-effort) rather than fail a good
+	// upload, but we surface it at Warning (see below) so it is not silent.
 	localHash, err := backup.GenerateChecksumBounded(ctx, c.logger, localFile, c.fsIoTimeout())
 	if err != nil {
 		if ctx.Err() != nil {
 			return false, err
 		}
+		// We hold the remote SHA256 but could not compute the local one, so the
+		// object is kept on the (already-passed) size-only verdict rather than
+		// failed: a local-read fault is no evidence the remote object is bad, the
+		// upload already streamed those bytes, and cloud is non-critical. Unlike a
+		// backend that simply has no SHA256 (an expected capability limit, Debug
+		// above), this is an actionable anomaly (typically a dead/stale BACKUP_PATH
+		// mount), so surface it at Warning: it must not be silently swallowed, and
+		// the run's exit code should reflect that the requested checksum could not
+		// actually run.
 		if errors.Is(err, safefs.ErrTimeout) {
-			c.logger.Debug("Cloud verify: hashing local %s stalled (dead/stale mount?), kept size-only verification", filename)
+			c.logger.Warning("Cloud verify: hashing local %s stalled (dead/stale mount?); object kept on size-only verification, full checksum NOT performed - check the backup mount", filename)
 			return true, nil
 		}
-		c.logger.Debug("Cloud verify: could not hash local %s, kept size-only verification: %v", filename, err)
+		c.logger.Warning("Cloud verify: could not hash local %s; object kept on size-only verification, full checksum NOT performed: %v", filename, err)
 		return true, nil
 	}
 	if remoteHash != localHash {

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -694,8 +694,10 @@ func (c *CloudStorage) Store(ctx context.Context, backupFile string, metadata *t
 		return err
 	}
 
-	// Verify source file exists
-	stat, err := os.Stat(backupFile)
+	// Verify source file exists. Bound the stat with FS_IO_TIMEOUT: this runs
+	// before uploadCtx/rclone, so a dead/stale BACKUP_PATH mount must not wedge
+	// Store in an uninterruptible (D-state) syscall here.
+	stat, err := safefs.Stat(ctx, backupFile, c.fsIoTimeout())
 	if err != nil {
 		c.logger.Debug("Cloud storage: source file %s not found", backupFile)
 		c.logger.Warning("WARNING: Cloud storage - backup file not found: %s: %v", backupFile, err)
@@ -717,7 +719,7 @@ func (c *CloudStorage) Store(ctx context.Context, backupFile string, metadata *t
 		// canonical bundle exists alongside the raw archive.
 		bundleFile := bundlePathFor(backupFile)
 		if bundleFile != backupFile {
-			bundleStat, err := os.Stat(bundleFile)
+			bundleStat, err := safefs.Stat(ctx, bundleFile, c.fsIoTimeout())
 			if err == nil {
 				primaryFile = bundleFile
 				primaryStat = bundleStat
@@ -769,8 +771,8 @@ func (c *CloudStorage) Store(ctx context.Context, backupFile string, metadata *t
 		}
 
 		for _, srcFile := range associatedFiles {
-			if _, err := os.Stat(srcFile); err != nil {
-				continue // Skip if doesn't exist
+			if _, err := safefs.Stat(ctx, srcFile, c.fsIoTimeout()); err != nil {
+				continue // Skip if missing or unreachable (a dead mount must not wedge the store)
 			}
 
 			tasks = append(tasks, uploadTask{

--- a/internal/storage/cloud_floor_clamp_test.go
+++ b/internal/storage/cloud_floor_clamp_test.go
@@ -1,0 +1,214 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+)
+
+// boundManagementCtx floors a deadline-less ctx with managementTimeout and never
+// re-floors a ctx that already carries a deadline.
+func TestBoundManagementCtx(t *testing.T) {
+	prev := cloudManagementTimeoutFloor
+	cloudManagementTimeoutFloor = 123 * time.Millisecond
+	t.Cleanup(func() { cloudManagementTimeoutFloor = prev })
+
+	cs := newCloudStorageForTest(&config.Config{CloudRemote: "remote", RcloneTimeoutOperation: 0})
+
+	// deadline-less -> floored to the management floor (op=0)
+	ctx, cancel := cs.boundManagementCtx(context.Background())
+	defer cancel()
+	dl, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("a deadline-less ctx must be floored")
+	}
+	if d := time.Until(dl); d <= 0 || d > 250*time.Millisecond {
+		t.Fatalf("floored deadline = %s; want ~123ms", d)
+	}
+
+	// already-bounded -> passthrough, not re-floored
+	parent, pcancel := context.WithTimeout(context.Background(), time.Hour)
+	defer pcancel()
+	ctx2, cancel2 := cs.boundManagementCtx(parent)
+	defer cancel2()
+	if dl2, _ := ctx2.Deadline(); time.Until(dl2) < 30*time.Minute {
+		t.Fatalf("a bounded ctx was wrongly re-floored: %s", time.Until(dl2))
+	}
+
+	// op>0 -> managementTimeout uses RcloneTimeoutOperation
+	csOp := newCloudStorageForTest(&config.Config{CloudRemote: "remote", RcloneTimeoutOperation: 7})
+	if got := csOp.managementTimeout(); got != 7*time.Second {
+		t.Fatalf("managementTimeout(op=7) = %s; want 7s", got)
+	}
+}
+
+// A wedged management op (List) on the deadline-less run ctx must be floored
+// (bounded, not hang) and surface as a NON-CRITICAL StorageError.
+func TestListFloorsWedgedDeadlessCtx(t *testing.T) {
+	prev := cloudManagementTimeoutFloor
+	cloudManagementTimeoutFloor = 100 * time.Millisecond
+	t.Cleanup(func() { cloudManagementTimeoutFloor = prev })
+
+	cs := newCloudStorageForTest(&config.Config{CloudRemote: "remote", RcloneTimeoutOperation: 0})
+	var sawDeadline atomic.Bool
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_, ok := ctx.Deadline()
+		sawDeadline.Store(ok)
+		<-ctx.Done() // wedge until the floor cancels
+		return nil, ctx.Err()
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := cs.List(context.Background())
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		var se *StorageError
+		if !errors.As(err, &se) || se.IsCritical {
+			t.Fatalf("want a non-critical StorageError, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("List hung: the deadline-less ctx was not floored")
+	}
+	if !sawDeadline.Load() {
+		t.Fatal("exec did not observe a floored deadline")
+	}
+}
+
+// countLogFiles is a second floored management site: a wedge must be bounded.
+func TestCountLogFilesFloorsWedgedDeadlessCtx(t *testing.T) {
+	prev := cloudManagementTimeoutFloor
+	cloudManagementTimeoutFloor = 100 * time.Millisecond
+	t.Cleanup(func() { cloudManagementTimeoutFloor = prev })
+
+	cs := newCloudStorageForTest(&config.Config{CloudRemote: "remote", CloudLogPath: "logs", RcloneTimeoutOperation: 0})
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	done := make(chan int, 1)
+	go func() { done <- cs.countLogFiles(context.Background()) }()
+	select {
+	case <-done: // returns (-1 best-effort) promptly; not hung
+	case <-time.After(3 * time.Second):
+		t.Fatal("countLogFiles hung: the deadline-less ctx was not floored")
+	}
+}
+
+// CLAMP: with RCLONE_TIMEOUT_OPERATION=0 the upload must NOT instant-fail (the old
+// WithTimeout(ctx,0) bug) and must reach rclone with an UNBOUNDED ctx (no deadline).
+func TestRunUploadTaskOperationZeroIsUnbounded(t *testing.T) {
+	cs := newCloudStorageForTest(&config.Config{CloudRemote: "remote", RcloneRetries: 1, RcloneTimeoutOperation: 0})
+	var called, sawDeadline atomic.Bool
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		called.Store(true)
+		if _, ok := ctx.Deadline(); ok {
+			sawDeadline.Store(true)
+		}
+		return []byte(""), nil // copy succeeds
+	}
+
+	if err := cs.runUploadTask(context.Background(), uploadTask{local: "/tmp/x", remote: "remote:x", verify: false}); err != nil {
+		t.Fatalf("op=0 upload must not instant-fail, got %v", err)
+	}
+	if !called.Load() {
+		t.Fatal("op=0 collapsed to an already-expired ctx: rclone was never invoked")
+	}
+	if sawDeadline.Load() {
+		t.Fatal("op=0 must leave the upload ctx unbounded (no deadline)")
+	}
+}
+
+// op>0: the upload ctx IS bounded by RcloneTimeoutOperation (the guard's positive arm).
+func TestRunUploadTaskOperationPositiveBoundsUpload(t *testing.T) {
+	cs := newCloudStorageForTest(&config.Config{CloudRemote: "remote", RcloneRetries: 1, RcloneTimeoutOperation: 30})
+	var sawDeadline atomic.Bool
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if _, ok := ctx.Deadline(); ok {
+			sawDeadline.Store(true)
+		}
+		return []byte(""), nil
+	}
+	if err := cs.runUploadTask(context.Background(), uploadTask{local: "/tmp/x", remote: "remote:x", verify: false}); err != nil {
+		t.Fatalf("runUploadTask: %v", err)
+	}
+	if !sawDeadline.Load() {
+		t.Fatal("op>0 must bound the upload ctx with a deadline")
+	}
+}
+
+// CLAMP at the Store boundary: Store builds its own uploadCtx before delegating, so
+// it needs its own guard. With op=0 the rclone copyto must be REACHED (not
+// instant-failed by WithTimeout(ctx,0)) and on an UNBOUNDED ctx. We assert only the
+// clamp property; Store may still error later on verify (not relevant here).
+func TestStoreOperationZeroReachesUploadUnbounded(t *testing.T) {
+	tmp := t.TempDir()
+	backupFile := filepath.Join(tmp, "pbs1-backup.tar.zst")
+	if err := os.WriteFile(backupFile, []byte("primary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cs := newCloudStorageForTest(&config.Config{CloudEnabled: true, CloudRemote: "remote", RcloneRetries: 1, RcloneTimeoutOperation: 0})
+	var copyCalled, copySawDeadline atomic.Bool
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "copyto" {
+			copyCalled.Store(true)
+			if _, ok := ctx.Deadline(); ok {
+				copySawDeadline.Store(true)
+			}
+		}
+		return []byte(""), nil
+	}
+
+	_ = cs.Store(context.Background(), backupFile, nil)
+	if !copyCalled.Load() {
+		t.Fatal("op=0 Store instant-failed: rclone copyto was never invoked (WithTimeout(ctx,0) bug)")
+	}
+	if copySawDeadline.Load() {
+		t.Fatal("op=0 Store must leave the upload ctx unbounded (no deadline)")
+	}
+}
+
+// A wedged deletefile must be floored (deleteBackupInternal's insertion point). The
+// snapshot lsl fails (snapshot not ready) so the deletefile is attempted; it then
+// wedges and must be cut by the floor instead of hanging the retention path.
+func TestDeleteBackupInternalFloorsWedgedDeletefile(t *testing.T) {
+	prev := cloudManagementTimeoutFloor
+	cloudManagementTimeoutFloor = 100 * time.Millisecond
+	t.Cleanup(func() { cloudManagementTimeoutFloor = prev })
+
+	cs := newCloudStorageForTest(&config.Config{CloudRemote: "remote", RcloneTimeoutOperation: 0})
+	var sawDeadline atomic.Bool
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && (args[0] == "deletefile" || args[0] == "delete") {
+			_, ok := ctx.Deadline()
+			sawDeadline.Store(ok)
+			<-ctx.Done() // wedge until the floor cancels
+			return nil, ctx.Err()
+		}
+		// snapshot lsl/lsf: fail fast so the snapshot stays empty and deletefile is attempted
+		return nil, errors.New("no listing")
+	}
+
+	done := make(chan struct{}, 1)
+	go func() {
+		_, _ = cs.deleteBackupInternal(context.Background(), "pbs1-backup.tar.zst")
+		done <- struct{}{}
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("deleteBackupInternal hung: the wedged deletefile was not floored")
+	}
+	if !sawDeadline.Load() {
+		t.Fatal("deletefile did not observe a floored deadline")
+	}
+}

--- a/internal/storage/cloud_timeout_test.go
+++ b/internal/storage/cloud_timeout_test.go
@@ -123,3 +123,70 @@ func TestVerifyRemoteChecksumLocalHashTimeoutDegrades(t *testing.T) {
 		t.Fatalf("local hash was not bounded: %s", d)
 	}
 }
+
+// Item 5 (mutation-prover for the per-chunk cloud-verify fix): a HEALTHY local
+// archive whose read is slow-but-progressing (aggregate hash time exceeds
+// FS_IO_TIMEOUT, yet every individual chunk lands well under it) must be hashed
+// to completion and verified by CONTENT, not silently downgraded to size-only.
+//
+// This pins verifyRemoteChecksum to the per-chunk-bounded backup.GenerateChecksumBounded.
+// The superseded whole-file safefs.Run(..., FS_IO_TIMEOUT) wrapper would abandon
+// this read at the 1s whole-file deadline and degrade to size-only, so the wrong
+// remote hash below would be wrongly accepted as (true, nil). With the per-chunk
+// budget the read finishes and the mismatch is caught: (false, "checksum mismatch").
+// Reverting cloud.go to the whole-file wrapper turns this test red.
+func TestVerifyRemoteChecksumHealthySlowReadIsContentVerified(t *testing.T) {
+	tmp := t.TempDir()
+	fifo := filepath.Join(tmp, "log.txt")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+
+	// A slow-but-alive producer: 15 chunks, 100ms apart => ~1.5s aggregate (well
+	// over the 1s FS_IO_TIMEOUT) while no single read waits anywhere near 1s. The
+	// total payload (<1 KiB) stays inside the pipe buffer, so the writer is paced
+	// solely by its own sleeps, never by the reader.
+	const chunks = 15
+	chunk := []byte("proxsave-healthy-slow-chunk\n")
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		w, err := os.OpenFile(fifo, os.O_WRONLY, 0) // rendezvous: unblocks once the reader opens the FIFO
+		if err != nil {
+			return
+		}
+		defer func() { _ = w.Close() }()
+		for i := 0; i < chunks; i++ {
+			time.Sleep(100 * time.Millisecond)
+			if _, werr := w.Write(chunk); werr != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-writerDone:
+		case <-time.After(5 * time.Second):
+			t.Error("slow FIFO writer did not finish")
+		}
+	})
+
+	cfg := &config.Config{CloudRemote: "remote", FsIoTimeoutSeconds: 1, RcloneTimeoutOperation: 30}
+	cs := newCloudStorageForTest(cfg)
+	// A valid-but-wrong remote SHA256: the streamed content hashes to something
+	// else, so a COMPLETED local hash must report a mismatch rather than a
+	// size-only "OK". (A whole-file deadline would never reach this comparison.)
+	q := &commandQueue{t: t, queue: []queuedResponse{
+		{name: "rclone", out: strings.Repeat("0", 64) + "  log.txt"},
+	}}
+	cs.execCommand = q.exec
+
+	start := time.Now()
+	ok, err := cs.verifyRemoteChecksum(context.Background(), fifo, "remote:logs/log.txt", "log.txt")
+	if d := time.Since(start); d < time.Second {
+		t.Fatalf("hash finished in %s; the slow producer must push it past the 1s FS_IO_TIMEOUT to exercise the per-chunk budget", d)
+	}
+	if ok || err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("want content-verified mismatch (false, \"checksum mismatch\"), got (%v, %v)", ok, err)
+	}
+}

--- a/internal/storage/cloud_timeout_test.go
+++ b/internal/storage/cloud_timeout_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/safefs"
+	"github.com/tis24dev/proxsave/internal/types"
 )
 
 // Item 1: UploadToRemotePath must bound a deadline-less ctx so a stalled rclone
@@ -89,6 +91,53 @@ func TestVerifyUploadLocalStatBounded(t *testing.T) {
 	}
 	if called {
 		t.Fatal("no rclone exec should run when the local stat is bounded out")
+	}
+}
+
+// Item 3b: Store's pre-upload local source stat is bounded by FS_IO_TIMEOUT, so a
+// dead/stale BACKUP_PATH mount cannot wedge Store before uploadCtx/rclone apply.
+// The source file EXISTS, so a reverted raw os.Stat would SUCCEED (the dead-mount
+// stub only intercepts safefs's stat) and let the upload run; the per-chunk fix
+// instead times the stat out and skips the upload. Reverting Store's os.Stat ->
+// safefs.Stat swap turns this red (it would proceed to rclone).
+func TestStoreLocalSourceStatBoundedAgainstDeadMount(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "node-backup.tar.zst")
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg := &config.Config{CloudEnabled: true, CloudRemote: "remote", FsIoTimeoutSeconds: 1, RcloneTimeoutOperation: 30}
+	cs := newCloudStorageForTest(cfg)
+	var uploaded bool
+	cs.execCommand = func(context.Context, string, ...string) ([]byte, error) {
+		uploaded = true
+		return nil, nil
+	}
+
+	// Simulate a dead/stale local mount: the source stat never returns. Installed
+	// last so test setup is unaffected; the abandoned worker is released on cleanup.
+	park := make(chan struct{})
+	t.Cleanup(func() { close(park) })
+	restore := safefs.SetOsStatForTest(func(string) (os.FileInfo, error) {
+		<-park
+		return nil, errors.New("released")
+	})
+	t.Cleanup(restore)
+
+	done := make(chan error, 1)
+	go func() { done <- cs.Store(context.Background(), src, &types.BackupMetadata{}) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Store must fail when the local source stat times out, not succeed")
+		}
+		if uploaded {
+			t.Fatal("no rclone upload may run after a source-stat timeout (a raw os.Stat would have let it through)")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Store hung on a dead-mount source stat: the local source stat is not bounded")
 	}
 }
 

--- a/internal/storage/cloud_timeout_test.go
+++ b/internal/storage/cloud_timeout_test.go
@@ -1,0 +1,125 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+)
+
+// Item 1: UploadToRemotePath must bound a deadline-less ctx so a stalled rclone
+// cannot hang shutdown.
+func TestUploadToRemotePathBoundsDeadlessCtx(t *testing.T) {
+	tmp := t.TempDir()
+	local := filepath.Join(tmp, "log.txt")
+	writeTestFile(t, local, "x")
+	cfg := &config.Config{CloudEnabled: true, CloudRemote: "remote", RcloneRetries: 1, RcloneTimeoutOperation: 1}
+	cs := newCloudStorageForTest(cfg)
+	cs.waitForRetry = func(context.Context, time.Duration) error { return nil }
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		<-ctx.Done() // a wedged copy that respects ctx; the WithTimeout must fire
+		return nil, ctx.Err()
+	}
+
+	start := time.Now()
+	err := cs.UploadToRemotePath(context.Background(), local, "remote:logs/log.txt", false)
+	if err == nil {
+		t.Fatal("expected a deadline error, got nil")
+	}
+	if d := time.Since(start); d > 5*time.Second {
+		t.Fatalf("UploadToRemotePath was not bounded: %s", d)
+	}
+}
+
+// Item 2: defaultExecCommand must set WaitDelay and return exec.ErrWaitDelay as an
+// ERROR (not swallow it to nil like osCommandRunner).
+func TestDefaultExecCommandWaitDelayReturnsError(t *testing.T) {
+	old := cloudExecWaitDelay
+	cloudExecWaitDelay = 100 * time.Millisecond
+	t.Cleanup(func() { cloudExecWaitDelay = old })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	// sh exits immediately; the backgrounded sleep inherits stdout and holds the
+	// pipe open, forcing CombinedOutput's Wait past WaitDelay -> ErrWaitDelay.
+	_, err := defaultExecCommand(ctx, "sh", "-c", "sleep 30 & exit 0")
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("want exec.ErrWaitDelay, got %v", err)
+	}
+	if d := time.Since(start); d > 5*time.Second {
+		t.Fatalf("WaitDelay did not bound the wait: %s", d)
+	}
+}
+
+func TestDefaultExecCommandHappyPath(t *testing.T) {
+	out, err := defaultExecCommand(context.Background(), "echo", "ok")
+	if err != nil || strings.TrimSpace(string(out)) != "ok" {
+		t.Fatalf("echo: out=%q err=%v", out, err)
+	}
+}
+
+// Item 3: VerifyUpload's local stat is bounded; a done ctx returns before any
+// rclone exec.
+func TestVerifyUploadLocalStatBounded(t *testing.T) {
+	tmp := t.TempDir()
+	local := filepath.Join(tmp, "log.txt")
+	writeTestFile(t, local, "x")
+	cfg := &config.Config{CloudRemote: "remote", FsIoTimeoutSeconds: 1}
+	cs := newCloudStorageForTest(cfg)
+	called := false
+	cs.execCommand = func(context.Context, string, ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already done -> safefs.Stat returns immediately
+
+	ok, err := cs.VerifyUpload(ctx, local, "remote:logs/log.txt")
+	if ok || err == nil {
+		t.Fatalf("want (false, err), got (%v, %v)", ok, err)
+	}
+	if called {
+		t.Fatal("no rclone exec should run when the local stat is bounded out")
+	}
+}
+
+// Item 4: a timed-out local hash (dead/stale mount) degrades to the size-only
+// verdict (true, nil), it must not hang or hard-fail a good upload.
+func TestVerifyRemoteChecksumLocalHashTimeoutDegrades(t *testing.T) {
+	tmp := t.TempDir()
+	fifo := filepath.Join(tmp, "log.txt")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+	t.Cleanup(func() {
+		// Unblock the abandoned GenerateChecksum os.Open(fifo) worker goroutine.
+		if w, e := os.OpenFile(fifo, os.O_WRONLY, 0); e == nil {
+			_ = w.Close()
+		}
+	})
+
+	cfg := &config.Config{CloudRemote: "remote", FsIoTimeoutSeconds: 1, RcloneTimeoutOperation: 30}
+	cs := newCloudStorageForTest(cfg)
+	q := &commandQueue{t: t, queue: []queuedResponse{
+		{name: "rclone", out: "0000000000000000000000000000000000000000000000000000000000000000  log.txt"},
+	}}
+	cs.execCommand = q.exec
+
+	start := time.Now()
+	ok, err := cs.verifyRemoteChecksum(context.Background(), fifo, "remote:logs/log.txt", "log.txt")
+	if !ok || err != nil {
+		t.Fatalf("want degrade to size-only (true, nil), got (%v, %v)", ok, err)
+	}
+	if d := time.Since(start); d > 5*time.Second {
+		t.Fatalf("local hash was not bounded: %s", d)
+	}
+}

--- a/internal/storage/cloud_timeout_test.go
+++ b/internal/storage/cloud_timeout_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/internal/types"
 )
@@ -158,6 +160,13 @@ func TestVerifyRemoteChecksumLocalHashTimeoutDegrades(t *testing.T) {
 
 	cfg := &config.Config{CloudRemote: "remote", FsIoTimeoutSeconds: 1, RcloneTimeoutOperation: 30}
 	cs := newCloudStorageForTest(cfg)
+	// Capture at Info level: a genuine stall must be surfaced at Warning (not the
+	// silent Debug used for a capability-limited backend). Info filters out Debug,
+	// so reverting the warning back to Debug leaves the buffer empty and fails this.
+	var buf bytes.Buffer
+	lg := logging.New(types.LogLevelInfo, false)
+	lg.SetOutput(&buf)
+	cs.logger = lg
 	q := &commandQueue{t: t, queue: []queuedResponse{
 		{name: "rclone", out: "0000000000000000000000000000000000000000000000000000000000000000  log.txt"},
 	}}
@@ -170,6 +179,9 @@ func TestVerifyRemoteChecksumLocalHashTimeoutDegrades(t *testing.T) {
 	}
 	if d := time.Since(start); d > 5*time.Second {
 		t.Fatalf("local hash was not bounded: %s", d)
+	}
+	if !strings.Contains(buf.String(), "stalled") || !strings.Contains(buf.String(), "full checksum NOT performed") {
+		t.Fatalf("a genuine local-hash stall must be surfaced at Warning, got log:\n%s", buf.String())
 	}
 }
 

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -247,15 +247,26 @@ func (d *FilesystemDetector) testOwnershipSupport(ctx context.Context, path stri
 	// syscall, so the whole sequence is bounded as a single unit; on timeout the
 	// worker goroutine is abandoned and we conservatively report "no ownership".
 	ok, err := safefs.Run(ctx, "ownership-probe", path, d.ioTimeout, func() (bool, error) {
-		testFile := filepath.Join(path, ".ownership_test_"+utils.GenerateRandomString(8))
+		// Confine every probe op to `path` via os.Root: the create-by-name carries
+		// no tainted absolute path, so this is structurally free of gosec G304 (file
+		// inclusion via a variable) without a #nosec, and the probe file can never
+		// escape the directory under test.
+		root, rerr := os.OpenRoot(path)
+		if rerr != nil {
+			d.logger.Debug("Cannot open root for ownership check: %v", rerr)
+			return false, nil
+		}
+		defer func() { _ = root.Close() }()
+
+		name := ".ownership_test_" + utils.GenerateRandomString(8)
 
 		// Create the test file
-		f, cerr := os.Create(testFile)
+		f, cerr := root.Create(name)
 		if cerr != nil {
 			d.logger.Debug("Cannot create test file for ownership check: %v", cerr)
 			return false, nil
 		}
-		defer func() { _ = os.Remove(testFile) }()
+		defer func() { _ = root.Remove(name) }()
 
 		if cerr := f.Close(); cerr != nil {
 			d.logger.Debug("Cannot close test file for ownership check: %v", cerr)
@@ -266,19 +277,19 @@ func (d *FilesystemDetector) testOwnershipSupport(ctx context.Context, path stri
 		uid := os.Getuid()
 		gid := os.Getgid()
 
-		if cerr := os.Chown(testFile, uid, gid); cerr != nil {
+		if cerr := root.Chown(name, uid, gid); cerr != nil {
 			d.logger.Debug("Chown test failed: %v", cerr)
 			return false, nil
 		}
 
 		// Try to change permissions
-		if cerr := os.Chmod(testFile, 0600); cerr != nil {
+		if cerr := root.Chmod(name, 0600); cerr != nil {
 			d.logger.Debug("Chmod test failed: %v", cerr)
 			return false, nil
 		}
 
 		// Verify the changes took effect
-		stat, serr := os.Stat(testFile)
+		stat, serr := root.Stat(name)
 		if serr != nil {
 			return false, nil
 		}

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -24,6 +24,11 @@ type FilesystemDetector struct {
 	// touch dead/stale network mounts should opt in via WithIOTimeout.
 	ioTimeout time.Duration
 
+	// dryRun, when true, suppresses the network-FS ownership write-probe
+	// (testOwnershipSupport creates/chowns/chmods a temp file). A dry run must not
+	// mutate the filesystem, so detection falls back to the type-based default.
+	dryRun bool
+
 	// Test hooks (nil in production).
 	mountPointLookup     func(path string) (string, error)
 	filesystemTypeLookup func(ctx context.Context, mountPoint string) (FilesystemType, string, error)
@@ -44,6 +49,15 @@ func WithIOTimeout(timeout time.Duration) DetectorOption {
 			timeout = 0
 		}
 		d.ioTimeout = timeout
+	}
+}
+
+// WithDryRun suppresses the detector's network-FS ownership write-probe so a dry
+// run performs no filesystem mutations; SupportsOwnership then falls back to the
+// filesystem type's default.
+func WithDryRun(dryRun bool) DetectorOption {
+	return func(d *FilesystemDetector) {
+		d.dryRun = dryRun
 	}
 }
 
@@ -103,18 +117,24 @@ func (d *FilesystemDetector) DetectFilesystem(ctx context.Context, path string) 
 	// Log the detected filesystem in real-time (live output)
 	d.logFilesystemInfo(info)
 
-	// Check if we need to test ownership support for network filesystems
+	// Check if we need to test ownership support for network filesystems. The
+	// probe writes a temp file, so it is skipped in dry-run (which must not mutate
+	// the filesystem); SupportsOwnership keeps the type-based default.
 	if info.IsNetworkFS {
-		testFn := d.testOwnershipSupport
-		if d.ownershipSupportTest != nil {
-			testFn = d.ownershipSupportTest
-		}
-		supportsOwnership := testFn(ctx, path)
-		info.SupportsOwnership = supportsOwnership
-		if supportsOwnership {
-			d.logger.Info("Network filesystem %s supports Unix ownership", fsType)
+		if d.dryRun {
+			d.logger.Debug("DRY RUN: skipping network-FS ownership write-probe for %s; assuming type default (%v)", path, info.SupportsOwnership)
 		} else {
-			d.logger.Info("Network filesystem %s does NOT support Unix ownership", fsType)
+			testFn := d.testOwnershipSupport
+			if d.ownershipSupportTest != nil {
+				testFn = d.ownershipSupportTest
+			}
+			supportsOwnership := testFn(ctx, path)
+			info.SupportsOwnership = supportsOwnership
+			if supportsOwnership {
+				d.logger.Info("Network filesystem %s supports Unix ownership", fsType)
+			} else {
+				d.logger.Info("Network filesystem %s does NOT support Unix ownership", fsType)
+			}
 		}
 	}
 

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
+	"time"
 
 	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/safefs"
 	"github.com/tis24dev/proxsave/pkg/utils"
 )
 
@@ -17,24 +18,52 @@ import (
 type FilesystemDetector struct {
 	logger *logging.Logger
 
+	// ioTimeout bounds each raw filesystem syscall the detector performs (the
+	// initial existence stat, the statfs on the mount point, and the network-FS
+	// ownership probe). Zero means unbounded (legacy behaviour); callers that may
+	// touch dead/stale network mounts should opt in via WithIOTimeout.
+	ioTimeout time.Duration
+
 	// Test hooks (nil in production).
 	mountPointLookup     func(path string) (string, error)
 	filesystemTypeLookup func(ctx context.Context, mountPoint string) (FilesystemType, string, error)
 	ownershipSupportTest func(ctx context.Context, path string) bool
 }
 
-// NewFilesystemDetector creates a new filesystem detector
-func NewFilesystemDetector(logger *logging.Logger) *FilesystemDetector {
-	return &FilesystemDetector{
+// DetectorOption configures a FilesystemDetector at construction time.
+type DetectorOption func(*FilesystemDetector)
+
+// WithIOTimeout bounds every blocking filesystem syscall the detector performs
+// with the supplied per-operation timeout. A non-positive value keeps the legacy
+// unbounded behaviour. Use it on user-configured storage paths that may be
+// dead/stale network mounts, where a raw syscall would otherwise block forever
+// in uninterruptible (D) state.
+func WithIOTimeout(timeout time.Duration) DetectorOption {
+	return func(d *FilesystemDetector) {
+		if timeout < 0 {
+			timeout = 0
+		}
+		d.ioTimeout = timeout
+	}
+}
+
+// NewFilesystemDetector creates a new filesystem detector. With no options the
+// detector is unbounded (legacy behaviour); pass WithIOTimeout to bound syscalls.
+func NewFilesystemDetector(logger *logging.Logger, opts ...DetectorOption) *FilesystemDetector {
+	d := &FilesystemDetector{
 		logger: logger,
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
 }
 
 // DetectFilesystem detects the filesystem type for a given path
 // This function logs the detected filesystem type in real-time
 func (d *FilesystemDetector) DetectFilesystem(ctx context.Context, path string) (*FilesystemInfo, error) {
-	// Ensure path exists
-	if _, err := os.Stat(path); err != nil {
+	// Ensure path exists. Bounded so a dead/stale mount does not wedge here.
+	if _, err := safefs.Stat(ctx, path, d.ioTimeout); err != nil {
 		return nil, fmt.Errorf("path does not exist: %s: %w", path, err)
 	}
 
@@ -160,9 +189,9 @@ func (d *FilesystemDetector) getMountPoint(path string) (string, error) {
 
 // getFilesystemType gets the filesystem type for a mount point using df
 func (d *FilesystemDetector) getFilesystemType(ctx context.Context, mountPoint string) (FilesystemType, string, error) {
-	// Use stat syscall to get filesystem information
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(mountPoint, &stat); err != nil {
+	// Use statfs to confirm the mount point is reachable. Bounded so a dead/stale
+	// mount does not wedge here in an uninterruptible syscall.
+	if _, err := safefs.Statfs(ctx, mountPoint, d.ioTimeout); err != nil {
 		return FilesystemUnknown, "", err
 	}
 
@@ -193,50 +222,60 @@ func (d *FilesystemDetector) getFilesystemType(ctx context.Context, mountPoint s
 // testOwnershipSupport tests if a filesystem actually supports Unix ownership
 // This is necessary for network filesystems (NFS/CIFS) which may or may not support it
 func (d *FilesystemDetector) testOwnershipSupport(ctx context.Context, path string) bool {
-	// Create a temporary test file
-	testFile := filepath.Join(path, ".ownership_test_"+utils.GenerateRandomString(8))
+	// The probe creates a temp file and exercises chown/chmod/stat on it. On a
+	// dead/stale network mount any of these can block in an uninterruptible
+	// syscall, so the whole sequence is bounded as a single unit; on timeout the
+	// worker goroutine is abandoned and we conservatively report "no ownership".
+	ok, err := safefs.Run(ctx, "ownership-probe", path, d.ioTimeout, func() (bool, error) {
+		testFile := filepath.Join(path, ".ownership_test_"+utils.GenerateRandomString(8))
 
-	// Create the test file
-	f, err := os.Create(testFile)
+		// Create the test file
+		f, cerr := os.Create(testFile)
+		if cerr != nil {
+			d.logger.Debug("Cannot create test file for ownership check: %v", cerr)
+			return false, nil
+		}
+		defer func() { _ = os.Remove(testFile) }()
+
+		if cerr := f.Close(); cerr != nil {
+			d.logger.Debug("Cannot close test file for ownership check: %v", cerr)
+			return false, nil
+		}
+
+		// Try to change ownership to current user (should be safe)
+		uid := os.Getuid()
+		gid := os.Getgid()
+
+		if cerr := os.Chown(testFile, uid, gid); cerr != nil {
+			d.logger.Debug("Chown test failed: %v", cerr)
+			return false, nil
+		}
+
+		// Try to change permissions
+		if cerr := os.Chmod(testFile, 0600); cerr != nil {
+			d.logger.Debug("Chmod test failed: %v", cerr)
+			return false, nil
+		}
+
+		// Verify the changes took effect
+		stat, serr := os.Stat(testFile)
+		if serr != nil {
+			return false, nil
+		}
+
+		// Check if permissions were actually set
+		if stat.Mode().Perm() != 0600 {
+			d.logger.Debug("Permissions not set correctly: expected 0600, got %o", stat.Mode().Perm())
+			return false, nil
+		}
+
+		return true, nil
+	})
 	if err != nil {
-		d.logger.Debug("Cannot create test file for ownership check: %v", err)
+		d.logger.Debug("Ownership probe on %s did not complete: %v", path, err)
 		return false
 	}
-	defer func() { _ = os.Remove(testFile) }()
-
-	if err := f.Close(); err != nil {
-		d.logger.Debug("Cannot close test file for ownership check: %v", err)
-		return false
-	}
-
-	// Try to change ownership to current user (should be safe)
-	uid := os.Getuid()
-	gid := os.Getgid()
-
-	if err := os.Chown(testFile, uid, gid); err != nil {
-		d.logger.Debug("Chown test failed: %v", err)
-		return false
-	}
-
-	// Try to change permissions
-	if err := os.Chmod(testFile, 0600); err != nil {
-		d.logger.Debug("Chmod test failed: %v", err)
-		return false
-	}
-
-	// Verify the changes took effect
-	stat, err := os.Stat(testFile)
-	if err != nil {
-		return false
-	}
-
-	// Check if permissions were actually set
-	if stat.Mode().Perm() != 0600 {
-		d.logger.Debug("Permissions not set correctly: expected 0600, got %o", stat.Mode().Perm())
-		return false
-	}
-
-	return true
+	return ok
 }
 
 // parseFilesystemType converts a filesystem type string to FilesystemType

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -386,8 +386,10 @@ func (d *FilesystemDetector) SetPermissions(ctx context.Context, path string, ui
 		return nil
 	}
 
-	// Try to set ownership
-	if err := os.Chown(path, uid, gid); err != nil {
+	// Try to set ownership (bounded against a dead/stale mount).
+	if _, err := safefs.Run(ctx, "setperm-chown", path, d.ioTimeout, func() (struct{}, error) {
+		return struct{}{}, os.Chown(path, uid, gid)
+	}); err != nil {
 		// On compatible filesystem, this is a warning (not an error)
 		if fsInfo != nil && !fsInfo.Type.ShouldAutoExclude() {
 			d.logger.Warning("Failed to set ownership for %s (filesystem %s): %v", path, fsInfo.Type, err)
@@ -395,8 +397,8 @@ func (d *FilesystemDetector) SetPermissions(ctx context.Context, path string, ui
 		// Don't return error - continue with chmod
 	}
 
-	// Try to set permissions
-	if err := os.Chmod(path, mode); err != nil {
+	// Try to set permissions (bounded against a dead/stale mount).
+	if err := safefs.Chmod(ctx, path, mode, d.ioTimeout); err != nil {
 		// On compatible filesystem, this is a warning (not an error)
 		if fsInfo != nil && !fsInfo.Type.ShouldAutoExclude() {
 			d.logger.Warning("Failed to set permissions for %s (filesystem %s): %v", path, fsInfo.Type, err)

--- a/internal/storage/filesystem_timeout_test.go
+++ b/internal/storage/filesystem_timeout_test.go
@@ -22,3 +22,30 @@ func TestDetectFilesystemTimeout(t *testing.T) {
 		t.Fatalf("DetectFilesystem err = %v; want safefs.ErrTimeout", err)
 	}
 }
+
+// TestDetectFilesystemDryRunSkipsOwnershipProbe verifies that a dry-run detector
+// does not run the network-FS ownership write-probe (which mutates the FS).
+func TestDetectFilesystemDryRunSkipsOwnershipProbe(t *testing.T) {
+	detector := NewFilesystemDetector(newTestLogger(), WithDryRun(true))
+	dir := t.TempDir()
+	detector.mountPointLookup = func(string) (string, error) { return "/mnt", nil }
+	detector.filesystemTypeLookup = func(context.Context, string) (FilesystemType, string, error) {
+		return FilesystemNFS, "server:/export", nil
+	}
+	probed := false
+	detector.ownershipSupportTest = func(context.Context, string) bool {
+		probed = true
+		return false
+	}
+
+	info, err := detector.DetectFilesystem(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("DetectFilesystem error: %v", err)
+	}
+	if probed {
+		t.Fatal("dry-run must not run the ownership write-probe")
+	}
+	if info.SupportsOwnership != FilesystemNFS.SupportsUnixOwnership() {
+		t.Fatalf("SupportsOwnership = %v; want type default %v", info.SupportsOwnership, FilesystemNFS.SupportsUnixOwnership())
+	}
+}

--- a/internal/storage/filesystem_timeout_test.go
+++ b/internal/storage/filesystem_timeout_test.go
@@ -1,0 +1,24 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/safefs"
+)
+
+// TestDetectFilesystemTimeout verifies that a detector built WithIOTimeout maps a
+// blocking/expired filesystem operation to safefs.ErrTimeout instead of hanging.
+func TestDetectFilesystemTimeout(t *testing.T) {
+	detector := NewFilesystemDetector(newTestLogger(), WithIOTimeout(30*time.Second))
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+
+	_, err := detector.DetectFilesystem(ctx, t.TempDir())
+	if err == nil || !errors.Is(err, safefs.ErrTimeout) {
+		t.Fatalf("DetectFilesystem err = %v; want safefs.ErrTimeout", err)
+	}
+}

--- a/internal/storage/fsbound.go
+++ b/internal/storage/fsbound.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+)
+
+// fsIoTimeout converts the configured FS_IO_TIMEOUT into a per-operation safefs
+// budget shared by the storage backends. A non-positive value (the explicit
+// FS_IO_TIMEOUT=0 opt-out, or an unset cfg) yields 0, which safefs treats as
+// unbounded (legacy behaviour). It bounds individual filesystem syscalls on
+// user-configured mount paths (BACKUP_PATH / SECONDARY_PATH / cloud local source)
+// so a dead/stale mount cannot wedge the run in an uninterruptible (D) syscall.
+func fsIoTimeout(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.FsIoTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.FsIoTimeoutSeconds) * time.Second
+}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/backup"
@@ -37,7 +36,7 @@ func NewLocalStorage(cfg *config.Config, logger *logging.Logger) (*LocalStorage,
 		config:     cfg,
 		logger:     logger,
 		basePath:   cfg.BackupPath,
-		fsDetector: NewFilesystemDetector(logger),
+		fsDetector: NewFilesystemDetector(logger, WithIOTimeout(fsIoTimeout(cfg))),
 	}, nil
 }
 
@@ -65,8 +64,8 @@ func (l *LocalStorage) IsCritical() bool {
 func (l *LocalStorage) DetectFilesystem(ctx context.Context) (info *FilesystemInfo, err error) {
 	done := logging.DebugStart(l.logger, "local detect filesystem", "path=%s", l.basePath)
 	defer func() { done(err) }()
-	// Ensure directory exists
-	if err := os.MkdirAll(l.basePath, 0700); err != nil {
+	// Ensure directory exists (bounded: basePath may be a dead/stale mount).
+	if err := safefs.MkdirAll(ctx, l.basePath, 0700, fsIoTimeout(l.config)); err != nil {
 		return nil, &StorageError{
 			Location:   LocationPrimary,
 			Operation:  "detect_filesystem",
@@ -103,8 +102,8 @@ func (l *LocalStorage) Store(ctx context.Context, backupFile string, metadata *t
 		return err
 	}
 
-	// Verify file exists
-	if _, err := os.Stat(backupFile); err != nil {
+	// Verify file exists (bounded against a dead/stale mount).
+	if _, err := safefs.Stat(ctx, backupFile, fsIoTimeout(l.config)); err != nil {
 		l.logger.Debug("Local storage: source file %s not found", backupFile)
 		return &StorageError{
 			Location:   LocationPrimary,
@@ -156,10 +155,13 @@ func (l *LocalStorage) List(ctx context.Context) (backups []*types.BackupMetadat
 		filepath.Join(l.basePath, "*-backup-*.tar*"),        // Go pipeline naming (+ bundle)
 	}
 
+	timeout := fsIoTimeout(l.config)
 	var matches []string
 	seen := make(map[string]struct{})
 	for _, pattern := range globPatterns {
-		patternMatches, err := filepath.Glob(pattern)
+		patternMatches, err := safefs.Run(ctx, "local-glob", l.basePath, timeout, func() ([]string, error) {
+			return filepath.Glob(pattern)
+		})
 		if err != nil {
 			return nil, &StorageError{
 				Location:   LocationPrimary,
@@ -193,7 +195,7 @@ func (l *LocalStorage) List(ctx context.Context) (backups []*types.BackupMetadat
 			if !strings.HasSuffix(match, ".bundle.tar") {
 				// This is a standalone file, check if bundle exists
 				bundlePath := match + ".bundle.tar"
-				if _, err := os.Stat(bundlePath); err == nil {
+				if _, err := safefs.Stat(ctx, bundlePath, timeout); err == nil {
 					// Bundle exists, skip the standalone file
 					l.logger.Debug("Skipping standalone file %s (bundle exists at %s)",
 						filepath.Base(match), filepath.Base(bundlePath))
@@ -206,14 +208,14 @@ func (l *LocalStorage) List(ctx context.Context) (backups []*types.BackupMetadat
 			match, l.config != nil && l.config.BundleAssociatedFiles)
 
 		// Parse metadata if available
-		metadata, err := l.loadMetadata(match)
+		metadata, err := l.loadMetadata(ctx, match)
 		if err != nil {
 			l.logger.Warning("Missing .metadata for %s - using filename metadata", filepath.Base(match))
 			// Create minimal metadata from filename
 			metadata = &types.BackupMetadata{
 				BackupFile: match,
 			}
-			if stat, statErr := os.Stat(match); statErr == nil {
+			if stat, statErr := safefs.Stat(ctx, match, timeout); statErr == nil {
 				metadata.Timestamp = stat.ModTime()
 				metadata.Size = stat.Size()
 			} else {
@@ -233,25 +235,32 @@ func (l *LocalStorage) List(ctx context.Context) (backups []*types.BackupMetadat
 }
 
 // loadMetadata loads metadata for a backup file
-func (l *LocalStorage) loadMetadata(backupFile string) (*types.BackupMetadata, error) {
+func (l *LocalStorage) loadMetadata(ctx context.Context, backupFile string) (*types.BackupMetadata, error) {
 	isBundle := strings.HasSuffix(backupFile, ".bundle.tar")
 	l.logger.Debug("Local storage: loadMetadata for %s (isBundle=%v)", backupFile, isBundle)
 
-	// If file IS a bundle → read metadata from INSIDE the bundle
+	timeout := fsIoTimeout(l.config)
+
+	// If file IS a bundle → read metadata from INSIDE the bundle. Bounded as a unit
+	// so a dead/stale mount cannot wedge the open or the bundle (tar) read.
 	if isBundle {
 		l.logger.Debug("Local storage: reading metadata from inside bundle %s", backupFile)
-		return l.loadMetadataFromBundle(backupFile)
+		return safefs.Run(ctx, "local-bundle-meta", backupFile, timeout, func() (*types.BackupMetadata, error) {
+			return l.loadMetadataFromBundle(backupFile)
+		})
 	}
 
 	// If file is NOT a bundle → read metadata from OUTSIDE (sidecar .metadata file)
 	metadataFile := backupFile + ".metadata"
 	l.logger.Debug("Local storage: looking for sidecar metadata %s", metadataFile)
-	if _, err := os.Stat(metadataFile); err != nil {
+	if _, err := safefs.Stat(ctx, metadataFile, timeout); err != nil {
 		l.logger.Debug("Local storage: sidecar metadata %s missing/inaccessible: %v", metadataFile, err)
 		return nil, err
 	}
 
-	manifest, err := backup.LoadManifest(metadataFile)
+	manifest, err := safefs.Run(ctx, "local-loadmanifest", metadataFile, timeout, func() (*backup.Manifest, error) {
+		return backup.LoadManifest(metadataFile)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +276,7 @@ func (l *LocalStorage) loadMetadata(backupFile string) (*types.BackupMetadata, e
 	}
 
 	if metadata.Timestamp.IsZero() || metadata.Size == 0 {
-		if stat, statErr := os.Stat(backupFile); statErr == nil {
+		if stat, statErr := safefs.Stat(ctx, backupFile, timeout); statErr == nil {
 			if metadata.Timestamp.IsZero() {
 				metadata.Timestamp = stat.ModTime()
 			}
@@ -360,6 +369,7 @@ func (l *LocalStorage) deleteBackupInternal(ctx context.Context, backupFile stri
 	// track whether the data archive itself (not just a sidecar) failed, so the
 	// caller never counts a backup whose archive remains on disk as deleted
 	// (PS-BH-001), while a sidecar-only failure still counts (the archive IS gone).
+	timeout := fsIoTimeout(l.config)
 	var failedFiles []string
 	dataFailed := false
 	for _, f := range filesToDelete {
@@ -367,7 +377,7 @@ func (l *LocalStorage) deleteBackupInternal(ctx context.Context, backupFile stri
 			continue
 		}
 		l.logger.Debug("Local storage: removing file %s", f)
-		if err := os.Remove(f); err != nil {
+		if err := safefs.Remove(ctx, f, timeout); err != nil {
 			if os.IsNotExist(err) {
 				l.logger.Debug("Local storage: file already removed %s", f)
 				continue
@@ -684,9 +694,8 @@ func (l *LocalStorage) GetStats(ctx context.Context) (stats *StorageStats, err e
 	stats.OldestBackup = oldest
 	stats.NewestBackup = newest
 
-	// Get available/total space using statfs
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(l.basePath, &stat); err == nil {
+	// Get available/total space using statfs (bounded against a dead/stale mount).
+	if stat, err := safefs.Statfs(ctx, l.basePath, fsIoTimeout(l.config)); err == nil {
 		total, available, used := safefs.SpaceUsageFromStatfs(stat)
 		stats.AvailableSpace = available
 		stats.TotalSpace = total

--- a/internal/storage/secondary.go
+++ b/internal/storage/secondary.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
@@ -37,7 +36,7 @@ func NewSecondaryStorage(cfg *config.Config, logger *logging.Logger) (*Secondary
 		config:     cfg,
 		logger:     logger,
 		basePath:   cfg.SecondaryPath,
-		fsDetector: NewFilesystemDetector(logger),
+		fsDetector: NewFilesystemDetector(logger, WithIOTimeout(fsIoTimeout(cfg))),
 	}, nil
 }
 
@@ -66,8 +65,8 @@ func (s *SecondaryStorage) IsCritical() bool {
 func (s *SecondaryStorage) DetectFilesystem(ctx context.Context) (info *FilesystemInfo, err error) {
 	done := logging.DebugStart(s.logger, "secondary detect filesystem", "path=%s", s.basePath)
 	defer func() { done(err) }()
-	// Ensure directory exists
-	if err := os.MkdirAll(s.basePath, 0700); err != nil {
+	// Ensure directory exists (bounded: secondary is typically an NFS/CIFS mount).
+	if err := safefs.MkdirAll(ctx, s.basePath, 0700, fsIoTimeout(s.config)); err != nil {
 		// Non-critical error - log warning and return
 		s.logger.Warning("WARNING: Cannot create secondary backup directory %s: %v", s.basePath, err)
 		s.logger.Warning("WARNING: Secondary backup will be skipped")
@@ -115,8 +114,8 @@ func (s *SecondaryStorage) Store(ctx context.Context, backupFile string, metadat
 		sourceFile = bundlePathFor(sourceFile)
 	}
 
-	// Verify source file exists
-	if _, err := os.Stat(sourceFile); err != nil {
+	// Verify source file exists (bounded against a dead/stale mount).
+	if _, err := safefs.Stat(ctx, sourceFile, fsIoTimeout(s.config)); err != nil {
 		s.logger.Debug("Secondary storage: source file %s not found", sourceFile)
 		s.logger.Warning("WARNING: Secondary storage - backup file not found: %s: %v", sourceFile, err)
 		return &StorageError{
@@ -129,8 +128,8 @@ func (s *SecondaryStorage) Store(ctx context.Context, backupFile string, metadat
 		}
 	}
 
-	// Ensure destination directory exists
-	if err := os.MkdirAll(s.basePath, 0700); err != nil {
+	// Ensure destination directory exists (bounded against a dead/stale mount).
+	if err := safefs.MkdirAll(ctx, s.basePath, 0700, fsIoTimeout(s.config)); err != nil {
 		s.logger.Debug("Secondary storage: failed to create destination folder %s", s.basePath)
 		s.logger.Warning("WARNING: Secondary storage - failed to create destination directory %s: %v", s.basePath, err)
 		return &StorageError{
@@ -172,7 +171,7 @@ func (s *SecondaryStorage) Store(ctx context.Context, backupFile string, metadat
 		failedAssoc := make([]string, 0)
 
 		for _, srcFile := range associatedFiles {
-			if _, err := os.Stat(srcFile); err != nil {
+			if _, err := safefs.Stat(ctx, srcFile, fsIoTimeout(s.config)); err != nil {
 				continue // Skip if doesn't exist
 			}
 
@@ -227,41 +226,50 @@ func (s *SecondaryStorage) copyFile(ctx context.Context, src, dest string) (err 
 		return err
 	}
 
-	sourceInfo, err := os.Stat(src)
+	// Bound the leaf metadata/open/finalize syscalls so a dead/stale secondary mount
+	// cannot wedge them. (The byte-transfer loop below is bounded separately in a
+	// follow-up; today it keeps its per-iteration ctx check.)
+	to := fsIoTimeout(s.config)
+
+	sourceInfo, err := safefs.Stat(ctx, src, to)
 	if err != nil {
 		return fmt.Errorf("failed to stat source file %s: %w", src, err)
 	}
 
 	destDir := filepath.Dir(dest)
-	if err := os.MkdirAll(destDir, 0700); err != nil {
+	if err := safefs.MkdirAll(ctx, destDir, 0700, to); err != nil {
 		return fmt.Errorf("failed to create destination directory %s: %w", destDir, err)
 	}
 
-	tempFile, err := os.CreateTemp(destDir, fmt.Sprintf(".tmp-%s-", filepath.Base(dest)))
+	tempFile, err := safefs.CreateTemp(ctx, destDir, fmt.Sprintf(".tmp-%s-", filepath.Base(dest)), to)
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file in %s: %w", destDir, err)
 	}
 	tempName := tempFile.Name()
 	defer func() {
 		if tempFile != nil {
-			if closeErr := tempFile.Close(); closeErr != nil && err == nil {
+			if _, closeErr := safefs.Run(ctx, "secondary-close-temp", tempName, to, func() (struct{}, error) {
+				return struct{}{}, tempFile.Close()
+			}); closeErr != nil && err == nil {
 				err = fmt.Errorf("failed to close temporary file %s: %w", tempName, closeErr)
 			}
 		}
 		if tempName != "" {
-			if removeErr := os.Remove(tempName); removeErr != nil && err == nil && !os.IsNotExist(removeErr) {
+			if removeErr := safefs.Remove(ctx, tempName, to); removeErr != nil && err == nil && !os.IsNotExist(removeErr) {
 				err = fmt.Errorf("failed to remove temporary file %s: %w", tempName, removeErr)
 			}
 		}
 	}()
 
 	start := time.Now()
-	sourceFile, err := os.Open(src)
+	sourceFile, err := safefs.Open(ctx, src, to)
 	if err != nil {
 		return fmt.Errorf("failed to open source file %s: %w", src, err)
 	}
 	defer func() {
-		if closeErr := sourceFile.Close(); closeErr != nil && err == nil {
+		if _, closeErr := safefs.Run(ctx, "secondary-close-src", src, to, func() (struct{}, error) {
+			return struct{}{}, sourceFile.Close()
+		}); closeErr != nil && err == nil {
 			err = fmt.Errorf("failed to close source file %s: %w", src, closeErr)
 		}
 	}()
@@ -290,23 +298,29 @@ func (s *SecondaryStorage) copyFile(ctx context.Context, src, dest string) (err 
 		}
 	}
 
-	if err := tempFile.Sync(); err != nil {
+	if _, err := safefs.Run(ctx, "secondary-sync-temp", tempName, to, func() (struct{}, error) {
+		return struct{}{}, tempFile.Sync()
+	}); err != nil {
 		return fmt.Errorf("failed to sync temporary file %s: %w", tempName, err)
 	}
-	closeErr := tempFile.Close()
+	_, closeErr := safefs.Run(ctx, "secondary-close-temp", tempName, to, func() (struct{}, error) {
+		return struct{}{}, tempFile.Close()
+	})
 	tempFile = nil
 	if closeErr != nil {
 		return fmt.Errorf("failed to close temporary file %s: %w", tempName, closeErr)
 	}
 
-	if err := os.Chmod(tempName, sourceInfo.Mode()); err != nil {
+	if err := safefs.Chmod(ctx, tempName, sourceInfo.Mode(), to); err != nil {
 		s.logger.Debug("Secondary storage: unable to mirror permissions on %s: %v", tempName, err)
 	}
-	if err := os.Chtimes(tempName, sourceInfo.ModTime(), sourceInfo.ModTime()); err != nil {
+	if _, err := safefs.Run(ctx, "secondary-chtimes", tempName, to, func() (struct{}, error) {
+		return struct{}{}, os.Chtimes(tempName, sourceInfo.ModTime(), sourceInfo.ModTime())
+	}); err != nil {
 		s.logger.Debug("Secondary storage: unable to mirror timestamps on %s: %v", tempName, err)
 	}
 
-	if err := os.Rename(tempName, dest); err != nil {
+	if err := safefs.Rename(ctx, tempName, dest, to); err != nil {
 		return fmt.Errorf("failed to finalize copy to %s: %w", dest, err)
 	}
 	tempName = ""
@@ -340,10 +354,13 @@ func (s *SecondaryStorage) List(ctx context.Context) (backups []*types.BackupMet
 		filepath.Join(s.basePath, "*-backup-*.tar*"),        // Go pipeline naming (bundle included)
 	}
 
+	timeout := fsIoTimeout(s.config)
 	var matches []string
 	seen := make(map[string]struct{})
 	for _, pattern := range globPatterns {
-		patternMatches, err := filepath.Glob(pattern)
+		patternMatches, err := safefs.Run(ctx, "secondary-glob", s.basePath, timeout, func() ([]string, error) {
+			return filepath.Glob(pattern)
+		})
 		if err != nil {
 			s.logger.Warning("WARNING: Secondary storage - failed to list backups: %v", err)
 			return nil, &StorageError{
@@ -379,7 +396,7 @@ func (s *SecondaryStorage) List(ctx context.Context) (backups []*types.BackupMet
 			if !strings.HasSuffix(match, ".bundle.tar") {
 				// This is a standalone file, check if bundle exists
 				bundlePath := match + ".bundle.tar"
-				if _, err := os.Stat(bundlePath); err == nil {
+				if _, err := safefs.Stat(ctx, bundlePath, timeout); err == nil {
 					// Bundle exists, skip the standalone file
 					s.logger.Debug("Skipping standalone file %s (bundle exists at %s)",
 						filepath.Base(match), filepath.Base(bundlePath))
@@ -388,8 +405,8 @@ func (s *SecondaryStorage) List(ctx context.Context) (backups []*types.BackupMet
 			}
 		}
 
-		// Get file info
-		stat, err := os.Stat(match)
+		// Get file info (bounded against a dead/stale mount).
+		stat, err := safefs.Stat(ctx, match, timeout)
 		if err != nil {
 			continue
 		}
@@ -431,6 +448,7 @@ func (s *SecondaryStorage) deleteBackupInternal(ctx context.Context, backupFile 
 	// track whether the data archive itself (not just a sidecar) failed, so the
 	// caller never counts a backup whose archive remains on disk as deleted
 	// (PS-BH-001), while a sidecar-only failure still counts (the archive IS gone).
+	timeout := fsIoTimeout(s.config)
 	var failedFiles []string
 	dataFailed := false
 	for _, f := range filesToDelete {
@@ -438,7 +456,7 @@ func (s *SecondaryStorage) deleteBackupInternal(ctx context.Context, backupFile 
 			continue
 		}
 		s.logger.Debug("Removing file: %s", f)
-		if err := os.Remove(f); err != nil {
+		if err := safefs.Remove(ctx, f, timeout); err != nil {
 			if os.IsNotExist(err) {
 				s.logger.Debug("Secondary storage: file already removed %s", f)
 				continue
@@ -757,9 +775,8 @@ func (s *SecondaryStorage) GetStats(ctx context.Context) (stats *StorageStats, e
 	stats.OldestBackup = oldest
 	stats.NewestBackup = newest
 
-	// Get available/total space using statfs
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(s.basePath, &stat); err == nil {
+	// Get available/total space using statfs (bounded against a dead/stale mount).
+	if stat, err := safefs.Statfs(ctx, s.basePath, fsIoTimeout(s.config)); err == nil {
 		total, available, used := safefs.SpaceUsageFromStatfs(stat)
 		stats.AvailableSpace = available
 		stats.TotalSpace = total

--- a/internal/storage/secondary.go
+++ b/internal/storage/secondary.go
@@ -219,6 +219,12 @@ func (s *SecondaryStorage) countBackups(ctx context.Context) int {
 	return len(backups)
 }
 
+// secondaryCloseSourceFile closes the read source after a copy. It is a seam so
+// a test can prove that a close failure on the success path (after the
+// destination has been durably renamed) is treated as best-effort read-side
+// cleanup and never turns a committed copy into a reported failure.
+var secondaryCloseSourceFile = func(f *os.File) error { return f.Close() }
+
 // copyFile copies a file using Go's io.Copy
 func (s *SecondaryStorage) copyFile(ctx context.Context, src, dest string) (err error) {
 	if err := ctx.Err(); err != nil {
@@ -269,10 +275,16 @@ func (s *SecondaryStorage) copyFile(ctx context.Context, src, dest string) (err 
 		if sourceFile == nil { // abandoned copy worker may still hold this fd
 			return
 		}
+		// Best-effort read-side cleanup: on the success path the destination has
+		// already been durably renamed into place before this runs, so a failed or
+		// timed-out close of the read-only source must NOT turn a committed copy
+		// into a reported failure (that would drive misleading retries / duplicate
+		// backups). On the error paths err is already set, so this never masks a
+		// pre-commit failure either.
 		if _, closeErr := safefs.Run(ctx, "secondary-close-src", src, to, func() (struct{}, error) {
-			return struct{}{}, sourceFile.Close()
-		}); closeErr != nil && err == nil {
-			err = fmt.Errorf("failed to close source file %s: %w", src, closeErr)
+			return struct{}{}, secondaryCloseSourceFile(sourceFile)
+		}); closeErr != nil {
+			s.logger.Debug("Secondary storage: failed to close source file %s: %v", src, closeErr)
 		}
 	}()
 

--- a/internal/storage/secondary.go
+++ b/internal/storage/secondary.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -226,9 +225,9 @@ func (s *SecondaryStorage) copyFile(ctx context.Context, src, dest string) (err 
 		return err
 	}
 
-	// Bound the leaf metadata/open/finalize syscalls so a dead/stale secondary mount
-	// cannot wedge them. (The byte-transfer loop below is bounded separately in a
-	// follow-up; today it keeps its per-iteration ctx check.)
+	// Bound the leaf metadata/open/finalize syscalls AND the byte-transfer loop
+	// (via safefs.CopyBounded below) so a dead/stale secondary mount cannot wedge
+	// any of them in an uninterruptible syscall.
 	to := fsIoTimeout(s.config)
 
 	sourceInfo, err := safefs.Stat(ctx, src, to)
@@ -267,6 +266,9 @@ func (s *SecondaryStorage) copyFile(ctx context.Context, src, dest string) (err 
 		return fmt.Errorf("failed to open source file %s: %w", src, err)
 	}
 	defer func() {
+		if sourceFile == nil { // abandoned copy worker may still hold this fd
+			return
+		}
 		if _, closeErr := safefs.Run(ctx, "secondary-close-src", src, to, func() (struct{}, error) {
 			return struct{}{}, sourceFile.Close()
 		}); closeErr != nil && err == nil {
@@ -274,28 +276,19 @@ func (s *SecondaryStorage) copyFile(ctx context.Context, src, dest string) (err 
 		}
 	}()
 
-	buf := make([]byte, 1024*1024) // 1MB buffer
-	var written int64
-
-	for {
-		if err := ctx.Err(); err != nil {
-			return err
+	// Stream the bytes under a per-chunk stall budget so a mount dying mid-copy
+	// cannot wedge Read/Write in an uninterruptible (D-state) syscall. The copy
+	// bypasses the shared safefs limiter (it is sequential, so it self-throttles
+	// to one in-flight worker and must not erode the slot budget the critical
+	// paths rely on). On a stalled chunk the worker is abandoned and may still
+	// hold these handles, so on abandonment we drop them and skip the closes.
+	written, copyErr := safefs.CopyBounded(ctx, tempFile, sourceFile, 1024*1024, to, "secondary-copy", src)
+	if copyErr != nil {
+		if safefs.IsAbandoned(copyErr) {
+			tempFile = nil
+			sourceFile = nil
 		}
-
-		nr, er := sourceFile.Read(buf)
-		if nr > 0 {
-			if _, ew := tempFile.Write(buf[:nr]); ew != nil {
-				return fmt.Errorf("write error during copy: %w", ew)
-			}
-			written += int64(nr)
-		}
-
-		if er != nil {
-			if er == io.EOF {
-				break
-			}
-			return fmt.Errorf("read error during copy: %w", er)
-		}
+		return fmt.Errorf("stream copy %s -> %s: %w", src, dest, copyErr)
 	}
 
 	if _, err := safefs.Run(ctx, "secondary-sync-temp", tempName, to, func() (struct{}, error) {

--- a/internal/storage/secondary_test.go
+++ b/internal/storage/secondary_test.go
@@ -410,6 +410,45 @@ func TestSecondaryStorage_Store_NilConfigTreatsSourceAsUnbundled(t *testing.T) {
 	}
 }
 
+// A source-close failure on the SUCCESS path (after the destination has been
+// durably renamed) must not turn a committed copy into a reported failure:
+// Store would otherwise retry and create duplicate backups. This pins the
+// best-effort close. Reverting to the old "err = close error when err == nil"
+// turns it red (copyFile would return the synthetic close error even though the
+// destination is fully written).
+func TestSecondaryStorage_CopyFile_SourceCloseErrorAfterCommitStillSucceeds(t *testing.T) {
+	prev := secondaryCloseSourceFile
+	secondaryCloseSourceFile = func(f *os.File) error {
+		_ = f.Close() // release the real fd, then report a close failure (e.g. a dying read mount)
+		return errors.New("simulated source close failure")
+	}
+	t.Cleanup(func() { secondaryCloseSourceFile = prev })
+
+	logger := logging.New(types.LogLevelInfo, false)
+	cfg := &config.Config{SecondaryEnabled: true, FsIoTimeoutSeconds: 30}
+	s := &SecondaryStorage{config: cfg, logger: logger}
+
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "node-backup.tar.zst")
+	const content = "secondary-durable-payload"
+	if err := os.WriteFile(src, []byte(content), 0o640); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	dest := filepath.Join(t.TempDir(), "node-backup.tar.zst")
+
+	if err := s.copyFile(context.Background(), src, dest); err != nil {
+		t.Fatalf("copyFile must succeed despite a source-close error after a durable rename; got %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("destination missing after a 'failed' copy: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("destination content mismatch: got %q want %q", got, content)
+	}
+}
+
 func TestSecondaryStorage_CopyFile_CoversErrorBranches(t *testing.T) {
 	logger := logging.New(types.LogLevelInfo, false)
 	cfg := &config.Config{SecondaryEnabled: true, SecondaryPath: t.TempDir()}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -155,6 +155,10 @@ func (e *StorageError) Error() string {
 		" operation failed for " + e.Path + recoverable + ": " + e.Err.Error()
 }
 
+// Unwrap exposes the wrapped cause so callers can classify it with errors.Is/As
+// (e.g. errors.Is(err, safefs.ErrTimeout)).
+func (e *StorageError) Unwrap() error { return e.Err }
+
 // SupportsUnixOwnership returns true if the filesystem supports Unix ownership (chown/chmod)
 func (f FilesystemType) SupportsUnixOwnership() bool {
 	switch f {

--- a/internal/storage/storage_step1_timeout_test.go
+++ b/internal/storage/storage_step1_timeout_test.go
@@ -1,0 +1,114 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/safefs"
+)
+
+func expiredStorageCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// LocalStorage.DetectFilesystem bounds its MkdirAll; on timeout it returns a
+// CRITICAL StorageError wrapping safefs.ErrTimeout (primary is critical).
+func TestLocalDetectFilesystemTimeoutIsCritical(t *testing.T) {
+	cfg := &config.Config{BackupPath: t.TempDir(), FsIoTimeoutSeconds: 30}
+	l, err := NewLocalStorage(cfg, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewLocalStorage: %v", err)
+	}
+	_, err = l.DetectFilesystem(expiredStorageCtx(t))
+	if !errors.Is(err, safefs.ErrTimeout) {
+		t.Fatalf("want safefs.ErrTimeout, got %v", err)
+	}
+	var se *StorageError
+	if !errors.As(err, &se) || !se.IsCritical {
+		t.Fatalf("want a critical StorageError, got %v", err)
+	}
+}
+
+// SecondaryStorage.DetectFilesystem bounds its MkdirAll; on timeout it returns a
+// NON-critical StorageError (secondary is best-effort).
+func TestSecondaryDetectFilesystemTimeoutNonCritical(t *testing.T) {
+	cfg := &config.Config{SecondaryEnabled: true, SecondaryPath: t.TempDir(), FsIoTimeoutSeconds: 30}
+	s, err := NewSecondaryStorage(cfg, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewSecondaryStorage: %v", err)
+	}
+	_, err = s.DetectFilesystem(expiredStorageCtx(t))
+	if !errors.Is(err, safefs.ErrTimeout) {
+		t.Fatalf("want safefs.ErrTimeout, got %v", err)
+	}
+	var se *StorageError
+	if !errors.As(err, &se) || se.IsCritical {
+		t.Fatalf("want a non-critical StorageError, got %v", err)
+	}
+}
+
+// copyFile bounds its leaf ops: a source on a wedged mount (FIFO with no writer)
+// makes the bounded Open time out instead of hanging.
+func TestSecondaryCopyFileLeafOpenTimeout(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "src.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+	t.Cleanup(func() {
+		if w, e := os.OpenFile(fifo, os.O_WRONLY, 0); e == nil {
+			_ = w.Close()
+		}
+	})
+
+	cfg := &config.Config{SecondaryEnabled: true, SecondaryPath: dir, FsIoTimeoutSeconds: 1}
+	s, err := NewSecondaryStorage(cfg, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewSecondaryStorage: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.copyFile(context.Background(), fifo, filepath.Join(dir, "dst")) }()
+	select {
+	case err := <-done:
+		if !errors.Is(err, safefs.ErrTimeout) {
+			t.Fatalf("want safefs.ErrTimeout, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("copyFile hung on a wedged source mount")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "dst")); !os.IsNotExist(statErr) {
+		t.Fatalf("dst must not exist after a timed-out copy; stat err = %v", statErr)
+	}
+}
+
+// A healthy copy still works with the bounded leaf ops in place.
+func TestSecondaryCopyFileHealthy(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.WriteFile(src, []byte("payload"), 0o640); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	cfg := &config.Config{SecondaryEnabled: true, SecondaryPath: dir, FsIoTimeoutSeconds: 30}
+	s, err := NewSecondaryStorage(cfg, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewSecondaryStorage: %v", err)
+	}
+	dst := filepath.Join(dir, "dst")
+	if err := s.copyFile(context.Background(), src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil || string(data) != "payload" {
+		t.Fatalf("dst content = %q, err = %v; want \"payload\"", data, err)
+	}
+}

--- a/internal/storage/storage_step2_timeout_test.go
+++ b/internal/storage/storage_step2_timeout_test.go
@@ -1,0 +1,95 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/safefs"
+)
+
+// A secondary mount that delivers one chunk then wedges mid-stream must make the
+// bounded copy time out (per-chunk stall budget) instead of hanging, and must
+// leave no destination behind.
+func TestSecondaryCopyFileMidStreamWedge(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "src.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+
+	releaseWriter := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		w, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+		if err != nil {
+			return
+		}
+		defer w.Close()
+		_, _ = w.Write([]byte("first chunk delivered, then the mount wedges"))
+		<-releaseWriter // keep the write end open (no EOF) so the next Read blocks
+	}()
+	t.Cleanup(func() {
+		close(releaseWriter)
+		<-writerDone
+	})
+
+	cfg := &config.Config{SecondaryEnabled: true, SecondaryPath: dir, FsIoTimeoutSeconds: 1}
+	s, err := NewSecondaryStorage(cfg, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewSecondaryStorage: %v", err)
+	}
+
+	dst := filepath.Join(dir, "dst")
+	done := make(chan error, 1)
+	go func() { done <- s.copyFile(context.Background(), fifo, dst) }()
+	select {
+	case err := <-done:
+		if !errors.Is(err, safefs.ErrTimeout) {
+			t.Fatalf("want safefs.ErrTimeout, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("copyFile hung on a mid-stream wedge")
+	}
+	if _, statErr := os.Stat(dst); !os.IsNotExist(statErr) {
+		t.Fatalf("dst must not exist after a stalled copy; stat err = %v", statErr)
+	}
+}
+
+// A healthy multi-chunk copy must still succeed byte-for-byte with the bounded
+// streaming loop in place (no false stall across many chunks).
+func TestSecondaryCopyFileHealthyLarge(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	data := make([]byte, 5*1024*1024+777) // > 5 chunks of 1 MiB
+	for i := range data {
+		data[i] = byte((i*31 + 7) % 251)
+	}
+	if err := os.WriteFile(src, data, 0o640); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	cfg := &config.Config{SecondaryEnabled: true, SecondaryPath: dir, FsIoTimeoutSeconds: 30}
+	s, err := NewSecondaryStorage(cfg, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewSecondaryStorage: %v", err)
+	}
+	dst := filepath.Join(dir, "dst")
+	if err := s.copyFile(context.Background(), src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("dst content mismatch (got %d bytes, want %d)", len(got), len(data))
+	}
+}

--- a/internal/storage/storage_step2_timeout_test.go
+++ b/internal/storage/storage_step2_timeout_test.go
@@ -32,7 +32,7 @@ func TestSecondaryCopyFileMidStreamWedge(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer w.Close()
+		defer func() { _ = w.Close() }()
 		_, _ = w.Write([]byte("first chunk delivered, then the mount wedges"))
 		<-releaseWriter // keep the write end open (no EOF) so the next Read blocks
 	}()

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -515,7 +515,7 @@ func TestLocalStorageLoadMetadataFromBundle(t *testing.T) {
 	}
 
 	// Call loadMetadata with the bundle path directly
-	meta, err := local.loadMetadata(bundlePath)
+	meta, err := local.loadMetadata(context.Background(), bundlePath)
 	if err != nil {
 		t.Fatalf("loadMetadata() error = %v", err)
 	}
@@ -706,7 +706,7 @@ func TestLocalStorageLoadMetadataFallsBackToSidecar(t *testing.T) {
 		t.Fatalf("write metadata: %v", err)
 	}
 
-	meta, err := local.loadMetadata(backupPath)
+	meta, err := local.loadMetadata(context.Background(), backupPath)
 	if err != nil {
 		t.Fatalf("loadMetadata() error = %v", err)
 	}
@@ -739,7 +739,7 @@ func TestLocalStorageLoadMetadataMissingFile(t *testing.T) {
 		t.Fatalf("write backup: %v", err)
 	}
 
-	if _, err := local.loadMetadata(backupPath); err == nil {
+	if _, err := local.loadMetadata(context.Background(), backupPath); err == nil {
 		t.Fatal("loadMetadata() should fail when metadata file is missing")
 	}
 }


### PR DESCRIPTION
Automated release PR for `v0.27.0`.

<!-- release-tag: v0.27.0 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended configurable per-syscall I/O timeout behavior across backup, restore, logging, storage, cloud, and security preflight workflows.

* **Bug Fixes**
  * Improved resilience to slow/unavailable mounts so operations time out or skip instead of hanging.
  * Moved runtime profiling output to `/tmp/proxsave` and hardened related cleanup.
  * Prevented logging from stalling on dead/stale `LOG_PATH` mounts.
  * Made dry-run behavior consistent across permissions, integrity/hash, and cloud verification paths.

* **Documentation**
  * Updated `FS_IO_TIMEOUT` and profiling documentation to reflect per-syscall and `/tmp/proxsave` behavior.

* **Tests**
  * Added extensive bounded-timeout and “doesn’t wedge” test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR releases v0.27.0 with broader bounded filesystem I/O behavior.

- Per-syscall timeout handling across backup, restore, logging, storage, cloud, and security flows.
- Profiling output moved away from `LOG_PATH` into `/tmp/proxsave`.
- Dry-run handling tightened for permissions, logging, integrity, and hash paths.
- Documentation and tests updated for the new timeout behavior.

<h3>Confidence Score: 4/5</h3>

This is close, but the cloud checksum path should be fixed before merging.

- A checksum-enabled cloud upload can still pass after local hashing times out.
- The remote object can be accepted with only size verification even when a remote SHA256 is available.
- The warning helps operators notice the issue, but it does not make verification fail.

internal/storage/cloud.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/storage/cloud.go | Cloud verification now uses bounded local hashing, but the timeout branch still accepts size-only verification when checksum comparison was requested. |
| internal/backup/checksum.go | Checksum generation now supports bounded open, read, and close behavior for paths that may stall. |
| internal/security/security.go | Security preflight hash-file operations were moved onto bounded filesystem helpers with dry-run checks. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/security/security.go`, line 400 ([link](https://github.com/tis24dev/proxsave/blob/e1999d6014e09d98d714c405b004ff7c59137e95/internal/security/security.go#L400)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Executable Read Still Unbounded**

   The preflight now bounds `Lstat` and `Open`, but this call still reads the executable with raw `io.Copy` inside `checksumReader`. If the executable mount is responsive for open and then stalls during reads, `FS_IO_TIMEOUT` no longer applies and the security preflight can hang indefinitely.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fsecurity%2Fsecurity.go%0ALine%3A%20400%0A%0AComment%3A%0A**Executable%20Read%20Still%20Unbounded**%0A%0AThe%20preflight%20now%20bounds%20%60Lstat%60%20and%20%60Open%60%2C%20but%20this%20call%20still%20reads%20the%20executable%20with%20raw%20%60io.Copy%60%20inside%20%60checksumReader%60.%20If%20the%20executable%20mount%20is%20responsive%20for%20open%20and%20then%20stalls%20during%20reads%2C%20%60FS_IO_TIMEOUT%60%20no%20longer%20applies%20and%20the%20security%20preflight%20can%20hang%20indefinitely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fsecurity%2Fsecurity.go%0ALine%3A%20400%0A%0AComment%3A%0A**Executable%20Read%20Still%20Unbounded**%0A%0AThe%20preflight%20now%20bounds%20%60Lstat%60%20and%20%60Open%60%2C%20but%20this%20call%20still%20reads%20the%20executable%20with%20raw%20%60io.Copy%60%20inside%20%60checksumReader%60.%20If%20the%20executable%20mount%20is%20responsive%20for%20open%20and%20then%20stalls%20during%20reads%2C%20%60FS_IO_TIMEOUT%60%20no%20longer%20applies%20and%20the%20security%20preflight%20can%20hang%20indefinitely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Fproxsave%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fsecurity%2Fsecurity.go%0ALine%3A%20400%0A%0AComment%3A%0A**Executable%20Read%20Still%20Unbounded**%0A%0AThe%20preflight%20now%20bounds%20%60Lstat%60%20and%20%60Open%60%2C%20but%20this%20call%20still%20reads%20the%20executable%20with%20raw%20%60io.Copy%60%20inside%20%60checksumReader%60.%20If%20the%20executable%20mount%20is%20responsive%20for%20open%20and%20then%20stalls%20during%20reads%2C%20%60FS_IO_TIMEOUT%60%20no%20longer%20applies%20and%20the%20security%20preflight%20can%20hang%20indefinitely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `internal/security/security.go`, line 645 ([link](https://github.com/tis24dev/proxsave/blob/e1999d6014e09d98d714c405b004ff7c59137e95/internal/security/security.go#L645)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Key Scan Callback Is Unbounded**

   `WalkBounded` only bounds directory traversal; the callback then calls `fileContainsMarker`, which uses raw `os.Open` and unbounded reads. If `BaseDir/identity` is on a network or FUSE mount that enumerates entries but stalls opening one file, the private-key scan can still hang the whole security preflight.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fsecurity%2Fsecurity.go%0ALine%3A%20645%0A%0AComment%3A%0A**Key%20Scan%20Callback%20Is%20Unbounded**%0A%0A%60WalkBounded%60%20only%20bounds%20directory%20traversal%3B%20the%20callback%20then%20calls%20%60fileContainsMarker%60%2C%20which%20uses%20raw%20%60os.Open%60%20and%20unbounded%20reads.%20If%20%60BaseDir%2Fidentity%60%20is%20on%20a%20network%20or%20FUSE%20mount%20that%20enumerates%20entries%20but%20stalls%20opening%20one%20file%2C%20the%20private-key%20scan%20can%20still%20hang%20the%20whole%20security%20preflight.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fsecurity%2Fsecurity.go%0ALine%3A%20645%0A%0AComment%3A%0A**Key%20Scan%20Callback%20Is%20Unbounded**%0A%0A%60WalkBounded%60%20only%20bounds%20directory%20traversal%3B%20the%20callback%20then%20calls%20%60fileContainsMarker%60%2C%20which%20uses%20raw%20%60os.Open%60%20and%20unbounded%20reads.%20If%20%60BaseDir%2Fidentity%60%20is%20on%20a%20network%20or%20FUSE%20mount%20that%20enumerates%20entries%20but%20stalls%20opening%20one%20file%2C%20the%20private-key%20scan%20can%20still%20hang%20the%20whole%20security%20preflight.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Fproxsave%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fsecurity%2Fsecurity.go%0ALine%3A%20645%0A%0AComment%3A%0A**Key%20Scan%20Callback%20Is%20Unbounded**%0A%0A%60WalkBounded%60%20only%20bounds%20directory%20traversal%3B%20the%20callback%20then%20calls%20%60fileContainsMarker%60%2C%20which%20uses%20raw%20%60os.Open%60%20and%20unbounded%20reads.%20If%20%60BaseDir%2Fidentity%60%20is%20on%20a%20network%20or%20FUSE%20mount%20that%20enumerates%20entries%20but%20stalls%20opening%20one%20file%2C%20the%20private-key%20scan%20can%20still%20hang%20the%20whole%20security%20preflight.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ainternal%2Fstorage%2Fcloud.go%3A1175%0A**Checksum%20Still%20Passes**%0A%0AWhen%20%60CLOUD_VERIFY_CHECKSUM%60%20is%20enabled%20and%20the%20local%20archive%20read%20stalls%20for%20%60FS_IO_TIMEOUT%60%2C%20this%20branch%20returns%20%60true%2C%20nil%60%20after%20only%20the%20size%20check%20has%20passed.%20%60runUploadTask%60%20treats%20that%20as%20a%20verified%20upload%2C%20so%20a%20corrupt%20remote%20object%20with%20the%20same%20size%20can%20still%20be%20recorded%20as%20successfully%20stored%20even%20though%20the%20remote%20SHA256%20was%20available%20and%20never%20compared.%20The%20warning%20makes%20the%20problem%20visible%2C%20but%20it%20does%20not%20prevent%20the%20bad%20object%20from%20being%20accepted%3B%20this%20checksum-enabled%20path%20should%20fail%20verification%20instead%20of%20preserving%20the%20size-only%20result.%0A%0A&repo=tis24dev%2Fproxsave&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ainternal%2Fstorage%2Fcloud.go%3A1175%0A**Checksum%20Still%20Passes**%0A%0AWhen%20%60CLOUD_VERIFY_CHECKSUM%60%20is%20enabled%20and%20the%20local%20archive%20read%20stalls%20for%20%60FS_IO_TIMEOUT%60%2C%20this%20branch%20returns%20%60true%2C%20nil%60%20after%20only%20the%20size%20check%20has%20passed.%20%60runUploadTask%60%20treats%20that%20as%20a%20verified%20upload%2C%20so%20a%20corrupt%20remote%20object%20with%20the%20same%20size%20can%20still%20be%20recorded%20as%20successfully%20stored%20even%20though%20the%20remote%20SHA256%20was%20available%20and%20never%20compared.%20The%20warning%20makes%20the%20problem%20visible%2C%20but%20it%20does%20not%20prevent%20the%20bad%20object%20from%20being%20accepted%3B%20this%20checksum-enabled%20path%20should%20fail%20verification%20instead%20of%20preserving%20the%20size-only%20result.%0A%0A&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Fproxsave%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ainternal%2Fstorage%2Fcloud.go%3A1175%0A**Checksum%20Still%20Passes**%0A%0AWhen%20%60CLOUD_VERIFY_CHECKSUM%60%20is%20enabled%20and%20the%20local%20archive%20read%20stalls%20for%20%60FS_IO_TIMEOUT%60%2C%20this%20branch%20returns%20%60true%2C%20nil%60%20after%20only%20the%20size%20check%20has%20passed.%20%60runUploadTask%60%20treats%20that%20as%20a%20verified%20upload%2C%20so%20a%20corrupt%20remote%20object%20with%20the%20same%20size%20can%20still%20be%20recorded%20as%20successfully%20stored%20even%20though%20the%20remote%20SHA256%20was%20available%20and%20never%20compared.%20The%20warning%20makes%20the%20problem%20visible%2C%20but%20it%20does%20not%20prevent%20the%20bad%20object%20from%20being%20accepted%3B%20this%20checksum-enabled%20path%20should%20fail%20verification%20instead%20of%20preserving%20the%20size-only%20result.%0A%0A&repo=tis24dev%2Fproxsave&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["test(security): bound the FIFO cleanups ..."](https://github.com/tis24dev/proxsave/commit/1285b07bcf170f1a6d5436c537943c52a879d9ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40506931)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->