### PR TITLE
Release v0.28.0

### DIFF
--- a/cmd/proxsave/backup_notifications.go
+++ b/cmd/proxsave/backup_notifications.go
@@ -38,6 +38,7 @@ func registerNotificationSecrets(logger *logging.Logger, cfg *config.Config) {
 		return
 	}
 	logger.RegisterSecret(cfg.TelegramBotToken)
+	logger.RegisterSecret(cfg.TelegramNotifySecret)
 	logger.RegisterSecret(cfg.GotifyToken)
 	if cfg.WebhookEnabled {
 		for _, ep := range cfg.BuildWebhookConfig().Endpoints {
@@ -101,6 +102,7 @@ func initializeTelegramNotification(opts backupModeOptions, orch *orchestrator.O
 		ChatID:        cfg.TelegramChatID,
 		ServerAPIHost: cfg.TelegramServerAPIHost,
 		ServerID:      cfg.ServerID,
+		NotifySecret:  cfg.TelegramNotifySecret,
 	}
 	telegramNotifier, err := notify.NewTelegramNotifier(telegramConfig, logger)
 	if err != nil {

--- a/cmd/proxsave/backup_notifications.go
+++ b/cmd/proxsave/backup_notifications.go
@@ -103,6 +103,7 @@ func initializeTelegramNotification(opts backupModeOptions, orch *orchestrator.O
 		ServerAPIHost: cfg.TelegramServerAPIHost,
 		ServerID:      cfg.ServerID,
 		NotifySecret:  cfg.TelegramNotifySecret,
+		BaseDir:       cfg.BaseDir,
 	}
 	telegramNotifier, err := notify.NewTelegramNotifier(telegramConfig, logger)
 	if err != nil {

--- a/cmd/proxsave/install.go
+++ b/cmd/proxsave/install.go
@@ -197,7 +197,7 @@ func runPostInstallAuditCLI(ctx context.Context, reader *bufio.Reader, execPath,
 		for _, s := range suggestions {
 			keys = append(keys, s.Key)
 		}
-		bootstrap.Info("Post-install audit: suggested disables (%d): %s", len(keys), strings.Join(keys, ", "))
+		bootstrap.Debug("Post-install audit: suggested disables (%d): %s", len(keys), strings.Join(keys, ", "))
 	}
 	for _, s := range suggestions {
 		reason := ""
@@ -269,7 +269,8 @@ func runPostInstallAuditCLI(ctx context.Context, reader *bufio.Reader, execPath,
 
 	fmt.Printf("✓ Updated %s: disabled %d component(s): %s\n", configPath, len(keys), strings.Join(keys, ", "))
 	if bootstrap != nil {
-		bootstrap.Info("Post-install audit: disabled (%d): %s", len(keys), strings.Join(keys, ", "))
+		bootstrap.Info("Post-install audit: disabled %d of %d unused component(s)", len(keys), len(suggestions))
+		bootstrap.Debug("Post-install audit: disabled keys: %s", strings.Join(keys, ", "))
 	}
 	return nil
 }

--- a/cmd/proxsave/install_tui.go
+++ b/cmd/proxsave/install_tui.go
@@ -173,11 +173,12 @@ func runInstallTUI(ctx context.Context, configPath string, bootstrap *logging.Bo
 					for _, s := range auditRes.Suggestions {
 						keys = append(keys, s.Key)
 					}
-					bootstrap.Info("Post-install audit: suggested disables (%d): %s", len(keys), strings.Join(keys, ", "))
+					bootstrap.Debug("Post-install audit: suggested disables (%d): %s", len(keys), strings.Join(keys, ", "))
 					if len(auditRes.AppliedKeys) > 0 {
-						bootstrap.Info("Post-install audit: disabled (%d): %s", len(auditRes.AppliedKeys), strings.Join(auditRes.AppliedKeys, ", "))
+						bootstrap.Info("Post-install audit: disabled %d of %d unused component(s)", len(auditRes.AppliedKeys), len(keys))
+						bootstrap.Debug("Post-install audit: disabled keys: %s", strings.Join(auditRes.AppliedKeys, ", "))
 					} else {
-						bootstrap.Info("Post-install audit: no disables applied")
+						bootstrap.Info("Post-install audit: %d unused component(s) detected, none disabled", len(keys))
 					}
 				}
 			}

--- a/cmd/proxsave/main_identity.go
+++ b/cmd/proxsave/main_identity.go
@@ -67,7 +67,7 @@ func checkTelegramServerStatus(rt *appRuntime) (string, bool) {
 
 	logging.Debug("Contacting remote Telegram server...")
 	logging.Debug("Telegram server URL: %s", rt.cfg.TelegramServerAPIHost)
-	status := notify.CheckTelegramRegistration(rt.ctx, rt.cfg.TelegramServerAPIHost, rt.serverIDValue, rt.logger)
+	status := notify.CheckTelegramRegistrationAndProvision(rt.ctx, rt.cfg.TelegramServerAPIHost, rt.serverIDValue, rt.cfg.BaseDir, rt.logger)
 	if status.Error != nil {
 		logging.Warning("Telegram: %s", status.Message)
 		logging.Debug("Telegram connection error: %v", status.Error)

--- a/cmd/proxsave/main_identity.go
+++ b/cmd/proxsave/main_identity.go
@@ -67,7 +67,8 @@ func checkTelegramServerStatus(rt *appRuntime) (string, bool) {
 
 	logging.Debug("Contacting remote Telegram server...")
 	logging.Debug("Telegram server URL: %s", rt.cfg.TelegramServerAPIHost)
-	status := notify.CheckTelegramRegistrationAndProvision(rt.ctx, rt.cfg.TelegramServerAPIHost, rt.serverIDValue, rt.cfg.BaseDir, rt.logger)
+	res := notify.CheckTelegramRegistrationAndProvision(rt.ctx, rt.cfg.TelegramServerAPIHost, rt.serverIDValue, rt.cfg.BaseDir, rt.logger)
+	status := res.Status
 	if status.Error != nil {
 		logging.Warning("Telegram: %s", status.Message)
 		logging.Debug("Telegram connection error: %v", status.Error)

--- a/cmd/proxsave/telegram_setup_cli.go
+++ b/cmd/proxsave/telegram_setup_cli.go
@@ -5,10 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/notify"
@@ -23,119 +20,9 @@ var (
 )
 
 func sanitizeTelegramSetupStatusMessage(raw string) string {
-	msg := strings.TrimSpace(raw)
-	if msg == "" {
-		return ""
-	}
-
-	sanitized := stripTelegramTerminalSequences(msg)
-	sanitized = orchestrator.TruncateTelegramSetupStatusMessage(sanitized)
-	if sanitized != "" {
-		return sanitized
-	}
-
-	quoted := strconv.QuoteToASCII(msg)
-	quoted = strings.TrimPrefix(quoted, `"`)
-	quoted = strings.TrimSuffix(quoted, `"`)
-	return orchestrator.TruncateTelegramSetupStatusMessage(quoted)
-}
-
-func stripTelegramTerminalSequences(msg string) string {
-	var b strings.Builder
-	b.Grow(len(msg))
-	pendingSpace := false
-
-	for i := 0; i < len(msg); {
-		switch msg[i] {
-		case 0x1b:
-			i = skipTelegramEscapeSequence(msg, i)
-			pendingSpace = true
-			continue
-		case 0x9b:
-			i = skipTelegramCSI(msg, i+1)
-			pendingSpace = true
-			continue
-		}
-
-		r, size := utf8.DecodeRuneInString(msg[i:])
-		if r == utf8.RuneError && size == 1 {
-			i++
-			continue
-		}
-		if unicode.IsSpace(r) || unicode.IsControl(r) {
-			pendingSpace = true
-			i += size
-			continue
-		}
-		if !unicode.IsPrint(r) {
-			i += size
-			continue
-		}
-		if pendingSpace && b.Len() > 0 {
-			b.WriteByte(' ')
-		}
-		pendingSpace = false
-		b.WriteRune(r)
-		i += size
-	}
-
-	return strings.TrimSpace(b.String())
-}
-
-func skipTelegramEscapeSequence(msg string, i int) int {
-	if i >= len(msg) || msg[i] != 0x1b {
-		return i + 1
-	}
-	i++
-	if i >= len(msg) {
-		return i
-	}
-	switch msg[i] {
-	case '[':
-		return skipTelegramCSI(msg, i+1)
-	case ']':
-		return skipTelegramOSC(msg, i+1)
-	case 'P', 'X', '^', '_':
-		return skipTelegramST(msg, i+1)
-	default:
-		return i + 1
-	}
-}
-
-func skipTelegramCSI(msg string, i int) int {
-	for i < len(msg) {
-		b := msg[i]
-		i++
-		if b >= 0x40 && b <= 0x7e {
-			return i
-		}
-	}
-	return i
-}
-
-func skipTelegramOSC(msg string, i int) int {
-	for i < len(msg) {
-		switch msg[i] {
-		case 0x07:
-			return i + 1
-		case 0x1b:
-			if i+1 < len(msg) && msg[i+1] == '\\' {
-				return i + 2
-			}
-		}
-		i++
-	}
-	return i
-}
-
-func skipTelegramST(msg string, i int) int {
-	for i < len(msg) {
-		if msg[i] == 0x1b && i+1 < len(msg) && msg[i+1] == '\\' {
-			return i + 2
-		}
-		i++
-	}
-	return i
+	// Delegates to the shared orchestrator sanitizer so the CLI, the TUI, and the
+	// classifier all scrub control/terminal sequences and truncate identically.
+	return orchestrator.SanitizeTelegramSetupStatusMessage(raw)
 }
 
 func logTelegramSetupBootstrapOutcome(bootstrap *logging.BootstrapLogger, state orchestrator.TelegramSetupBootstrap) {

--- a/cmd/proxsave/telegram_setup_cli.go
+++ b/cmd/proxsave/telegram_setup_cli.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"unicode"
@@ -12,11 +13,12 @@ import (
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/notify"
 	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/types"
 )
 
 var (
 	telegramSetupBuildBootstrap    = orchestrator.BuildTelegramSetupBootstrap
-	telegramSetupCheckRegistration = notify.CheckTelegramRegistration
+	telegramSetupCheckRegistration = notify.CheckTelegramRegistrationAndProvision
 	telegramSetupPromptYesNo       = promptYesNo
 )
 
@@ -187,45 +189,56 @@ func runTelegramSetupCLI(ctx context.Context, reader *bufio.Reader, baseDir, con
 		return nil
 	}
 
+	// Real-but-silent logger: the reused provision path registers and masks the
+	// relay secret via this logger, but io.Discard keeps every debug line off the
+	// install console (full debug stays on the runtime backup path via rt.logger).
+	silentLogger := logging.New(types.LogLevelDebug, false)
+	silentLogger.SetOutput(io.Discard)
+
 	attempts := 0
 	for {
 		attempts++
-		status := telegramSetupCheckRegistration(ctx, state.ServerAPIHost, state.ServerID, nil)
-		if status.Code == 200 && status.Error == nil {
-			fmt.Println("✓ Telegram linked successfully.")
-			logBootstrapInfo(bootstrap, "Telegram setup: verified (attempts=%d)", attempts)
+		res := telegramSetupCheckRegistration(ctx, state.ServerAPIHost, state.ServerID, baseDir, silentLogger)
+		st := orchestrator.ClassifyTelegramSetupResult(res)
+
+		if st.Verified {
+			if st.Partial {
+				fmt.Println(st.Message)
+				logBootstrapInfo(bootstrap, "Telegram setup: verified with pending follow-up (attempts=%d state=%s)", attempts, st.Code)
+			} else {
+				fmt.Printf("✓ %s\n", st.Message)
+				logBootstrapInfo(bootstrap, "Telegram setup: verified (attempts=%d)", attempts)
+			}
 			return nil
 		}
 
-		msg := sanitizeTelegramSetupStatusMessage(status.Message)
-		if msg == "" {
-			msg = "Registration not active yet"
+		// rawMsg drives ONLY the byte-identical failure log line (sanitized RAW
+		// server message). The user-facing line is always the classifier message.
+		rawMsg := sanitizeTelegramSetupStatusMessage(res.Status.Message)
+		if rawMsg == "" {
+			rawMsg = "Registration not active yet"
 		}
-		fmt.Printf("Telegram: %s\n", msg)
-		switch status.Code {
-		case 403, 409:
-			fmt.Println("Hint: Start the bot, send the Server ID, then retry.")
-		case 422:
-			fmt.Println("Hint: The Server ID appears invalid. If this persists, re-run the installer.")
-		default:
-			if status.Error != nil {
-				fmt.Printf("Hint: Check failed: %v\n", status.Error)
-			}
+		fmt.Printf("Telegram: %s\n", sanitizeTelegramSetupStatusMessage(st.Message))
+
+		if st.Fatal { // 422 / 426: re-checking cannot help, do NOT offer "Check again?"
+			logBootstrapInfo(bootstrap, "Telegram setup: not verified (attempts=%d last=%d %s)", attempts, res.Status.Code, rawMsg)
+			return nil
 		}
 
 		if attempts >= orchestrator.TelegramSetupMaxVerificationAttempts {
-			fmt.Println("Maximum verification attempts reached. You can retry later by running proxsave.")
-			logBootstrapInfo(bootstrap, "Telegram setup: not verified (attempts=%d last=%d %s)", attempts, status.Code, msg)
+			fmt.Println(orchestrator.TelegramSetupMaxAttemptsHint)
+			logBootstrapInfo(bootstrap, "Telegram setup: not verified (attempts=%d last=%d %s)", attempts, res.Status.Code, rawMsg)
 			return nil
 		}
 
+		fmt.Println(orchestrator.TelegramSetupRetryHint)
 		retry, err := telegramSetupPromptYesNo(ctx, reader, "Check again? [y/N]: ", false)
 		if err != nil {
 			return skipOptionalInstallStepOnAbort(bootstrap, "Telegram setup", err)
 		}
 		if !retry {
 			fmt.Println("Verification not completed. You can retry later by running proxsave.")
-			logBootstrapInfo(bootstrap, "Telegram setup: not verified (attempts=%d last=%d %s)", attempts, status.Code, msg)
+			logBootstrapInfo(bootstrap, "Telegram setup: not verified (attempts=%d last=%d %s)", attempts, res.Status.Code, rawMsg)
 			return nil
 		}
 	}

--- a/cmd/proxsave/telegram_setup_cli_test.go
+++ b/cmd/proxsave/telegram_setup_cli_test.go
@@ -42,9 +42,9 @@ func TestRunTelegramSetupCLI_SkipOnConfigError(t *testing.T) {
 		t.Fatalf("prompt should not run for config skip")
 		return false, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		t.Fatalf("registration check should not run for config skip")
-		return notify.TelegramRegistrationStatus{}
+		return notify.TelegramRegistrationResult{}
 	}
 
 	if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
@@ -67,9 +67,9 @@ func TestRunTelegramSetupCLI_SkipOnPersonalMode(t *testing.T) {
 		t.Fatalf("prompt should not run for personal mode")
 		return false, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		t.Fatalf("registration check should not run for personal mode")
-		return notify.TelegramRegistrationStatus{}
+		return notify.TelegramRegistrationResult{}
 	}
 
 	if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
@@ -93,9 +93,9 @@ func TestRunTelegramSetupCLI_SkipOnMissingIdentity(t *testing.T) {
 		t.Fatalf("prompt should not run when identity is unavailable")
 		return false, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		t.Fatalf("registration check should not run when identity is unavailable")
-		return notify.TelegramRegistrationStatus{}
+		return notify.TelegramRegistrationResult{}
 	}
 
 	if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
@@ -123,9 +123,9 @@ func TestRunTelegramSetupCLI_DeclineVerification(t *testing.T) {
 		}
 		return false, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		t.Fatalf("registration check should not run when user declines")
-		return notify.TelegramRegistrationStatus{}
+		return notify.TelegramRegistrationResult{}
 	}
 
 	if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
@@ -156,7 +156,7 @@ func TestRunTelegramSetupCLI_VerifiesSuccessfully(t *testing.T) {
 		}
 		return true, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		checkCalls++
 		if serverAPIHost != "https://api.example.test" {
 			t.Fatalf("serverAPIHost=%q, want https://api.example.test", serverAPIHost)
@@ -164,7 +164,7 @@ func TestRunTelegramSetupCLI_VerifiesSuccessfully(t *testing.T) {
 		if serverID != "123456789" {
 			t.Fatalf("serverID=%q, want 123456789", serverID)
 		}
-		return notify.TelegramRegistrationStatus{Code: 200, Message: "ok"}
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200, Message: "ok"}}
 	}
 
 	if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
@@ -198,12 +198,12 @@ func TestRunTelegramSetupCLI_StopsAfterMaxVerificationAttempts(t *testing.T) {
 		promptCalls++
 		return true, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		checkCalls++
-		return notify.TelegramRegistrationStatus{
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{
 			Code:    409,
 			Message: "not linked yet",
-		}
+		}}
 	}
 
 	bootstrap := logging.NewBootstrapLogger()
@@ -237,9 +237,9 @@ func TestRunTelegramSetupCLI_BootstrapErrorNonBlocking(t *testing.T) {
 		t.Fatalf("prompt should not run on bootstrap error")
 		return false, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		t.Fatalf("registration check should not run on bootstrap error")
-		return notify.TelegramRegistrationStatus{}
+		return notify.TelegramRegistrationResult{}
 	}
 
 	if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
@@ -266,9 +266,9 @@ func TestRunTelegramSetupCLI_PromptAbortIsNonBlocking(t *testing.T) {
 		promptCalls++
 		return false, errInteractiveAborted
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		t.Fatalf("registration check should not run when the prompt aborts")
-		return notify.TelegramRegistrationStatus{}
+		return notify.TelegramRegistrationResult{}
 	}
 
 	if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
@@ -329,12 +329,12 @@ func TestRunTelegramSetupCLI_SanitizesRegistrationStatusOutput(t *testing.T) {
 		promptCalls++
 		return promptCalls == 1, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
-		return notify.TelegramRegistrationStatus{
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{
 			Code:    500,
 			Message: "\x1b[31mneeds\tpairing\r\nnow\x1b[0m\x07",
 			Error:   errors.New("unexpected status 500"),
-		}
+		}}
 	}
 
 	output := captureStdout(t, func() {
@@ -348,5 +348,106 @@ func TestRunTelegramSetupCLI_SanitizesRegistrationStatusOutput(t *testing.T) {
 	}
 	if strings.Contains(output, "\x1b") {
 		t.Fatalf("output should not contain raw escape sequences, got %q", output)
+	}
+}
+
+// TestRunTelegramSetupCLI_UpgradeRequiredStopsRetry pins the CLI parity with the
+// TUI: a 426 (upgrade required) is fatal, so the CLI shows the distinct message
+// and returns WITHOUT offering "Check again?" (no second prompt, single check).
+func TestRunTelegramSetupCLI_UpgradeRequiredStopsRetry(t *testing.T) {
+	stubTelegramSetupCLIDeps(t)
+
+	telegramSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.TelegramSetupBootstrap, error) {
+		return orchestrator.TelegramSetupBootstrap{
+			Eligibility:     orchestrator.TelegramSetupEligibleCentralized,
+			ConfigLoaded:    true,
+			TelegramEnabled: true,
+			TelegramMode:    "centralized",
+			ServerAPIHost:   "https://api.example.test",
+			ServerID:        "123456789",
+		}, nil
+	}
+	promptCalls := 0
+	telegramSetupPromptYesNo = func(ctx context.Context, reader *bufio.Reader, question string, defaultYes bool) (bool, error) {
+		promptCalls++
+		if promptCalls != 1 {
+			t.Fatalf("expected only the initial check prompt, got call %d: %q", promptCalls, question)
+		}
+		return true, nil
+	}
+	checkCalls := 0
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
+		checkCalls++
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{
+			Code:    426,
+			Message: "426 - Upgrade ProxSave to v0.28.0 or later to complete pairing",
+			Error:   errors.New("upgrade"),
+		}}
+	}
+
+	output := captureStdout(t, func() {
+		if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
+			t.Fatalf("runTelegramSetupCLI error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "Upgrade ProxSave to v0.28.0 or later to complete pairing.") {
+		t.Fatalf("expected upgrade-required message in output, got %q", output)
+	}
+	if checkCalls != 1 {
+		t.Fatalf("checkCalls=%d, want 1", checkCalls)
+	}
+	if promptCalls != 1 {
+		t.Fatalf("promptCalls=%d, want 1 (no 'Check again?' after a fatal status)", promptCalls)
+	}
+}
+
+// TestRunTelegramSetupCLI_PartialLinked pins that a 200 with a failed persist
+// counts as verified (the CLI returns successfully after one check) but shows the
+// distinct partial message instead of the clean success line.
+func TestRunTelegramSetupCLI_PartialLinked(t *testing.T) {
+	stubTelegramSetupCLIDeps(t)
+
+	telegramSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.TelegramSetupBootstrap, error) {
+		return orchestrator.TelegramSetupBootstrap{
+			Eligibility:     orchestrator.TelegramSetupEligibleCentralized,
+			ConfigLoaded:    true,
+			TelegramEnabled: true,
+			TelegramMode:    "centralized",
+			ServerAPIHost:   "https://api.example.test",
+			ServerID:        "123456789",
+		}, nil
+	}
+	promptCalls := 0
+	telegramSetupPromptYesNo = func(ctx context.Context, reader *bufio.Reader, question string, defaultYes bool) (bool, error) {
+		promptCalls++
+		if promptCalls != 1 {
+			t.Fatalf("expected only the initial check prompt, got call %d: %q", promptCalls, question)
+		}
+		return true, nil
+	}
+	checkCalls := 0
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
+		checkCalls++
+		return notify.TelegramRegistrationResult{
+			Status:    notify.TelegramRegistrationStatus{Code: 200, Message: "ok"},
+			Provision: notify.TelegramProvisionPersistFailed,
+		}
+	}
+
+	output := captureStdout(t, func() {
+		if err := runTelegramSetupCLI(context.Background(), bufio.NewReader(strings.NewReader("")), t.TempDir(), "/fake/backup.env", logging.NewBootstrapLogger()); err != nil {
+			t.Fatalf("runTelegramSetupCLI error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "could not be saved locally") {
+		t.Fatalf("expected distinct partial message in output, got %q", output)
+	}
+	if checkCalls != 1 {
+		t.Fatalf("checkCalls=%d, want 1", checkCalls)
+	}
+	if promptCalls != 1 {
+		t.Fatalf("promptCalls=%d, want 1", promptCalls)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,6 +192,7 @@ type Config struct {
 	TelegramChatID        string // For personal mode
 	TelegramServerAPIHost string // For centralized mode
 	ServerID              string // Server identifier for centralized mode
+	TelegramNotifySecret  string // Per-server relay secret (centralized mode); empty = legacy token-fetch
 
 	// Email Notifications
 	EmailEnabled          bool
@@ -386,6 +387,7 @@ func (c *Config) loadEnvOverrides() {
 		"RETENTION_DAILY", "RETENTION_WEEKLY", "RETENTION_MONTHLY", "RETENTION_YEARLY",
 		"BUNDLE_ASSOCIATED_FILES", "ENCRYPT_ARCHIVE", "AGE_RECIPIENT", "AGE_RECIPIENT_FILE",
 		"TELEGRAM_ENABLE", "TELEGRAM_ENABLED", "BOT_TELEGRAM_TYPE", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID",
+		"TELEGRAM_NOTIFY_SECRET",
 		"EMAIL_ENABLE", "EMAIL_ENABLED", "EMAIL_DELIVERY_METHOD", "EMAIL_FALLBACK_PMF", "EMAIL_FALLBACK_SENDMAIL",
 		"EMAIL_RECIPIENT", "EMAIL_FROM",
 		"GOTIFY_ENABLE", "GOTIFY_ENABLED", "GOTIFY_SERVER_URL", "GOTIFY_TOKEN",
@@ -729,6 +731,7 @@ func (c *Config) parseNotificationSettings() {
 	c.TelegramChatID = c.getString("TELEGRAM_CHAT_ID", "")
 	c.TelegramServerAPIHost = "https://bot.tis24.it:1443"
 	c.ServerID = ""
+	c.TelegramNotifySecret = strings.TrimSpace(c.getString("TELEGRAM_NOTIFY_SECRET", ""))
 
 	c.EmailEnabled = c.getBoolWithLegacyAlias(emailEnabledKey, emailEnableLegacyKey, false)
 	c.EmailDeliveryMethod = NormalizeEmailDeliveryMethod(c.getString("EMAIL_DELIVERY_METHOD", "relay"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,7 +192,7 @@ type Config struct {
 	TelegramChatID        string // For personal mode
 	TelegramServerAPIHost string // For centralized mode
 	ServerID              string // Server identifier for centralized mode
-	TelegramNotifySecret  string // Per-server relay secret (centralized mode); empty = legacy token-fetch
+	TelegramNotifySecret  string // Deprecated: no longer read from backup.env; the relay secret is provisioned via TOFU into the immutable identity file. Kept "" for compatibility.
 
 	// Email Notifications
 	EmailEnabled          bool
@@ -387,7 +387,6 @@ func (c *Config) loadEnvOverrides() {
 		"RETENTION_DAILY", "RETENTION_WEEKLY", "RETENTION_MONTHLY", "RETENTION_YEARLY",
 		"BUNDLE_ASSOCIATED_FILES", "ENCRYPT_ARCHIVE", "AGE_RECIPIENT", "AGE_RECIPIENT_FILE",
 		"TELEGRAM_ENABLE", "TELEGRAM_ENABLED", "BOT_TELEGRAM_TYPE", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID",
-		"TELEGRAM_NOTIFY_SECRET",
 		"EMAIL_ENABLE", "EMAIL_ENABLED", "EMAIL_DELIVERY_METHOD", "EMAIL_FALLBACK_PMF", "EMAIL_FALLBACK_SENDMAIL",
 		"EMAIL_RECIPIENT", "EMAIL_FROM",
 		"GOTIFY_ENABLE", "GOTIFY_ENABLED", "GOTIFY_SERVER_URL", "GOTIFY_TOKEN",
@@ -731,7 +730,7 @@ func (c *Config) parseNotificationSettings() {
 	c.TelegramChatID = c.getString("TELEGRAM_CHAT_ID", "")
 	c.TelegramServerAPIHost = "https://bot.tis24.it:1443"
 	c.ServerID = ""
-	c.TelegramNotifySecret = strings.TrimSpace(c.getString("TELEGRAM_NOTIFY_SECRET", ""))
+	c.TelegramNotifySecret = "" // no longer read from backup.env; provisioned via TOFU into the immutable identity file
 
 	c.EmailEnabled = c.getBoolWithLegacyAlias(emailEnabledKey, emailEnableLegacyKey, false)
 	c.EmailDeliveryMethod = NormalizeEmailDeliveryMethod(c.getString("EMAIL_DELIVERY_METHOD", "relay"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -658,6 +658,43 @@ WEBHOOK_ENABLE=true
 	}
 }
 
+func TestParseTelegramNotifySecret(t *testing.T) {
+	t.Run("absent defaults to empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "no_secret.env")
+		if err := os.WriteFile(configPath, []byte("TELEGRAM_ENABLED=true\n"), 0o600); err != nil {
+			t.Fatalf("Failed to create test config: %v", err)
+		}
+		setBaseDirEnv(t, "/notify/secret/base")
+
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+		if cfg.TelegramNotifySecret != "" {
+			t.Fatalf("TelegramNotifySecret = %q; want empty string when absent", cfg.TelegramNotifySecret)
+		}
+	})
+
+	t.Run("parses and trims value", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "with_secret.env")
+		content := "TELEGRAM_ENABLED=true\nTELEGRAM_NOTIFY_SECRET=  relay-secret-abc123  \n"
+		if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+			t.Fatalf("Failed to create test config: %v", err)
+		}
+		setBaseDirEnv(t, "/notify/secret/base")
+
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+		if cfg.TelegramNotifySecret != "relay-secret-abc123" {
+			t.Fatalf("TelegramNotifySecret = %q; want relay-secret-abc123", cfg.TelegramNotifySecret)
+		}
+	})
+}
+
 func TestLoadConfigEmailDeliveryAliasesAndFallbackSendmail(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "email_aliases.env")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -676,7 +676,10 @@ func TestParseTelegramNotifySecret(t *testing.T) {
 		}
 	})
 
-	t.Run("parses and trims value", func(t *testing.T) {
+	t.Run("ignored when present", func(t *testing.T) {
+		// The relay secret is no longer read from backup.env; it is provisioned
+		// via TOFU into the immutable identity file. Any value present in the
+		// config must be ignored.
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "with_secret.env")
 		content := "TELEGRAM_ENABLED=true\nTELEGRAM_NOTIFY_SECRET=  relay-secret-abc123  \n"
@@ -689,8 +692,8 @@ func TestParseTelegramNotifySecret(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
 		}
-		if cfg.TelegramNotifySecret != "relay-secret-abc123" {
-			t.Fatalf("TelegramNotifySecret = %q; want relay-secret-abc123", cfg.TelegramNotifySecret)
+		if cfg.TelegramNotifySecret != "" {
+			t.Fatalf("TelegramNotifySecret = %q; the secret must not be read from backup.env", cfg.TelegramNotifySecret)
 		}
 	})
 }

--- a/internal/config/templates/backup.env
+++ b/internal/config/templates/backup.env
@@ -246,7 +246,7 @@ TELEGRAM_ENABLED=false
 BOT_TELEGRAM_TYPE=centralized          # "centralized" or "personal"
 TELEGRAM_BOT_TOKEN=                    # For personal mode only
 TELEGRAM_CHAT_ID=                      # For personal mode only
-TELEGRAM_NOTIFY_SECRET=                # Centralized relay secret shown by the bot at registration; enables secure delivery (bot token never sent to this host). Keep backup.env chmod 600.
+# Centralized relay secret is auto-provisioned and stored under <BASE_DIR>/identity/ (immutable); not configured here.
 
 # Email Notifications
 EMAIL_ENABLED=false

--- a/internal/config/templates/backup.env
+++ b/internal/config/templates/backup.env
@@ -246,6 +246,7 @@ TELEGRAM_ENABLED=false
 BOT_TELEGRAM_TYPE=centralized          # "centralized" or "personal"
 TELEGRAM_BOT_TOKEN=                    # For personal mode only
 TELEGRAM_CHAT_ID=                      # For personal mode only
+TELEGRAM_NOTIFY_SECRET=                # Centralized relay secret shown by the bot at registration; enables secure delivery (bot token never sent to this host). Keep backup.env chmod 600.
 
 # Email Notifications
 EMAIL_ENABLED=false

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -52,38 +52,61 @@ func PersistNotifySecret(ctx context.Context, baseDir, secret string, logger *lo
 	}
 	baseDir = strings.TrimSpace(baseDir)
 	if baseDir == "" {
+		logDebug(logger, "Identity: PersistNotifySecret: empty baseDir, refusing")
 		return fmt.Errorf("base directory is empty; cannot persist notify secret")
 	}
 	secret = strings.TrimSpace(secret)
 	if secret == "" {
+		logDebug(logger, "Identity: PersistNotifySecret: empty secret, refusing")
 		return fmt.Errorf("refusing to persist an empty notify secret")
 	}
 	dir := filepath.Join(baseDir, identityDirName)
 	if err := os.MkdirAll(dir, 0o750); err != nil { // same mode as Detect
+		logDebug(logger, "Identity: PersistNotifySecret: mkdir %s failed: %v", dir, err)
 		return fmt.Errorf("failed to create identity directory %s: %w", dir, err)
 	}
-	return writeIdentityFileWithContext(ctx, filepath.Join(dir, notifySecretFileName), secret+"\n", logger)
+	path := filepath.Join(dir, notifySecretFileName)
+	logDebug(logger, "Identity: PersistNotifySecret: writing immutable secret file %s (len=%d)", path, len(secret))
+	if err := writeIdentityFileWithContext(ctx, path, secret+"\n", logger); err != nil {
+		logDebug(logger, "Identity: PersistNotifySecret: write failed for %s: %v", path, err)
+		return err
+	}
+	logDebug(logger, "Identity: PersistNotifySecret: persisted (0600 + immutable) to %s", path)
+	return nil
 }
 
 // LoadNotifySecret returns the persisted relay secret, or ("", nil) when the file
 // is absent, empty, or fails the format check (junk is ignored rather than fed
 // into the auth header).
-func LoadNotifySecret(baseDir string) (string, error) {
+func LoadNotifySecret(baseDir string, logger ...*logging.Logger) (string, error) {
+	var lg *logging.Logger
+	if len(logger) > 0 {
+		lg = logger[0]
+	}
 	baseDir = strings.TrimSpace(baseDir)
 	if baseDir == "" {
 		return "", nil
 	}
-	data, err := os.ReadFile(filepath.Join(baseDir, identityDirName, notifySecretFileName))
+	path := filepath.Join(baseDir, identityDirName, notifySecretFileName)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			logDebug(lg, "Identity: LoadNotifySecret: no secret file at %s", path)
 			return "", nil
 		}
+		logDebug(lg, "Identity: LoadNotifySecret: read failed for %s: %v", path, err)
 		return "", err
 	}
 	secret := strings.TrimSpace(string(data))
-	if secret == "" || !notifySecretFormat.MatchString(secret) {
+	if secret == "" {
+		logDebug(lg, "Identity: LoadNotifySecret: secret file empty at %s", path)
 		return "", nil
 	}
+	if !notifySecretFormat.MatchString(secret) {
+		logDebug(lg, "Identity: LoadNotifySecret: ignoring malformed secret at %s (len=%d)", path, len(secret))
+		return "", nil
+	}
+	logDebug(lg, "Identity: LoadNotifySecret: loaded secret from %s (len=%d)", path, len(secret))
 	return secret, nil
 }
 

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -25,11 +26,66 @@ import (
 const (
 	identityDirName       = "identity"
 	identityFileName      = ".server_identity"
+	notifySecretFileName  = ".notify_secret"
 	maxProcVersionBytes   = 100
 	maxMachineIDBytes     = 32
 	systemKeyPrefixLength = 8
 	serverIDLength        = 16
 )
+
+// notifySecretFormat matches the server's generate_notify_secret output: lowercase
+// alphanumeric blocks separated by single dashes (e.g. 3h64-dyi8-q3d6-wcm5). It is
+// used only to reject a corrupted file, never to reject server-issued values strictly.
+var notifySecretFormat = regexp.MustCompile(`^[0-9a-z]+(-[0-9a-z]+)*$`)
+
+// NotifySecretPath returns the immutable identity-file path for the relay secret.
+func NotifySecretPath(baseDir string) string {
+	return filepath.Join(strings.TrimSpace(baseDir), identityDirName, notifySecretFileName)
+}
+
+// PersistNotifySecret writes the per-server relay secret into the same immutable
+// identity mechanism used for .server_identity (0600 + chattr +i), reusing
+// writeIdentityFileWithContext. Overwrite-safe: the helper clears +i first.
+func PersistNotifySecret(ctx context.Context, baseDir, secret string, logger *logging.Logger) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	baseDir = strings.TrimSpace(baseDir)
+	if baseDir == "" {
+		return fmt.Errorf("base directory is empty; cannot persist notify secret")
+	}
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return fmt.Errorf("refusing to persist an empty notify secret")
+	}
+	dir := filepath.Join(baseDir, identityDirName)
+	if err := os.MkdirAll(dir, 0o750); err != nil { // same mode as Detect
+		return fmt.Errorf("failed to create identity directory %s: %w", dir, err)
+	}
+	return writeIdentityFileWithContext(ctx, filepath.Join(dir, notifySecretFileName), secret+"\n", logger)
+}
+
+// LoadNotifySecret returns the persisted relay secret, or ("", nil) when the file
+// is absent, empty, or fails the format check (junk is ignored rather than fed
+// into the auth header).
+func LoadNotifySecret(baseDir string) (string, error) {
+	baseDir = strings.TrimSpace(baseDir)
+	if baseDir == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(filepath.Join(baseDir, identityDirName, notifySecretFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	secret := strings.TrimSpace(string(data))
+	if secret == "" || !notifySecretFormat.MatchString(secret) {
+		return "", nil
+	}
+	return secret, nil
+}
 
 // Info contains server identity information.
 type Info struct {

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -61,6 +61,13 @@ func PersistNotifySecret(ctx context.Context, baseDir, secret string, logger *lo
 		logDebug(logger, "Identity: PersistNotifySecret: empty secret, refusing")
 		return fmt.Errorf("refusing to persist an empty notify secret")
 	}
+	// Validate against the SAME format LoadNotifySecret enforces, so a persisted
+	// secret always reloads (otherwise a non-conforming value would be written but
+	// silently dropped on the next run, forcing reprovisioning).
+	if !notifySecretFormat.MatchString(secret) {
+		logDebug(logger, "Identity: PersistNotifySecret: malformed secret, refusing (len=%d)", len(secret))
+		return fmt.Errorf("refusing to persist a malformed notify secret")
+	}
 	dir := filepath.Join(baseDir, identityDirName)
 	if err := os.MkdirAll(dir, 0o750); err != nil { // same mode as Detect
 		logDebug(logger, "Identity: PersistNotifySecret: mkdir %s failed: %v", dir, err)

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"os"
@@ -87,8 +88,13 @@ func LoadNotifySecret(baseDir string, logger ...*logging.Logger) (string, error)
 	if baseDir == "" {
 		return "", nil
 	}
-	path := filepath.Join(baseDir, identityDirName, notifySecretFileName)
-	data, err := os.ReadFile(path)
+	dir := filepath.Join(baseDir, identityDirName)
+	path := filepath.Join(dir, notifySecretFileName)
+	// Read the secret confined to the identity directory via os.Root so the path is
+	// no longer a raw variable sink and a symlink or ".." cannot escape it, resolving
+	// the gosec G304 finding structurally (no #nosec). The basename is a constant; a
+	// missing directory or file still surfaces as os.ErrNotExist below.
+	data, err := readFileUnderRoot(dir, notifySecretFileName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			logDebug(lg, "Identity: LoadNotifySecret: no secret file at %s", path)
@@ -108,6 +114,28 @@ func LoadNotifySecret(baseDir string, logger ...*logging.Logger) (string, error)
 	}
 	logDebug(lg, "Identity: LoadNotifySecret: loaded secret from %s (len=%d)", path, len(secret))
 	return secret, nil
+}
+
+// readFileUnderRoot reads name (a single basename) from dir through an *os.Root on
+// dir, confining the read there at the syscall level: the path is no longer a raw
+// variable sink and a symlink or ".." in name cannot escape the directory. This
+// mirrors checks.readLockFileContent and resolves the gosec G304 finding
+// structurally rather than with a suppression. A missing directory or file
+// surfaces as os.ErrNotExist, matching os.ReadFile.
+func readFileUnderRoot(dir, name string) ([]byte, error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = root.Close() }()
+
+	f, err := root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	return io.ReadAll(f)
 }
 
 // Info contains server identity information.
@@ -431,7 +459,9 @@ func loadServerID(path string, macs []string, logger *logging.Logger) (string, s
 		logDebug(logger, "Identity: identity file stat failed: path=%s err=%v", path, err)
 	}
 
-	data, err := os.ReadFile(path)
+	// Read confined to the identity directory via os.Root (structural gosec G304
+	// fix, no #nosec); see readFileUnderRoot.
+	data, err := readFileUnderRoot(filepath.Dir(path), filepath.Base(path))
 	if err != nil {
 		return "", "", err
 	}
@@ -840,7 +870,9 @@ func maybeUpgradeIdentityFileWithContext(ctx context.Context, path string, serve
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	data, err := os.ReadFile(path)
+	// Read confined to the identity directory via os.Root (structural gosec G304
+	// fix, no #nosec); see readFileUnderRoot.
+	data, err := readFileUnderRoot(filepath.Dir(path), filepath.Base(path))
 	if err != nil {
 		return nil
 	}

--- a/internal/identity/notify_secret_containment_audited_test.go
+++ b/internal/identity/notify_secret_containment_audited_test.go
@@ -1,0 +1,44 @@
+package identity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadNotifySecretContainmentRejectsSymlinkEscape verifies the os.Root-based
+// read in LoadNotifySecret confines access to the identity directory: a
+// .notify_secret that is a symlink escaping the directory is NOT followed, so the
+// outside file's content is never returned. This documents the structural gosec
+// G304 fix (no #nosec) and mirrors checks' lock-read containment audited test.
+func TestLoadNotifySecretContainmentRejectsSymlinkEscape(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// A valid-format secret sitting OUTSIDE the identity directory.
+	outside := filepath.Join(baseDir, "outside_secret")
+	if err := os.WriteFile(outside, []byte("aaaa-bbbb\n"), 0o600); err != nil {
+		t.Fatalf("write outside secret: %v", err)
+	}
+
+	identityDir := filepath.Join(baseDir, identityDirName)
+	if err := os.MkdirAll(identityDir, 0o750); err != nil {
+		t.Fatalf("mkdir identity dir: %v", err)
+	}
+
+	// Point the secret file at a symlink that escapes the identity directory.
+	link := filepath.Join(identityDir, notifySecretFileName)
+	if err := os.Symlink(filepath.Join("..", "outside_secret"), link); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	// Control: a raw os.ReadFile WOULD follow the symlink and read the outside
+	// file; if it does not here, the host blocks symlinks and the test is moot.
+	if raw, rerr := os.ReadFile(link); rerr != nil || string(raw) != "aaaa-bbbb\n" {
+		t.Skipf("host does not follow the symlink via os.ReadFile (err=%v); containment test moot", rerr)
+	}
+
+	got, _ := LoadNotifySecret(baseDir)
+	if got != "" {
+		t.Fatalf("LoadNotifySecret followed an escaping symlink and leaked %q; want empty (containment broken)", got)
+	}
+}

--- a/internal/identity/notify_secret_test.go
+++ b/internal/identity/notify_secret_test.go
@@ -102,3 +102,16 @@ func TestPersistNotifySecretRejectsEmpty(t *testing.T) {
 		t.Fatalf("expected no notify secret file, stat err = %v", err)
 	}
 }
+
+func TestPersistNotifySecretRejectsMalformed(t *testing.T) {
+	baseDir := t.TempDir()
+	// Outside notifySecretFormat (uppercase + space + punctuation): the load path
+	// would drop it, so persist must refuse it to keep the read/write contract
+	// symmetric (a persisted secret always reloads).
+	if err := PersistNotifySecret(context.Background(), baseDir, "Bad Secret!!", nil); err == nil {
+		t.Fatalf("PersistNotifySecret() expected an error for a malformed secret")
+	}
+	if _, err := os.Stat(NotifySecretPath(baseDir)); !os.IsNotExist(err) {
+		t.Fatalf("expected no notify secret file written, stat err = %v", err)
+	}
+}

--- a/internal/identity/notify_secret_test.go
+++ b/internal/identity/notify_secret_test.go
@@ -1,0 +1,104 @@
+package identity
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNotifySecretPath(t *testing.T) {
+	got := NotifySecretPath("/var/lib/proxsave")
+	want := filepath.Join("/var/lib/proxsave", "identity", ".notify_secret")
+	if got != want {
+		t.Fatalf("NotifySecretPath() = %q, want %q", got, want)
+	}
+	if !strings.HasSuffix(got, filepath.Join("identity", ".notify_secret")) {
+		t.Fatalf("NotifySecretPath() = %q; expected to end in identity/.notify_secret", got)
+	}
+}
+
+func TestPersistAndLoadNotifySecret(t *testing.T) {
+	baseDir := t.TempDir()
+	const secret = "3h64-dyi8-q3d6-wcm5"
+
+	if err := PersistNotifySecret(context.Background(), baseDir, secret, nil); err != nil {
+		t.Fatalf("PersistNotifySecret() error = %v", err)
+	}
+
+	got, err := LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret() error = %v", err)
+	}
+	if got != secret {
+		t.Fatalf("LoadNotifySecret() = %q, want %q", got, secret)
+	}
+
+	// The file is created 0600 (immutable attribute is best-effort and skipped
+	// on filesystems/environments that do not support chattr).
+	info, err := os.Stat(NotifySecretPath(baseDir))
+	if err != nil {
+		t.Fatalf("stat notify secret file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("notify secret file mode = %o, want 0600", perm)
+	}
+}
+
+func TestPersistNotifySecretOverwrites(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := PersistNotifySecret(context.Background(), baseDir, "aaaa-bbbb", nil); err != nil {
+		t.Fatalf("first PersistNotifySecret() error = %v", err)
+	}
+	if err := PersistNotifySecret(context.Background(), baseDir, "cccc-dddd", nil); err != nil {
+		t.Fatalf("second PersistNotifySecret() error = %v", err)
+	}
+	got, err := LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret() error = %v", err)
+	}
+	if got != "cccc-dddd" {
+		t.Fatalf("LoadNotifySecret() = %q, want cccc-dddd", got)
+	}
+}
+
+func TestLoadNotifySecretMissing(t *testing.T) {
+	baseDir := t.TempDir()
+	got, err := LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret() error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("LoadNotifySecret() = %q, want empty string when absent", got)
+	}
+}
+
+func TestLoadNotifySecretIgnoresJunk(t *testing.T) {
+	baseDir := t.TempDir()
+	dir := filepath.Join(baseDir, "identity")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".notify_secret"), []byte("not a secret!!"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret() error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("LoadNotifySecret() = %q, want empty string for malformed content", got)
+	}
+}
+
+func TestPersistNotifySecretRejectsEmpty(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := PersistNotifySecret(context.Background(), baseDir, "   ", nil); err == nil {
+		t.Fatalf("PersistNotifySecret() expected an error for an empty secret")
+	}
+	// Nothing must have been written.
+	if _, err := os.Stat(NotifySecretPath(baseDir)); !os.IsNotExist(err) {
+		t.Fatalf("expected no notify secret file, stat err = %v", err)
+	}
+}

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -273,8 +273,14 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 		return "", "", fmt.Errorf("failed to create request: %w", err)
 	}
 	pv := setProxsaveVersionHeader(req)
-	req.Header.Set(proxsaveProvisionHeader, "1") // this is a real provisioning call
-	t.logger.Debug("Telegram: get-chat-id GET (serverID=%q X-Proxsave-Version=%q provisionIntent=1)", t.config.ServerID, pv)
+	// Only ask the server to (re)issue a relay secret when we can actually persist
+	// it (BaseDir set). Otherwise the 200 body's secret is discarded below and every
+	// run would churn a fresh unconfirmed token server-side.
+	provisionIntent := t.config.BaseDir != ""
+	if provisionIntent {
+		req.Header.Set(proxsaveProvisionHeader, "1")
+	}
+	t.logger.Debug("Telegram: get-chat-id GET (serverID=%q X-Proxsave-Version=%q provisionIntent=%v)", t.config.ServerID, pv, provisionIntent)
 
 	// Make request
 	resp, err := t.client.Do(req)

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -30,6 +31,7 @@ type TelegramConfig struct {
 	ChatID        string
 	ServerAPIHost string // For centralized mode
 	ServerID      string // Server identifier for centralized mode
+	NotifySecret  string // Per-server relay secret; when set, use the server-side relay
 }
 
 // TelegramNotifier implements the Notifier interface for Telegram
@@ -128,6 +130,24 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 	if !t.config.Enabled {
 		t.logger.Debug("Telegram notifications disabled")
 		result.Success = false
+		result.Duration = time.Since(startTime)
+		return result, nil
+	}
+
+	// Secure relay path: when a per-server secret is provisioned, the bot
+	// token never leaves the host. The server looks up the chat and sends
+	// the message itself. Falls back to the legacy path when no secret set.
+	if t.config.Mode == TelegramModeCentralized && t.config.NotifySecret != "" {
+		message := t.buildMessage(data)
+		if err := t.sendViaRelay(ctx, message); err != nil {
+			t.logger.Warning("WARNING: Failed to send Telegram notification via relay: %v", err)
+			result.Success = false
+			result.Error = err
+			result.Duration = time.Since(startTime)
+			return result, nil // Non-critical error, don't abort backup
+		}
+		t.logger.Debug("Telegram relay confirmed delivery")
+		result.Success = true
 		result.Duration = time.Since(startTime)
 		return result, nil
 	}
@@ -235,6 +255,63 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 		return "", "", fmt.Errorf("invalid SERVER_ID (HTTP 422)")
 	default:
 		return "", "", fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// sendViaRelay sends a message through the authenticated server-side relay so
+// the bot token never leaves this host. The per-server secret is sent only in
+// the X-Server-Auth header; any returned error string is scrubbed of it.
+func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message string) error {
+	endpoint := strings.TrimRight(t.config.ServerAPIHost, "/") + "/api/notify"
+
+	payload := struct {
+		ServerID string `json:"server_id"`
+		Message  string `json:"message"`
+	}{
+		ServerID: t.config.ServerID,
+		Message:  message,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to encode relay request: %w", err)
+	}
+
+	// 5-second timeout, mirroring fetchCentralizedCredentials.
+	reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, "POST", endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create relay request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Server-Auth", t.config.NotifySecret)
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("relay request failed: %s", logging.RedactSecrets(err.Error(), t.config.NotifySecret))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case 200:
+		return nil
+	case 401, 403:
+		return fmt.Errorf("relay auth rejected (HTTP %d)", resp.StatusCode)
+	case 404:
+		return fmt.Errorf("server unknown (HTTP 404)")
+	case 409:
+		return fmt.Errorf("registration missing (HTTP 409)")
+	case 413:
+		return fmt.Errorf("message too long (HTTP 413)")
+	default:
+		respBody, _ := io.ReadAll(resp.Body)
+		snippet := string(respBody)
+		if len(snippet) > 200 {
+			snippet = snippet[:200]
+		}
+		return fmt.Errorf("relay returned status %d: %s",
+			resp.StatusCode, logging.RedactSecrets(snippet, t.config.NotifySecret))
 	}
 }
 

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tis24dev/proxsave/internal/identity"
 	"github.com/tis24dev/proxsave/internal/logging"
 )
 
@@ -32,6 +33,7 @@ type TelegramConfig struct {
 	ServerAPIHost string // For centralized mode
 	ServerID      string // Server identifier for centralized mode
 	NotifySecret  string // Per-server relay secret; when set, use the server-side relay
+	BaseDir       string // Identity store root for lazy-load / persist of the relay secret
 }
 
 // TelegramNotifier implements the Notifier interface for Telegram
@@ -43,10 +45,11 @@ type TelegramNotifier struct {
 
 // Telegram API response for centralized mode
 type telegramCentralizedResponse struct {
-	BotToken string `json:"bot_token"`
-	ChatID   string `json:"chat_id"`
-	Status   int    `json:"status"`
-	Message  string `json:"message,omitempty"`
+	BotToken     string `json:"bot_token"`
+	ChatID       string `json:"chat_id"`
+	Status       int    `json:"status"`
+	Message      string `json:"message,omitempty"`
+	NotifySecret string `json:"notify_secret"` // TOFU one-time provisioning
 }
 
 // Token and ChatID validation regex patterns
@@ -134,6 +137,18 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 		return result, nil
 	}
 
+	// Lazily adopt a previously provisioned per-server secret from the
+	// immutable identity file so the relay is used without fetching the token.
+	if t.config.Mode == TelegramModeCentralized && t.config.NotifySecret == "" && t.config.BaseDir != "" {
+		if sec, err := identity.LoadNotifySecret(t.config.BaseDir); err != nil {
+			t.logger.Debug("Telegram: could not read persisted relay secret: %v", err)
+		} else if sec != "" {
+			t.config.NotifySecret = sec
+			t.logger.RegisterSecret(sec)
+			t.logger.Debug("Telegram: loaded persisted per-server relay secret")
+		}
+	}
+
 	// Secure relay path: when a per-server secret is provisioned, the bot
 	// token never leaves the host. The server looks up the chat and sends
 	// the message itself. Falls back to the legacy path when no secret set.
@@ -159,13 +174,31 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 	if t.config.Mode == TelegramModeCentralized {
 		t.logger.Debug("Fetching Telegram credentials from central server...")
 		var err error
-		botToken, chatID, err = t.fetchCentralizedCredentials(ctx)
+		botToken, chatID, err = t.fetchCentralizedCredentials(ctx) // may TOFU-provision+persist+set NotifySecret
 		if err != nil {
 			t.logger.Warning("WARNING: Failed to fetch Telegram credentials: %v", err)
 			result.Success = false
 			result.Error = err
 			result.Duration = time.Since(startTime)
 			return result, nil // Non-critical error, don't abort backup
+		}
+
+		// First-run provisioning: if the fetch just delivered a fresh secret,
+		// deliver THIS run via the relay so the new secret is used and the bot
+		// token is not.
+		if t.config.NotifySecret != "" {
+			message := t.buildMessage(data)
+			if err := t.sendViaRelay(ctx, message); err != nil {
+				t.logger.Warning("WARNING: Failed to send Telegram notification via relay: %v", err)
+				result.Success = false
+				result.Error = err
+				result.Duration = time.Since(startTime)
+				return result, nil // Non-critical error, don't abort backup
+			}
+			t.logger.Debug("Telegram relay confirmed delivery (first-run provisioning)")
+			result.Success = true
+			result.Duration = time.Since(startTime)
+			return result, nil
 		}
 	}
 
@@ -234,6 +267,28 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 		var response telegramCentralizedResponse
 		if err := json.Unmarshal(body, &response); err != nil {
 			return "", "", fmt.Errorf("failed to parse response: %w", err)
+		}
+
+		// TOFU: the server rides the per-server relay secret back on this 200
+		// the first time we are linked and have no secret yet. Persist it into
+		// the immutable identity file and adopt it, independent of the bot
+		// token's presence (Phase-3-ready). The secret is never logged.
+		if response.NotifySecret != "" && t.config.NotifySecret == "" && t.config.BaseDir != "" {
+			provisioned := strings.TrimSpace(response.NotifySecret)
+			if provisioned != "" {
+				t.logger.RegisterSecret(provisioned) // mask before any I/O can echo it
+				if err := identity.PersistNotifySecret(ctx, t.config.BaseDir, provisioned, t.logger); err != nil {
+					t.logger.Warning("WARNING: failed to persist provisioned relay secret: %v", err)
+				} else {
+					t.config.NotifySecret = provisioned
+					t.logger.Debug("Telegram: provisioned and persisted per-server relay secret")
+				}
+			}
+		}
+
+		// With a relay secret in hand, the bot token is irrelevant for this run.
+		if t.config.NotifySecret != "" {
+			return response.BotToken, response.ChatID, nil
 		}
 
 		// Validate credentials

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -23,8 +23,10 @@ const proxsaveVersionHeader = "X-Proxsave-Version"
 
 // setProxsaveVersionHeader stamps an outbound central-server request with the
 // normalized ProxSave version (e.g. "0.28.0").
-func setProxsaveVersionHeader(req *http.Request) {
-	req.Header.Set(proxsaveVersionHeader, version.String())
+func setProxsaveVersionHeader(req *http.Request) string {
+	v := version.String()
+	req.Header.Set(proxsaveVersionHeader, v)
+	return v
 }
 
 // TelegramMode represents the Telegram bot configuration mode
@@ -148,15 +150,21 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 		return result, nil
 	}
 
+	if t.config.Mode == TelegramModeCentralized {
+		t.logger.Debug("Telegram: send start (mode=centralized serverID=%q secretPreloaded=%v baseDir=%q)", t.config.ServerID, t.config.NotifySecret != "", t.config.BaseDir)
+	}
+
 	// Lazily adopt a previously provisioned per-server secret from the
 	// immutable identity file so the relay is used without fetching the token.
 	if t.config.Mode == TelegramModeCentralized && t.config.NotifySecret == "" && t.config.BaseDir != "" {
-		if sec, err := identity.LoadNotifySecret(t.config.BaseDir); err != nil {
+		if sec, err := identity.LoadNotifySecret(t.config.BaseDir, t.logger); err != nil {
 			t.logger.Debug("Telegram: could not read persisted relay secret: %v", err)
 		} else if sec != "" {
 			t.config.NotifySecret = sec
 			t.logger.RegisterSecret(sec)
-			t.logger.Debug("Telegram: loaded persisted per-server relay secret")
+			t.logger.Debug("Telegram: loaded persisted per-server relay secret (len=%d)", len(sec))
+		} else {
+			t.logger.Debug("Telegram: no persisted relay secret on disk; will attempt provisioning during fetch")
 		}
 	}
 
@@ -164,6 +172,7 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 	// token never leaves the host. The server looks up the chat and sends
 	// the message itself. Falls back to the legacy path when no secret set.
 	if t.config.Mode == TelegramModeCentralized && t.config.NotifySecret != "" {
+		t.logger.Debug("Telegram: using server-side relay path (bot token stays on host)")
 		message := t.buildMessage(data)
 		if err := t.sendViaRelay(ctx, message); err != nil {
 			t.logger.Warning("WARNING: Failed to send Telegram notification via relay: %v", err)
@@ -198,6 +207,7 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 		// deliver THIS run via the relay so the new secret is used and the bot
 		// token is not.
 		if t.config.NotifySecret != "" {
+			t.logger.Debug("Telegram: fetch provisioned a fresh relay secret; relaying this run")
 			message := t.buildMessage(data)
 			if err := t.sendViaRelay(ctx, message); err != nil {
 				t.logger.Warning("WARNING: Failed to send Telegram notification via relay: %v", err)
@@ -227,6 +237,7 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 	message := t.buildMessage(data)
 
 	// Send to Telegram API
+	t.logger.Debug("Telegram: legacy direct send via bot token (token leaves host; mode=%s)", t.config.Mode)
 	err := t.sendToTelegram(ctx, botToken, chatID, message)
 	if err != nil {
 		t.logger.Warning("WARNING: Failed to send Telegram notification: %v", err)
@@ -257,7 +268,8 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create request: %w", err)
 	}
-	setProxsaveVersionHeader(req)
+	pv := setProxsaveVersionHeader(req)
+	t.logger.Debug("Telegram: get-chat-id GET (serverID=%q X-Proxsave-Version=%q)", t.config.ServerID, pv)
 
 	// Make request
 	resp, err := t.client.Do(req)
@@ -280,6 +292,7 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 		if err := json.Unmarshal(body, &response); err != nil {
 			return "", "", fmt.Errorf("failed to parse response: %w", err)
 		}
+		t.logger.Debug("Telegram: get-chat-id 200 (notifySecretPresent=%v botTokenPresent=%v chatIDPresent=%v)", response.NotifySecret != "", response.BotToken != "", response.ChatID != "")
 
 		// TOFU: the server rides the per-server relay secret back on this 200
 		// the first time we are linked and have no secret yet. Persist it into
@@ -353,7 +366,8 @@ func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message string) err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Server-Auth", t.config.NotifySecret)
-	setProxsaveVersionHeader(req)
+	pv := setProxsaveVersionHeader(req)
+	t.logger.Debug("Telegram: relay POST %s (serverID=%q msgLen=%d X-Proxsave-Version=%q)", endpoint, t.config.ServerID, len(message), pv)
 
 	resp, err := t.client.Do(req)
 	if err != nil {
@@ -363,6 +377,7 @@ func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message string) err
 
 	switch resp.StatusCode {
 	case 200:
+		t.logger.Debug("Telegram: relay delivered (HTTP 200)")
 		return nil
 	case 401, 403:
 		return fmt.Errorf("relay auth rejected (HTTP %d)", resp.StatusCode)

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -21,6 +21,10 @@ import (
 // server can gate version-specific behavior (e.g. the one-time secret handoff).
 const proxsaveVersionHeader = "X-Proxsave-Version"
 
+// proxsaveProvisionHeader marks a real provisioning call (issue/re-issue the relay
+// secret). Sent ONLY by the two provisioning paths, never the bare status probe.
+const proxsaveProvisionHeader = "X-Proxsave-Provision"
+
 // setProxsaveVersionHeader stamps an outbound central-server request with the
 // normalized ProxSave version (e.g. "0.28.0").
 func setProxsaveVersionHeader(req *http.Request) string {
@@ -269,7 +273,8 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 		return "", "", fmt.Errorf("failed to create request: %w", err)
 	}
 	pv := setProxsaveVersionHeader(req)
-	t.logger.Debug("Telegram: get-chat-id GET (serverID=%q X-Proxsave-Version=%q)", t.config.ServerID, pv)
+	req.Header.Set(proxsaveProvisionHeader, "1") // this is a real provisioning call
+	t.logger.Debug("Telegram: get-chat-id GET (serverID=%q X-Proxsave-Version=%q provisionIntent=1)", t.config.ServerID, pv)
 
 	// Make request
 	resp, err := t.client.Do(req)
@@ -294,19 +299,20 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 		}
 		t.logger.Debug("Telegram: get-chat-id 200 (notifySecretPresent=%v botTokenPresent=%v chatIDPresent=%v)", response.NotifySecret != "", response.BotToken != "", response.ChatID != "")
 
-		// TOFU: the server rides the per-server relay secret back on this 200
-		// the first time we are linked and have no secret yet. Persist it into
-		// the immutable identity file and adopt it, independent of the bot
-		// token's presence (Phase-3-ready). The secret is never logged.
-		if response.NotifySecret != "" && t.config.NotifySecret == "" && t.config.BaseDir != "" {
-			provisioned := strings.TrimSpace(response.NotifySecret)
-			if provisioned != "" {
-				t.logger.RegisterSecret(provisioned) // mask before any I/O can echo it
-				if err := identity.PersistNotifySecret(ctx, t.config.BaseDir, provisioned, t.logger); err != nil {
-					t.logger.Warning("WARNING: failed to persist provisioned relay secret: %v", err)
-				} else {
-					t.config.NotifySecret = provisioned
-					t.logger.Debug("Telegram: provisioned and persisted per-server relay secret")
+		// Adopt-on-token-present: whenever a 200 carries a notify_secret, the
+		// server wants the client to (re)adopt it, so we OVERWRITE any existing
+		// persisted secret (no idempotent skip, or a re-issued token would be
+		// stranded) and then CONFIRM it. When the body carries no token we keep
+		// whatever we already have. The secret is never logged.
+		if provisioned := strings.TrimSpace(response.NotifySecret); provisioned != "" && t.config.BaseDir != "" {
+			t.logger.RegisterSecret(provisioned) // mask before any I/O can echo it
+			if err := identity.PersistNotifySecret(ctx, t.config.BaseDir, provisioned, t.logger); err != nil {
+				t.logger.Warning("WARNING: failed to persist provisioned relay secret: %v", err)
+			} else {
+				t.config.NotifySecret = provisioned // adopt in-memory for this run
+				t.logger.Debug("Telegram: adopted+persisted per-server relay secret (overwrite)")
+				if err := confirmTelegramRelaySecret(ctx, t.client, t.config.ServerAPIHost, t.config.ServerID, provisioned, t.logger); err != nil {
+					t.logger.Debug("Telegram: relay secret confirm failed (non-fatal): %v", err)
 				}
 			}
 		}

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -14,7 +14,18 @@ import (
 
 	"github.com/tis24dev/proxsave/internal/identity"
 	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/version"
 )
+
+// proxsaveVersionHeader carries the running ProxSave version so the central
+// server can gate version-specific behavior (e.g. the one-time secret handoff).
+const proxsaveVersionHeader = "X-Proxsave-Version"
+
+// setProxsaveVersionHeader stamps an outbound central-server request with the
+// normalized ProxSave version (e.g. "0.28.0").
+func setProxsaveVersionHeader(req *http.Request) {
+	req.Header.Set(proxsaveVersionHeader, version.String())
+}
 
 // TelegramMode represents the Telegram bot configuration mode
 type TelegramMode string
@@ -246,6 +257,7 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create request: %w", err)
 	}
+	setProxsaveVersionHeader(req)
 
 	// Make request
 	resp, err := t.client.Do(req)
@@ -341,6 +353,7 @@ func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message string) err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Server-Auth", t.config.NotifySecret)
+	setProxsaveVersionHeader(req)
 
 	resp, err := t.client.Do(req)
 	if err != nil {

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,11 @@ import (
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/version"
 )
+
+// errRelayAuthRejected signals the relay rejected our per-server secret (HTTP
+// 401/403): the secret is stale or rotated and should be dropped + reprovisioned
+// rather than treated as a permanent delivery failure.
+var errRelayAuthRejected = errors.New("relay auth rejected")
 
 // proxsaveVersionHeader carries the running ProxSave version so the central
 // server can gate version-specific behavior (e.g. the one-time secret handoff).
@@ -178,17 +184,26 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 	if t.config.Mode == TelegramModeCentralized && t.config.NotifySecret != "" {
 		t.logger.Debug("Telegram: using server-side relay path (bot token stays on host)")
 		message := t.buildMessage(data)
-		if err := t.sendViaRelay(ctx, message); err != nil {
+		err := t.sendViaRelay(ctx, message)
+		if err == nil {
+			t.logger.Debug("Telegram relay confirmed delivery")
+			result.Success = true
+			result.Duration = time.Since(startTime)
+			return result, nil
+		}
+		if !errors.Is(err, errRelayAuthRejected) {
 			t.logger.Warning("WARNING: Failed to send Telegram notification via relay: %v", err)
 			result.Success = false
 			result.Error = err
 			result.Duration = time.Since(startTime)
 			return result, nil // Non-critical error, don't abort backup
 		}
-		t.logger.Debug("Telegram relay confirmed delivery")
-		result.Success = true
-		result.Duration = time.Since(startTime)
-		return result, nil
+		// The relay rejected our per-server secret (stale/rotated). Drop it and fall
+		// through to the fetch path below, which reprovisions a fresh secret and
+		// relays this run (or falls back to the legacy bot-token path). Bounded: the
+		// fetch path retries the relay at most once and never loops back here.
+		t.logger.Warning("Telegram: relay auth rejected; dropping stale relay secret and reprovisioning")
+		t.config.NotifySecret = ""
 	}
 
 	// Get bot token and chat ID (fetch if centralized mode)
@@ -392,7 +407,7 @@ func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message string) err
 		t.logger.Debug("Telegram: relay delivered (HTTP 200)")
 		return nil
 	case 401, 403:
-		return fmt.Errorf("relay auth rejected (HTTP %d)", resp.StatusCode)
+		return fmt.Errorf("%w (HTTP %d)", errRelayAuthRejected, resp.StatusCode)
 	case 404:
 		return fmt.Errorf("server unknown (HTTP 404)")
 	case 409:

--- a/internal/notify/telegram_confirm_test.go
+++ b/internal/notify/telegram_confirm_test.go
@@ -1,0 +1,118 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+	"github.com/tis24dev/proxsave/internal/version"
+)
+
+// TestConfirmTelegramRelaySecretPostsTokenAndVersion verifies the phase-2 POST
+// carries the token in X-Server-Auth, the version header, and a JSON body with
+// the server_id, returns nil on 200, and never logs the plaintext token.
+func TestConfirmTelegramRelaySecretPostsTokenAndVersion(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
+
+	var gotAuth, gotVersion, gotBody, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("X-Server-Auth")
+		gotVersion = r.Header.Get("X-Proxsave-Version")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	err := confirmTelegramRelaySecret(context.Background(), http.DefaultClient, server.URL, "server-123", provisionTestSecret, logger)
+	if err != nil {
+		t.Fatalf("confirmTelegramRelaySecret error = %v, want nil", err)
+	}
+	if gotPath != "/api/confirm-secret" {
+		t.Fatalf("path = %q, want /api/confirm-secret", gotPath)
+	}
+	if gotAuth != provisionTestSecret {
+		t.Fatalf("X-Server-Auth = %q, want %q", gotAuth, provisionTestSecret)
+	}
+	if gotVersion != version.String() {
+		t.Fatalf("X-Proxsave-Version = %q, want %q", gotVersion, version.String())
+	}
+	if !strings.Contains(gotBody, `"server_id":"server-123"`) {
+		t.Fatalf("body = %q, want server_id server-123", gotBody)
+	}
+	if strings.Contains(buf.String(), provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into log output:\n%s", buf.String())
+	}
+}
+
+// TestConfirmTelegramRelaySecretNonFatalOnReject verifies a rejecting status
+// yields a non-nil error (the caller treats it as non-fatal) without panicking.
+func TestConfirmTelegramRelaySecretNonFatalOnReject(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+
+	for _, code := range []int{http.StatusForbidden, http.StatusInternalServerError} {
+		client := &http.Client{
+			Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: code,
+					Body:       io.NopCloser(strings.NewReader(`{"error":"nope"}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		}
+		err := confirmTelegramRelaySecret(context.Background(), client, "https://central.test", "server-123", provisionTestSecret, logger)
+		if err == nil {
+			t.Fatalf("expected error for HTTP %d, got nil", code)
+		}
+	}
+}
+
+// TestConfirmTelegramRelaySecretRedactsSecretInError verifies a transport error
+// that echoes the secret is masked before being returned.
+func TestConfirmTelegramRelaySecretRedactsSecretInError(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial failed leaking %s in the message", provisionTestSecret)
+		}),
+	}
+	err := confirmTelegramRelaySecret(context.Background(), client, "https://central.test", "server-123", provisionTestSecret, logger)
+	if err == nil {
+		t.Fatalf("expected a transport error, got nil")
+	}
+	if strings.Contains(err.Error(), provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into returned error: %v", err)
+	}
+	if !strings.Contains(err.Error(), logging.MaskSecret(provisionTestSecret)) {
+		t.Fatalf("masked secret not found in returned error: %v", err)
+	}
+}
+
+// TestConfirmTelegramRelaySecretEmptyInputs verifies empty secret or serverID
+// short-circuits with an error and never issues an HTTP request.
+func TestConfirmTelegramRelaySecretEmptyInputs(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("no HTTP request must be made for empty inputs; got %s", req.URL.Path)
+			return nil, nil
+		}),
+	}
+
+	if err := confirmTelegramRelaySecret(context.Background(), client, "https://central.test", "server-123", "", logger); err == nil {
+		t.Fatalf("expected error for empty secret, got nil")
+	}
+	if err := confirmTelegramRelaySecret(context.Background(), client, "https://central.test", "", provisionTestSecret, logger); err == nil {
+		t.Fatalf("expected error for empty serverID, got nil")
+	}
+}

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -63,6 +63,7 @@ func CheckTelegramRegistration(ctx context.Context, serverAPIHost, serverID stri
 		logTelegramRegistrationDebug(logger, "Telegram registration: failed to create request: %v", err)
 		return TelegramRegistrationStatus{Message: "Failed to create HTTP request", Error: err}
 	}
+	setProxsaveVersionHeader(req)
 	logTelegramRegistrationDebug(logger, "Telegram registration: performing HTTP request (method=%s host=%s path=%s)", req.Method, req.URL.Host, req.URL.Path)
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -45,17 +45,20 @@ type TelegramRegistrationStatus struct {
 const StatusCodeMissingServerID = -1
 
 // TelegramProvisionOutcome records what the best-effort persist+confirm phase did
-// after a 200. It NEVER alters the returned registration Status. NotApplicable is
-// the zero value, so a stub building TelegramRegistrationResult{Status:...} on a
-// 200 classifies as a clean link.
+// after a 200. It NEVER alters the returned registration Status, and the classifier
+// consults it ONLY on a 200. NotApplicable is the zero value, reserved for a
+// non-200 result; TelegramProvisionClean is the explicit "200 linked cleanly, no
+// provisioning action required" outcome. A 200-only stub that leaves the zero value
+// still classifies as a clean link via the classifier's default case.
 type TelegramProvisionOutcome int
 
 const (
-	TelegramProvisionNotApplicable TelegramProvisionOutcome = iota // non-200; also the 200-only stub default (see type doc)
+	TelegramProvisionNotApplicable TelegramProvisionOutcome = iota // non-200 result (zero value); Provision is consulted only on a 200
 	TelegramProvisionNoToken                                       // 200, server issued no token
 	TelegramProvisionConfirmed                                     // persisted AND confirmed
 	TelegramProvisionPersistFailed                                 // empty baseDir, or persist failed -> no confirm
 	TelegramProvisionConfirmFailed                                 // persisted, confirm POST failed
+	TelegramProvisionClean                                         // 200, clean link with no provisioning action required
 )
 
 // TelegramRegistrationResult bundles the public status with the provision outcome.

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tis24dev/proxsave/internal/identity"
 	"github.com/tis24dev/proxsave/internal/logging"
 )
 
@@ -36,8 +38,24 @@ type TelegramRegistrationStatus struct {
 	Error   error
 }
 
-// CheckTelegramRegistration checks the registration status on the centralized server.
-func CheckTelegramRegistration(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) TelegramRegistrationStatus {
+// parseTelegramNotifySecret lifts the one-time relay secret out of a get-chat-id
+// body. Best-effort: a non-JSON or secret-less body yields "".
+func parseTelegramNotifySecret(body []byte) string {
+	var parsed struct {
+		NotifySecret string `json:"notify_secret"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.NotifySecret)
+}
+
+// checkTelegramRegistrationWithSecret is the single shared implementation of the
+// get-chat-id handshake (5s timeout, X-Proxsave-Version header). It returns the
+// public status AND, on a 200, the one-time notify_secret parsed from the body.
+// The secret is registered with the logger BEFORE the body-preview line below, so
+// the masker scrubs it from every subsequent log line for ALL callers.
+func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) (TelegramRegistrationStatus, string) {
 	logTelegramRegistrationDebug(logger, "Telegram registration: start (serverAPIHost=%q serverID=%q len=%d)", serverAPIHost, serverID, len(serverID))
 
 	if serverID == "" {
@@ -46,7 +64,7 @@ func CheckTelegramRegistration(ctx context.Context, serverAPIHost, serverID stri
 			Code:    0,
 			Message: "SERVER_ID not available",
 			Error:   fmt.Errorf("server ID missing"),
-		}
+		}, ""
 	}
 
 	baseHost := strings.TrimRight(serverAPIHost, "/")
@@ -61,40 +79,82 @@ func CheckTelegramRegistration(ctx context.Context, serverAPIHost, serverID stri
 	req, err := http.NewRequestWithContext(reqCtx, "GET", apiURL, nil)
 	if err != nil {
 		logTelegramRegistrationDebug(logger, "Telegram registration: failed to create request: %v", err)
-		return TelegramRegistrationStatus{Message: "Failed to create HTTP request", Error: err}
+		return TelegramRegistrationStatus{Message: "Failed to create HTTP request", Error: err}, ""
 	}
-	setProxsaveVersionHeader(req)
+	setProxsaveVersionHeader(req) // keep X-Proxsave-Version on ALL get-chat-id requests
 	logTelegramRegistrationDebug(logger, "Telegram registration: performing HTTP request (method=%s host=%s path=%s)", req.Method, req.URL.Host, req.URL.Path)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		logTelegramRegistrationDebug(logger, "Telegram registration: request failed: %v", err)
-		return TelegramRegistrationStatus{Message: "Connection failed", Error: err}
+		return TelegramRegistrationStatus{Message: "Connection failed", Error: err}, ""
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
+
+	// SECRET-IN-LOG GUARD: on a 200, parse + register the one-time secret BEFORE
+	// the body-preview line so the masker scrubs it (and every later line).
+	var secret string
+	if resp.StatusCode == http.StatusOK {
+		secret = parseTelegramNotifySecret(body)
+		if secret != "" && logger != nil {
+			logger.RegisterSecret(secret)
+		}
+	}
+
 	logTelegramRegistrationDebug(logger, "Telegram registration: response status=%d bodyBytes=%d bodyPreview=%q", resp.StatusCode, len(body), truncateTelegramRegistrationBody(body, 200))
 
 	switch resp.StatusCode {
 	case 200:
 		logTelegramRegistrationDebug(logger, "Telegram registration: status 200 (active)")
-		return TelegramRegistrationStatus{Code: 200, Message: "200 - Registration active"}
+		return TelegramRegistrationStatus{Code: 200, Message: "200 - Registration active"}, secret
 	case 403:
 		logTelegramRegistrationDebug(logger, "Telegram registration: status 403 (bot not started / first contact)")
-		return TelegramRegistrationStatus{Code: 403, Message: "403 - Start the bot and send the Server ID", Error: fmt.Errorf("%s", body)}
+		return TelegramRegistrationStatus{Code: 403, Message: "403 - Start the bot and send the Server ID", Error: fmt.Errorf("%s", body)}, ""
 	case 409:
 		logTelegramRegistrationDebug(logger, "Telegram registration: status 409 (missing registration)")
-		return TelegramRegistrationStatus{Code: 409, Message: "409 - Registration missing on the bot", Error: fmt.Errorf("%s", body)}
+		return TelegramRegistrationStatus{Code: 409, Message: "409 - Registration missing on the bot", Error: fmt.Errorf("%s", body)}, ""
 	case 422:
 		logTelegramRegistrationDebug(logger, "Telegram registration: status 422 (invalid server ID)")
-		return TelegramRegistrationStatus{Code: 422, Message: "422 - Invalid Server ID", Error: fmt.Errorf("%s", body)}
+		return TelegramRegistrationStatus{Code: 422, Message: "422 - Invalid Server ID", Error: fmt.Errorf("%s", body)}, ""
 	default:
 		logTelegramRegistrationDebug(logger, "Telegram registration: unexpected status %d", resp.StatusCode)
 		return TelegramRegistrationStatus{
 			Code:    resp.StatusCode,
 			Message: fmt.Sprintf("%d - Unexpected response: %s", resp.StatusCode, string(body)),
 			Error:   fmt.Errorf("unexpected status %d", resp.StatusCode),
-		}
+		}, ""
 	}
+}
+
+// CheckTelegramRegistration checks the registration status on the centralized
+// server. Signature and behavior are unchanged; it does not provision the relay
+// secret (see CheckTelegramRegistrationAndProvision).
+func CheckTelegramRegistration(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) TelegramRegistrationStatus {
+	status, _ := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, logger)
+	return status
+}
+
+// CheckTelegramRegistrationAndProvision performs the same handshake and, on a 200
+// that carries a one-time notify_secret, persists it into the immutable identity
+// store so the subsequent Send in this same run relays through the server instead
+// of leaking the bot token. The returned status is identical to
+// CheckTelegramRegistration's; provisioning is best-effort and idempotent, and a
+// persist failure is logged and NEVER changes the returned status.
+func CheckTelegramRegistrationAndProvision(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) TelegramRegistrationStatus {
+	status, secret := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, logger)
+	if status.Code != 200 || secret == "" || strings.TrimSpace(baseDir) == "" {
+		return status
+	}
+	// Idempotent: never clobber a secret already on disk.
+	if existing, _ := identity.LoadNotifySecret(baseDir); existing != "" {
+		return status
+	}
+	if err := identity.PersistNotifySecret(ctx, baseDir, secret, logger); err != nil {
+		logTelegramRegistrationDebug(logger, "Telegram registration: failed to persist provisioned relay secret: %v", err)
+		return status // non-fatal: status unchanged
+	}
+	logTelegramRegistrationDebug(logger, "Telegram registration: provisioned and persisted per-server relay secret")
+	return status
 }

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -76,6 +76,20 @@ func parseTelegramNotifySecret(body []byte) string {
 	return strings.TrimSpace(parsed.NotifySecret)
 }
 
+// parseTelegramBotToken lifts the bot token out of a get-chat-id body so it can be
+// registered with the logger's masker BEFORE any raw body preview is logged. The
+// same provisioning endpoint returns bot_token on a 200, so without this it would
+// leak into debug logs. Best-effort: a non-JSON or token-less body yields "".
+func parseTelegramBotToken(body []byte) string {
+	var parsed struct {
+		BotToken string `json:"bot_token"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.BotToken)
+}
+
 // checkTelegramRegistrationWithSecret is the single shared implementation of the
 // get-chat-id handshake (5s timeout, X-Proxsave-Version header). It returns the
 // public status AND, on a 200, the notify_secret parsed from the body. The secret
@@ -132,6 +146,14 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 		secret = parseTelegramNotifySecret(body)
 		if secret != "" && logger != nil {
 			logger.RegisterSecret(secret)
+		}
+		// The same 200 body also carries bot_token; register it BEFORE the preview
+		// line below so the masker scrubs it (and every later line) rather than
+		// dumping it raw.
+		if logger != nil {
+			if botToken := parseTelegramBotToken(body); botToken != "" {
+				logger.RegisterSecret(botToken)
+			}
 		}
 		logTelegramRegistrationDebug(logger, "Telegram registration: 200 body parsed (notifySecretPresent=%v len=%d)", secret != "", len(secret))
 	}

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -52,10 +53,12 @@ func parseTelegramNotifySecret(body []byte) string {
 
 // checkTelegramRegistrationWithSecret is the single shared implementation of the
 // get-chat-id handshake (5s timeout, X-Proxsave-Version header). It returns the
-// public status AND, on a 200, the one-time notify_secret parsed from the body.
-// The secret is registered with the logger BEFORE the body-preview line below, so
-// the masker scrubs it from every subsequent log line for ALL callers.
-func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) (TelegramRegistrationStatus, string) {
+// public status AND, on a 200, the notify_secret parsed from the body. The secret
+// is registered with the logger BEFORE the body-preview line below, so the masker
+// scrubs it from every subsequent log line for ALL callers. When provision is
+// true it also sends the provision-intent header so the server may (re)issue a
+// token; the bare status probe passes false and never churns the relay secret.
+func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, serverID string, provision bool, logger *logging.Logger) (TelegramRegistrationStatus, string) {
 	logTelegramRegistrationDebug(logger, "Telegram registration: start (serverAPIHost=%q serverID=%q len=%d)", serverAPIHost, serverID, len(serverID))
 
 	if serverID == "" {
@@ -82,7 +85,10 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 		return TelegramRegistrationStatus{Message: "Failed to create HTTP request", Error: err}, ""
 	}
 	pv := setProxsaveVersionHeader(req) // keep X-Proxsave-Version on ALL get-chat-id requests
-	logTelegramRegistrationDebug(logger, "Telegram registration: X-Proxsave-Version=%q", pv)
+	if provision {
+		req.Header.Set(proxsaveProvisionHeader, "1")
+	}
+	logTelegramRegistrationDebug(logger, "Telegram registration: provisionIntent=%v X-Proxsave-Version=%q", provision, pv)
 	logTelegramRegistrationDebug(logger, "Telegram registration: performing HTTP request (method=%s host=%s path=%s)", req.Method, req.URL.Host, req.URL.Path)
 
 	resp, err := http.DefaultClient.Do(req)
@@ -131,35 +137,80 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 }
 
 // CheckTelegramRegistration checks the registration status on the centralized
-// server. Signature and behavior are unchanged; it does not provision the relay
-// secret (see CheckTelegramRegistrationAndProvision).
+// server. Signature and behavior are unchanged; it is the bare status probe and
+// sends NO provision-intent header, so it never issues/re-issues the relay secret
+// (see CheckTelegramRegistrationAndProvision).
 func CheckTelegramRegistration(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) TelegramRegistrationStatus {
-	status, _ := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, logger)
+	status, _ := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, false, logger)
 	return status
 }
 
-// CheckTelegramRegistrationAndProvision performs the same handshake and, on a 200
-// that carries a one-time notify_secret, persists it into the immutable identity
-// store so the subsequent Send in this same run relays through the server instead
-// of leaking the bot token. The returned status is identical to
-// CheckTelegramRegistration's; provisioning is best-effort and idempotent, and a
-// persist failure is logged and NEVER changes the returned status.
+// CheckTelegramRegistrationAndProvision performs the same handshake AS a real
+// provisioning call (provision-intent header set) and, on a 200 that carries a
+// notify_secret, OVERWRITES the persisted secret and CONFIRMS it back to the
+// server so the subsequent Send in this same run relays through the server
+// instead of leaking the bot token. The server returns a token ONLY when it wants
+// the client to (re)adopt it, so there is no idempotent skip. The returned status
+// is identical to CheckTelegramRegistration's; persist and confirm are
+// best-effort and NEVER change the returned status.
 func CheckTelegramRegistrationAndProvision(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) TelegramRegistrationStatus {
-	status, secret := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, logger)
+	status, secret := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, true, logger)
 	if status.Code != 200 || secret == "" || strings.TrimSpace(baseDir) == "" {
 		logTelegramRegistrationDebug(logger, "Telegram registration: skip provisioning (statusCode=%d secretPresent=%v baseDir=%q)", status.Code, secret != "", baseDir)
 		return status
 	}
-	// Idempotent: never clobber a secret already on disk.
-	if existing, _ := identity.LoadNotifySecret(baseDir, logger); existing != "" {
-		logTelegramRegistrationDebug(logger, "Telegram registration: relay secret already persisted (len=%d), skipping provisioning", len(existing))
-		return status
-	}
-	logTelegramRegistrationDebug(logger, "Telegram registration: provisioning relay secret -> %s", identity.NotifySecretPath(baseDir))
+	// Adopt-on-token-present: OVERWRITE (the server returns a token ONLY when it
+	// wants the client to (re)adopt it). No idempotent skip, or a re-issue strands.
+	// secret was already RegisterSecret'd in the helper on the 200 branch.
+	logTelegramRegistrationDebug(logger, "Telegram registration: provisioning relay secret (overwrite) -> %s", identity.NotifySecretPath(baseDir))
 	if err := identity.PersistNotifySecret(ctx, baseDir, secret, logger); err != nil {
 		logTelegramRegistrationDebug(logger, "Telegram registration: failed to persist provisioned relay secret: %v", err)
-		return status // non-fatal: status unchanged
+		return status // non-fatal: do NOT confirm; server re-issues next run
 	}
-	logTelegramRegistrationDebug(logger, "Telegram registration: provisioned and persisted per-server relay secret")
+	if err := confirmTelegramRelaySecret(ctx, http.DefaultClient, serverAPIHost, serverID, secret, logger); err != nil {
+		logTelegramRegistrationDebug(logger, "Telegram registration: relay secret confirm failed (non-fatal): %v", err)
+	}
 	return status
+}
+
+// confirmTelegramRelaySecret completes phase 2: POST the freshly adopted relay
+// token back to /api/confirm-secret (X-Server-Auth: secret) so the server marks
+// it confirmed and stops re-issuing. The client param lets the fetch path reuse
+// the notifier's t.client (and its test transport); nil falls back to
+// http.DefaultClient. Best-effort and NON-FATAL: failures are logged (never the
+// secret) and the server re-issues next run. Transport errors are redacted.
+func confirmTelegramRelaySecret(ctx context.Context, client *http.Client, serverAPIHost, serverID, secret string, logger *logging.Logger) error {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if strings.TrimSpace(secret) == "" || strings.TrimSpace(serverID) == "" {
+		return fmt.Errorf("confirm: missing secret or serverID")
+	}
+	endpoint := strings.TrimRight(serverAPIHost, "/") + "/api/confirm-secret"
+	body, err := json.Marshal(struct {
+		ServerID string `json:"server_id"`
+	}{ServerID: serverID})
+	if err != nil {
+		return fmt.Errorf("confirm: encode failed: %w", err)
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, "POST", endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("confirm: create request failed: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Server-Auth", secret)
+	pv := setProxsaveVersionHeader(req)
+	logTelegramRegistrationDebug(logger, "Telegram: confirm-secret POST %s (serverID=%q X-Proxsave-Version=%q)", endpoint, serverID, pv)
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("confirm: request failed: %s", logging.RedactSecrets(err.Error(), secret))
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		logTelegramRegistrationDebug(logger, "Telegram: confirm-secret accepted (HTTP 200)")
+		return nil
+	}
+	return fmt.Errorf("confirm: server rejected (HTTP %d)", resp.StatusCode)
 }

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -39,6 +39,11 @@ type TelegramRegistrationStatus struct {
 	Error   error
 }
 
+// StatusCodeMissingServerID is a sentinel (non-HTTP, negative) status Code set when
+// the local server identity is missing, so the classifier can give identity-specific
+// guidance instead of generic connectivity copy. Real transport failures keep Code 0.
+const StatusCodeMissingServerID = -1
+
 // TelegramProvisionOutcome records what the best-effort persist+confirm phase did
 // after a 200. It NEVER alters the returned registration Status. NotApplicable is
 // the zero value, so a stub building TelegramRegistrationResult{Status:...} on a
@@ -46,7 +51,7 @@ type TelegramRegistrationStatus struct {
 type TelegramProvisionOutcome int
 
 const (
-	TelegramProvisionNotApplicable TelegramProvisionOutcome = iota // non-200 (zero value)
+	TelegramProvisionNotApplicable TelegramProvisionOutcome = iota // non-200; also the 200-only stub default (see type doc)
 	TelegramProvisionNoToken                                       // 200, server issued no token
 	TelegramProvisionConfirmed                                     // persisted AND confirmed
 	TelegramProvisionPersistFailed                                 // empty baseDir, or persist failed -> no confirm
@@ -84,7 +89,7 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 	if serverID == "" {
 		logTelegramRegistrationDebug(logger, "Telegram registration: missing serverID (empty string)")
 		return TelegramRegistrationStatus{
-			Code:    0,
+			Code:    StatusCodeMissingServerID,
 			Message: "SERVER_ID not available",
 			Error:   fmt.Errorf("server ID missing"),
 		}, ""

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -39,6 +39,26 @@ type TelegramRegistrationStatus struct {
 	Error   error
 }
 
+// TelegramProvisionOutcome records what the best-effort persist+confirm phase did
+// after a 200. It NEVER alters the returned registration Status. NotApplicable is
+// the zero value, so a stub building TelegramRegistrationResult{Status:...} on a
+// 200 classifies as a clean link.
+type TelegramProvisionOutcome int
+
+const (
+	TelegramProvisionNotApplicable TelegramProvisionOutcome = iota // non-200 (zero value)
+	TelegramProvisionNoToken                                       // 200, server issued no token
+	TelegramProvisionConfirmed                                     // persisted AND confirmed
+	TelegramProvisionPersistFailed                                 // empty baseDir, or persist failed -> no confirm
+	TelegramProvisionConfirmFailed                                 // persisted, confirm POST failed
+)
+
+// TelegramRegistrationResult bundles the public status with the provision outcome.
+type TelegramRegistrationResult struct {
+	Status    TelegramRegistrationStatus
+	Provision TelegramProvisionOutcome
+}
+
 // parseTelegramNotifySecret lifts the one-time relay secret out of a get-chat-id
 // body. Best-effort: a non-JSON or secret-less body yields "".
 func parseTelegramNotifySecret(body []byte) string {
@@ -126,6 +146,13 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 	case 422:
 		logTelegramRegistrationDebug(logger, "Telegram registration: status 422 (invalid server ID)")
 		return TelegramRegistrationStatus{Code: 422, Message: "422 - Invalid Server ID", Error: fmt.Errorf("%s", body)}, ""
+	case 426:
+		logTelegramRegistrationDebug(logger, "Telegram registration: status 426 (upgrade required)")
+		return TelegramRegistrationStatus{
+			Code:    426,
+			Message: "426 - Upgrade ProxSave to v0.28.0 or later to complete pairing",
+			Error:   fmt.Errorf("%s", body),
+		}, ""
 	default:
 		logTelegramRegistrationDebug(logger, "Telegram registration: unexpected status %d", resp.StatusCode)
 		return TelegramRegistrationStatus{
@@ -150,27 +177,45 @@ func CheckTelegramRegistration(ctx context.Context, serverAPIHost, serverID stri
 // notify_secret, OVERWRITES the persisted secret and CONFIRMS it back to the
 // server so the subsequent Send in this same run relays through the server
 // instead of leaking the bot token. The server returns a token ONLY when it wants
-// the client to (re)adopt it, so there is no idempotent skip. The returned status
-// is identical to CheckTelegramRegistration's; persist and confirm are
-// best-effort and NEVER change the returned status.
-func CheckTelegramRegistrationAndProvision(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) TelegramRegistrationStatus {
+// the client to (re)adopt it, so there is no idempotent skip. The returned
+// Status is identical to CheckTelegramRegistration's; persist and confirm are
+// best-effort and NEVER change the returned Status. The Provision field records
+// what the persist+confirm phase did so callers (the install Check UIs) can show
+// a distinct message without altering the registration status.
+func CheckTelegramRegistrationAndProvision(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) TelegramRegistrationResult {
 	status, secret := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, true, logger)
-	if status.Code != 200 || secret == "" || strings.TrimSpace(baseDir) == "" {
-		logTelegramRegistrationDebug(logger, "Telegram registration: skip provisioning (statusCode=%d secretPresent=%v baseDir=%q)", status.Code, secret != "", baseDir)
-		return status
+	res := TelegramRegistrationResult{Status: status, Provision: TelegramProvisionNotApplicable}
+
+	if status.Code != 200 {
+		logTelegramRegistrationDebug(logger, "Telegram registration: skip provisioning (statusCode=%d)", status.Code)
+		return res
+	}
+	if secret == "" {
+		res.Provision = TelegramProvisionNoToken
+		logTelegramRegistrationDebug(logger, "Telegram registration: 200 without token (nothing to provision)")
+		return res
+	}
+	if strings.TrimSpace(baseDir) == "" {
+		res.Provision = TelegramProvisionPersistFailed
+		logTelegramRegistrationDebug(logger, "Telegram registration: 200 with token but empty baseDir (cannot persist)")
+		return res
 	}
 	// Adopt-on-token-present: OVERWRITE (the server returns a token ONLY when it
 	// wants the client to (re)adopt it). No idempotent skip, or a re-issue strands.
 	// secret was already RegisterSecret'd in the helper on the 200 branch.
 	logTelegramRegistrationDebug(logger, "Telegram registration: provisioning relay secret (overwrite) -> %s", identity.NotifySecretPath(baseDir))
 	if err := identity.PersistNotifySecret(ctx, baseDir, secret, logger); err != nil {
+		res.Provision = TelegramProvisionPersistFailed
 		logTelegramRegistrationDebug(logger, "Telegram registration: failed to persist provisioned relay secret: %v", err)
-		return status // non-fatal: do NOT confirm; server re-issues next run
+		return res // non-fatal: do NOT confirm; server re-issues next run
 	}
 	if err := confirmTelegramRelaySecret(ctx, http.DefaultClient, serverAPIHost, serverID, secret, logger); err != nil {
+		res.Provision = TelegramProvisionConfirmFailed
 		logTelegramRegistrationDebug(logger, "Telegram registration: relay secret confirm failed (non-fatal): %v", err)
+		return res
 	}
-	return status
+	res.Provision = TelegramProvisionConfirmed
+	return res
 }
 
 // confirmTelegramRelaySecret completes phase 2: POST the freshly adopted relay

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -81,7 +81,8 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 		logTelegramRegistrationDebug(logger, "Telegram registration: failed to create request: %v", err)
 		return TelegramRegistrationStatus{Message: "Failed to create HTTP request", Error: err}, ""
 	}
-	setProxsaveVersionHeader(req) // keep X-Proxsave-Version on ALL get-chat-id requests
+	pv := setProxsaveVersionHeader(req) // keep X-Proxsave-Version on ALL get-chat-id requests
+	logTelegramRegistrationDebug(logger, "Telegram registration: X-Proxsave-Version=%q", pv)
 	logTelegramRegistrationDebug(logger, "Telegram registration: performing HTTP request (method=%s host=%s path=%s)", req.Method, req.URL.Host, req.URL.Path)
 
 	resp, err := http.DefaultClient.Do(req)
@@ -101,6 +102,7 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 		if secret != "" && logger != nil {
 			logger.RegisterSecret(secret)
 		}
+		logTelegramRegistrationDebug(logger, "Telegram registration: 200 body parsed (notifySecretPresent=%v len=%d)", secret != "", len(secret))
 	}
 
 	logTelegramRegistrationDebug(logger, "Telegram registration: response status=%d bodyBytes=%d bodyPreview=%q", resp.StatusCode, len(body), truncateTelegramRegistrationBody(body, 200))
@@ -145,12 +147,15 @@ func CheckTelegramRegistration(ctx context.Context, serverAPIHost, serverID stri
 func CheckTelegramRegistrationAndProvision(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) TelegramRegistrationStatus {
 	status, secret := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, logger)
 	if status.Code != 200 || secret == "" || strings.TrimSpace(baseDir) == "" {
+		logTelegramRegistrationDebug(logger, "Telegram registration: skip provisioning (statusCode=%d secretPresent=%v baseDir=%q)", status.Code, secret != "", baseDir)
 		return status
 	}
 	// Idempotent: never clobber a secret already on disk.
-	if existing, _ := identity.LoadNotifySecret(baseDir); existing != "" {
+	if existing, _ := identity.LoadNotifySecret(baseDir, logger); existing != "" {
+		logTelegramRegistrationDebug(logger, "Telegram registration: relay secret already persisted (len=%d), skipping provisioning", len(existing))
 		return status
 	}
+	logTelegramRegistrationDebug(logger, "Telegram registration: provisioning relay secret -> %s", identity.NotifySecretPath(baseDir))
 	if err := identity.PersistNotifySecret(ctx, baseDir, secret, logger); err != nil {
 		logTelegramRegistrationDebug(logger, "Telegram registration: failed to persist provisioned relay secret: %v", err)
 		return status // non-fatal: status unchanged

--- a/internal/notify/telegram_registration_provision_test.go
+++ b/internal/notify/telegram_registration_provision_test.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -21,6 +22,19 @@ import (
 // secretMinRegister, so the logger registers and masks it.
 const provisionTestSecret = "3h64-dyi8-q3d6-wcm5"
 
+// provisionCapture records what the routed stub server observed. The handshake
+// is fully synchronous (the client blocks on each request), so the test reads
+// these fields only after the call under test returns, mirroring the existing
+// plain-variable capture pattern used elsewhere in this package.
+type provisionCapture struct {
+	getChatIDHits   int
+	confirmHits     int
+	version         string
+	provisionHeader string
+	confirmAuth     string
+	confirmBody     string
+}
+
 // newProvisionTestLogger returns a debug logger writing into the returned buffer
 // so tests can assert on (and against) the captured log output.
 func newProvisionTestLogger() (*logging.Logger, *bytes.Buffer) {
@@ -30,16 +44,31 @@ func newProvisionTestLogger() (*logging.Logger, *bytes.Buffer) {
 	return logger, buf
 }
 
-// secretServer returns a get-chat-id stub that answers 200 with the given JSON
-// body and records the X-Proxsave-Version header it received.
-func secretServer(t *testing.T, body string, captured *string) *httptest.Server {
+// routingSecretServer returns a stub that routes the get-chat-id handshake and
+// the phase-2 confirm-secret POST, recording what it observed into capture.
+// get-chat-id answers 200 with the given JSON body; confirm-secret answers with
+// confirmStatus (use http.StatusOK for the happy path).
+func routingSecretServer(t *testing.T, body string, confirmStatus int, capture *provisionCapture) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if captured != nil {
-			*captured = r.Header.Get("X-Proxsave-Version")
+		switch r.URL.Path {
+		case "/api/get-chat-id":
+			capture.getChatIDHits++
+			capture.version = r.Header.Get("X-Proxsave-Version")
+			capture.provisionHeader = r.Header.Get("X-Proxsave-Provision")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		case "/api/confirm-secret":
+			b, _ := io.ReadAll(r.Body)
+			capture.confirmHits++
+			capture.confirmAuth = r.Header.Get("X-Server-Auth")
+			capture.confirmBody = string(b)
+			w.WriteHeader(confirmStatus)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
 		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(body))
 	}))
 }
 
@@ -47,8 +76,8 @@ func TestCheckTelegramRegistrationAndProvisionPersistsSecretAndMasksLog(t *testi
 	logger, buf := newProvisionTestLogger()
 	baseDir := t.TempDir()
 
-	var capturedVersion string
-	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, &capturedVersion)
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
 	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
@@ -76,8 +105,14 @@ func TestCheckTelegramRegistrationAndProvisionPersistsSecretAndMasksLog(t *testi
 		t.Fatalf("masked secret not found in log output:\n%s", logged)
 	}
 
-	if capturedVersion != version.String() {
-		t.Fatalf("X-Proxsave-Version = %q, want %q", capturedVersion, version.String())
+	if capture.version != version.String() {
+		t.Fatalf("X-Proxsave-Version = %q, want %q", capture.version, version.String())
+	}
+	if capture.provisionHeader != "1" {
+		t.Fatalf("X-Proxsave-Provision = %q, want %q", capture.provisionHeader, "1")
+	}
+	if capture.confirmHits != 1 {
+		t.Fatalf("expected exactly 1 confirm-secret hit, got %d", capture.confirmHits)
 	}
 }
 
@@ -85,7 +120,8 @@ func TestCheckTelegramRegistrationAndProvisionNoSecretNoPersist(t *testing.T) {
 	logger, _ := newProvisionTestLogger()
 	baseDir := t.TempDir()
 
-	server := secretServer(t, `{"chat_id":"123","status":200}`, nil)
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"chat_id":"123","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
 	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
@@ -103,12 +139,17 @@ func TestCheckTelegramRegistrationAndProvisionNoSecretNoPersist(t *testing.T) {
 	if _, err := os.Stat(identity.NotifySecretPath(baseDir)); !os.IsNotExist(err) {
 		t.Fatalf("expected notify-secret file to be absent, got err=%v", err)
 	}
+	// No token -> nothing to confirm.
+	if capture.confirmHits != 0 {
+		t.Fatalf("expected no confirm-secret hit when no token issued, got %d", capture.confirmHits)
+	}
 }
 
 func TestCheckTelegramRegistrationAndProvisionEmptyBaseDir(t *testing.T) {
 	logger, _ := newProvisionTestLogger()
 
-	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, nil)
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
 	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", "", logger)
@@ -118,6 +159,10 @@ func TestCheckTelegramRegistrationAndProvisionEmptyBaseDir(t *testing.T) {
 	}
 	if loaded, _ := identity.LoadNotifySecret(""); loaded != "" {
 		t.Fatalf("expected no persisted secret for empty baseDir, got %q", loaded)
+	}
+	// Empty baseDir short-circuits before persist/confirm.
+	if capture.confirmHits != 0 {
+		t.Fatalf("expected no confirm-secret hit for empty baseDir, got %d", capture.confirmHits)
 	}
 }
 
@@ -132,7 +177,8 @@ func TestCheckTelegramRegistrationAndProvisionPersistFailureKeepsStatus(t *testi
 	}
 	baseDir := filepath.Join(blocker, "sub")
 
-	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, nil)
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
 	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
@@ -146,10 +192,17 @@ func TestCheckTelegramRegistrationAndProvisionPersistFailureKeepsStatus(t *testi
 	if strings.Contains(buf.String(), provisionTestSecret) {
 		t.Fatalf("plaintext secret leaked into log output:\n%s", buf.String())
 	}
+	// Persist failed -> we must NOT confirm (server re-issues next run).
+	if capture.confirmHits != 0 {
+		t.Fatalf("expected no confirm-secret hit when persist failed, got %d", capture.confirmHits)
+	}
 }
 
-func TestCheckTelegramRegistrationAndProvisionIdempotent(t *testing.T) {
-	logger, _ := newProvisionTestLogger()
+// TestCheckTelegramRegistrationAndProvisionOverwritesAndConfirms verifies the
+// adopt-on-token-present contract: a freshly issued token OVERWRITES any secret
+// already on disk (no idempotent skip) and is confirmed back to the server.
+func TestCheckTelegramRegistrationAndProvisionOverwritesAndConfirms(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
 	baseDir := t.TempDir()
 
 	const seeded = "abcd-efgh-ijkl-mnop"
@@ -157,7 +210,8 @@ func TestCheckTelegramRegistrationAndProvisionIdempotent(t *testing.T) {
 		t.Fatalf("seed PersistNotifySecret: %v", err)
 	}
 
-	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, nil)
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
 	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
@@ -169,20 +223,65 @@ func TestCheckTelegramRegistrationAndProvisionIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadNotifySecret error: %v", err)
 	}
-	if loaded != seeded {
-		t.Fatalf("seeded secret was clobbered: got %q, want %q", loaded, seeded)
+	// The seeded secret MUST be clobbered (opposite of the old idempotent test).
+	if loaded != provisionTestSecret {
+		t.Fatalf("re-issued secret was not adopted: got %q, want %q", loaded, provisionTestSecret)
+	}
+	if capture.confirmHits != 1 {
+		t.Fatalf("expected exactly 1 confirm-secret hit, got %d", capture.confirmHits)
+	}
+	if capture.confirmAuth != provisionTestSecret {
+		t.Fatalf("confirm X-Server-Auth = %q, want %q", capture.confirmAuth, provisionTestSecret)
+	}
+	if !strings.Contains(capture.confirmBody, `"server_id":"server-123"`) {
+		t.Fatalf("confirm body = %q, want server_id server-123", capture.confirmBody)
+	}
+	if strings.Contains(buf.String(), provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into log output:\n%s", buf.String())
+	}
+}
+
+// TestCheckTelegramRegistrationAndProvisionConfirmNonFatalOn403 verifies a 403
+// from confirm-secret is non-fatal: the status stays 200, the issued secret is
+// persisted, and nothing panics or leaks.
+func TestCheckTelegramRegistrationAndProvisionConfirmNonFatalOn403(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
+	baseDir := t.TempDir()
+
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusForbidden, &capture)
+	defer server.Close()
+
+	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+
+	if status.Code != 200 || status.Error != nil {
+		t.Fatalf("status = %+v, want Code=200 Error=nil despite confirm 403", status)
+	}
+	loaded, err := identity.LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret error: %v", err)
+	}
+	if loaded != provisionTestSecret {
+		t.Fatalf("persisted secret = %q, want %q", loaded, provisionTestSecret)
+	}
+	if capture.confirmHits != 1 {
+		t.Fatalf("expected exactly 1 confirm-secret hit, got %d", capture.confirmHits)
+	}
+	if strings.Contains(buf.String(), provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into log output:\n%s", buf.String())
 	}
 }
 
 // TestCheckTelegramRegistrationStatusCheckMasksSecretNoPersist guards the latent
 // body-preview leak through the unchanged wrapper: even the legacy status-only
 // path registers the secret with the logger (so it is masked) and never persists
-// it, since no baseDir is threaded through that signature.
+// it, sends NO provision-intent header, and never confirms.
 func TestCheckTelegramRegistrationStatusCheckMasksSecretNoPersist(t *testing.T) {
 	logger, buf := newProvisionTestLogger()
 	untouched := t.TempDir()
 
-	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, nil)
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
 	status := CheckTelegramRegistration(context.Background(), server.URL, "server-123", logger)
@@ -195,5 +294,12 @@ func TestCheckTelegramRegistrationStatusCheckMasksSecretNoPersist(t *testing.T) 
 	}
 	if loaded, _ := identity.LoadNotifySecret(untouched); loaded != "" {
 		t.Fatalf("status-only path must not persist anything, got %q", loaded)
+	}
+	// The bare status probe must not carry provision-intent and must not confirm.
+	if capture.provisionHeader != "" {
+		t.Fatalf("status probe sent X-Proxsave-Provision = %q, want empty", capture.provisionHeader)
+	}
+	if capture.confirmHits != 0 {
+		t.Fatalf("status probe must not confirm, got %d hits", capture.confirmHits)
 	}
 }

--- a/internal/notify/telegram_registration_provision_test.go
+++ b/internal/notify/telegram_registration_provision_test.go
@@ -1,0 +1,199 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/identity"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+	"github.com/tis24dev/proxsave/internal/version"
+)
+
+// provisionTestSecret is a realistic per-server relay secret matching the server
+// format (lowercase alnum groups joined by hyphens) and longer than
+// secretMinRegister, so the logger registers and masks it.
+const provisionTestSecret = "3h64-dyi8-q3d6-wcm5"
+
+// newProvisionTestLogger returns a debug logger writing into the returned buffer
+// so tests can assert on (and against) the captured log output.
+func newProvisionTestLogger() (*logging.Logger, *bytes.Buffer) {
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	return logger, buf
+}
+
+// secretServer returns a get-chat-id stub that answers 200 with the given JSON
+// body and records the X-Proxsave-Version header it received.
+func secretServer(t *testing.T, body string, captured *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if captured != nil {
+			*captured = r.Header.Get("X-Proxsave-Version")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestCheckTelegramRegistrationAndProvisionPersistsSecretAndMasksLog(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
+	baseDir := t.TempDir()
+
+	var capturedVersion string
+	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, &capturedVersion)
+	defer server.Close()
+
+	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+
+	if status.Code != 200 || status.Error != nil {
+		t.Fatalf("status = %+v, want Code=200 Error=nil", status)
+	}
+
+	loaded, err := identity.LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret error: %v", err)
+	}
+	if loaded != provisionTestSecret {
+		t.Fatalf("persisted secret = %q, want %q", loaded, provisionTestSecret)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "bodyPreview") {
+		t.Fatalf("expected the body-preview line to be logged, got:\n%s", logged)
+	}
+	if strings.Contains(logged, provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into log output:\n%s", logged)
+	}
+	if !strings.Contains(logged, logging.MaskSecret(provisionTestSecret)) {
+		t.Fatalf("masked secret not found in log output:\n%s", logged)
+	}
+
+	if capturedVersion != version.String() {
+		t.Fatalf("X-Proxsave-Version = %q, want %q", capturedVersion, version.String())
+	}
+}
+
+func TestCheckTelegramRegistrationAndProvisionNoSecretNoPersist(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+	baseDir := t.TempDir()
+
+	server := secretServer(t, `{"chat_id":"123","status":200}`, nil)
+	defer server.Close()
+
+	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+
+	if status.Code != 200 {
+		t.Fatalf("status.Code = %d, want 200", status.Code)
+	}
+	loaded, err := identity.LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret error: %v", err)
+	}
+	if loaded != "" {
+		t.Fatalf("expected no persisted secret, got %q", loaded)
+	}
+	if _, err := os.Stat(identity.NotifySecretPath(baseDir)); !os.IsNotExist(err) {
+		t.Fatalf("expected notify-secret file to be absent, got err=%v", err)
+	}
+}
+
+func TestCheckTelegramRegistrationAndProvisionEmptyBaseDir(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+
+	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, nil)
+	defer server.Close()
+
+	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", "", logger)
+
+	if status.Code != 200 {
+		t.Fatalf("status.Code = %d, want 200", status.Code)
+	}
+	if loaded, _ := identity.LoadNotifySecret(""); loaded != "" {
+		t.Fatalf("expected no persisted secret for empty baseDir, got %q", loaded)
+	}
+}
+
+func TestCheckTelegramRegistrationAndProvisionPersistFailureKeepsStatus(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
+
+	// Make PersistNotifySecret's os.MkdirAll(baseDir/identity) fail by placing a
+	// regular file where the parent directory would have to be created.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+	baseDir := filepath.Join(blocker, "sub")
+
+	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, nil)
+	defer server.Close()
+
+	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+
+	if status.Code != 200 || status.Error != nil {
+		t.Fatalf("status = %+v, want Code=200 Error=nil despite persist failure", status)
+	}
+	if loaded, _ := identity.LoadNotifySecret(baseDir); loaded != "" {
+		t.Fatalf("expected no persisted secret after failure, got %q", loaded)
+	}
+	if strings.Contains(buf.String(), provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into log output:\n%s", buf.String())
+	}
+}
+
+func TestCheckTelegramRegistrationAndProvisionIdempotent(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+	baseDir := t.TempDir()
+
+	const seeded = "abcd-efgh-ijkl-mnop"
+	if err := identity.PersistNotifySecret(context.Background(), baseDir, seeded, logger); err != nil {
+		t.Fatalf("seed PersistNotifySecret: %v", err)
+	}
+
+	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, nil)
+	defer server.Close()
+
+	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+
+	if status.Code != 200 {
+		t.Fatalf("status.Code = %d, want 200", status.Code)
+	}
+	loaded, err := identity.LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret error: %v", err)
+	}
+	if loaded != seeded {
+		t.Fatalf("seeded secret was clobbered: got %q, want %q", loaded, seeded)
+	}
+}
+
+// TestCheckTelegramRegistrationStatusCheckMasksSecretNoPersist guards the latent
+// body-preview leak through the unchanged wrapper: even the legacy status-only
+// path registers the secret with the logger (so it is masked) and never persists
+// it, since no baseDir is threaded through that signature.
+func TestCheckTelegramRegistrationStatusCheckMasksSecretNoPersist(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
+	untouched := t.TempDir()
+
+	server := secretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, nil)
+	defer server.Close()
+
+	status := CheckTelegramRegistration(context.Background(), server.URL, "server-123", logger)
+
+	if status.Code != 200 {
+		t.Fatalf("status.Code = %d, want 200", status.Code)
+	}
+	if strings.Contains(buf.String(), provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into log output on the status-only path:\n%s", buf.String())
+	}
+	if loaded, _ := identity.LoadNotifySecret(untouched); loaded != "" {
+		t.Fatalf("status-only path must not persist anything, got %q", loaded)
+	}
+}

--- a/internal/notify/telegram_registration_provision_test.go
+++ b/internal/notify/telegram_registration_provision_test.go
@@ -80,10 +80,14 @@ func TestCheckTelegramRegistrationAndProvisionPersistsSecretAndMasksLog(t *testi
 	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
-	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	res := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	status := res.Status
 
 	if status.Code != 200 || status.Error != nil {
 		t.Fatalf("status = %+v, want Code=200 Error=nil", status)
+	}
+	if res.Provision != TelegramProvisionConfirmed {
+		t.Fatalf("Provision = %d, want TelegramProvisionConfirmed", res.Provision)
 	}
 
 	loaded, err := identity.LoadNotifySecret(baseDir)
@@ -124,10 +128,14 @@ func TestCheckTelegramRegistrationAndProvisionNoSecretNoPersist(t *testing.T) {
 	server := routingSecretServer(t, `{"chat_id":"123","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
-	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	res := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	status := res.Status
 
 	if status.Code != 200 {
 		t.Fatalf("status.Code = %d, want 200", status.Code)
+	}
+	if res.Provision != TelegramProvisionNoToken {
+		t.Fatalf("Provision = %d, want TelegramProvisionNoToken", res.Provision)
 	}
 	loaded, err := identity.LoadNotifySecret(baseDir)
 	if err != nil {
@@ -152,10 +160,14 @@ func TestCheckTelegramRegistrationAndProvisionEmptyBaseDir(t *testing.T) {
 	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
-	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", "", logger)
+	res := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", "", logger)
+	status := res.Status
 
 	if status.Code != 200 {
 		t.Fatalf("status.Code = %d, want 200", status.Code)
+	}
+	if res.Provision != TelegramProvisionPersistFailed {
+		t.Fatalf("Provision = %d, want TelegramProvisionPersistFailed", res.Provision)
 	}
 	if loaded, _ := identity.LoadNotifySecret(""); loaded != "" {
 		t.Fatalf("expected no persisted secret for empty baseDir, got %q", loaded)
@@ -181,10 +193,14 @@ func TestCheckTelegramRegistrationAndProvisionPersistFailureKeepsStatus(t *testi
 	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
-	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	res := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	status := res.Status
 
 	if status.Code != 200 || status.Error != nil {
 		t.Fatalf("status = %+v, want Code=200 Error=nil despite persist failure", status)
+	}
+	if res.Provision != TelegramProvisionPersistFailed {
+		t.Fatalf("Provision = %d, want TelegramProvisionPersistFailed", res.Provision)
 	}
 	if loaded, _ := identity.LoadNotifySecret(baseDir); loaded != "" {
 		t.Fatalf("expected no persisted secret after failure, got %q", loaded)
@@ -214,10 +230,14 @@ func TestCheckTelegramRegistrationAndProvisionOverwritesAndConfirms(t *testing.T
 	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 
-	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	res := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	status := res.Status
 
 	if status.Code != 200 {
 		t.Fatalf("status.Code = %d, want 200", status.Code)
+	}
+	if res.Provision != TelegramProvisionConfirmed {
+		t.Fatalf("Provision = %d, want TelegramProvisionConfirmed", res.Provision)
 	}
 	loaded, err := identity.LoadNotifySecret(baseDir)
 	if err != nil {
@@ -252,10 +272,14 @@ func TestCheckTelegramRegistrationAndProvisionConfirmNonFatalOn403(t *testing.T)
 	server := routingSecretServer(t, `{"chat_id":"123","notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusForbidden, &capture)
 	defer server.Close()
 
-	status := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	res := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+	status := res.Status
 
 	if status.Code != 200 || status.Error != nil {
 		t.Fatalf("status = %+v, want Code=200 Error=nil despite confirm 403", status)
+	}
+	if res.Provision != TelegramProvisionConfirmFailed {
+		t.Fatalf("Provision = %d, want TelegramProvisionConfirmFailed", res.Provision)
 	}
 	loaded, err := identity.LoadNotifySecret(baseDir)
 	if err != nil {
@@ -301,5 +325,45 @@ func TestCheckTelegramRegistrationStatusCheckMasksSecretNoPersist(t *testing.T) 
 	}
 	if capture.confirmHits != 0 {
 		t.Fatalf("status probe must not confirm, got %d hits", capture.confirmHits)
+	}
+}
+
+// TestCheckTelegramRegistrationAndProvision426NoConfirm verifies a 426 upgrade
+// response short-circuits before any provisioning: the status is 426 with an
+// error, the provision outcome is NotApplicable, and confirm-secret is never hit.
+func TestCheckTelegramRegistrationAndProvision426NoConfirm(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+	baseDir := t.TempDir()
+
+	var confirmHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/get-chat-id":
+			w.WriteHeader(http.StatusUpgradeRequired)
+			_, _ = w.Write([]byte("client too old"))
+		case "/api/confirm-secret":
+			confirmHits++
+			t.Errorf("confirm-secret must not be hit on a 426 response")
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	res := CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+
+	if res.Status.Code != 426 {
+		t.Fatalf("status.Code = %d, want 426", res.Status.Code)
+	}
+	if res.Status.Error == nil {
+		t.Fatalf("expected a non-nil error on a 426 response")
+	}
+	if res.Provision != TelegramProvisionNotApplicable {
+		t.Fatalf("Provision = %d, want TelegramProvisionNotApplicable", res.Provision)
+	}
+	if confirmHits != 0 {
+		t.Fatalf("expected no confirm-secret hit on a 426 response, got %d", confirmHits)
 	}
 }

--- a/internal/notify/telegram_registration_provision_test.go
+++ b/internal/notify/telegram_registration_provision_test.go
@@ -120,6 +120,34 @@ func TestCheckTelegramRegistrationAndProvisionPersistsSecretAndMasksLog(t *testi
 	}
 }
 
+// TestCheckTelegramRegistrationMasksBotTokenInBodyPreview guards the bot-token
+// leak: the get-chat-id 200 body also carries bot_token, which must be registered
+// with the masker BEFORE the body-preview line so it never appears raw in logs.
+func TestCheckTelegramRegistrationMasksBotTokenInBodyPreview(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
+	baseDir := t.TempDir()
+
+	const botToken = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+	var capture provisionCapture
+	body := `{"chat_id":"123","bot_token":"` + botToken + `","notify_secret":"` + provisionTestSecret + `","status":200}`
+	server := routingSecretServer(t, body, http.StatusOK, &capture)
+	defer server.Close()
+
+	_ = CheckTelegramRegistrationAndProvision(context.Background(), server.URL, "server-123", baseDir, logger)
+
+	logged := buf.String()
+	if !strings.Contains(logged, "bodyPreview") {
+		t.Fatalf("expected the body-preview line to be logged, got:\n%s", logged)
+	}
+	if strings.Contains(logged, botToken) {
+		t.Fatalf("plaintext bot_token leaked into log output:\n%s", logged)
+	}
+	if strings.Contains(logged, provisionTestSecret) {
+		t.Fatalf("plaintext notify_secret leaked into log output:\n%s", logged)
+	}
+}
+
 func TestCheckTelegramRegistrationAndProvisionNoSecretNoPersist(t *testing.T) {
 	logger, _ := newProvisionTestLogger()
 	baseDir := t.TempDir()

--- a/internal/notify/telegram_registration_test.go
+++ b/internal/notify/telegram_registration_test.go
@@ -33,6 +33,7 @@ func TestCheckTelegramRegistrationResponses(t *testing.T) {
 		{"403-first-comm", http.StatusForbidden, 403, true},
 		{"409-missing-reg", http.StatusConflict, 409, true},
 		{"422-invalid", http.StatusUnprocessableEntity, 422, true},
+		{"426-upgrade", http.StatusUpgradeRequired, 426, true},
 		{"500-unexpected", http.StatusInternalServerError, 500, true},
 	}
 

--- a/internal/notify/telegram_registration_test.go
+++ b/internal/notify/telegram_registration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/types"
+	"github.com/tis24dev/proxsave/internal/version"
 )
 
 func TestCheckTelegramRegistrationMissingServerID(t *testing.T) {
@@ -54,5 +55,28 @@ func TestCheckTelegramRegistrationResponses(t *testing.T) {
 				t.Fatalf("unexpected error: %v", status.Error)
 			}
 		})
+	}
+}
+
+// TestCheckTelegramRegistrationSendsVersionHeader verifies the GET get-chat-id
+// request from CheckTelegramRegistration carries X-Proxsave-Version.
+func TestCheckTelegramRegistrationSendsVersionHeader(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+
+	var captured string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("X-Proxsave-Version")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	CheckTelegramRegistration(context.Background(), server.URL, "server-123", logger)
+
+	if captured == "" {
+		t.Fatalf("X-Proxsave-Version header was not set")
+	}
+	if captured != version.String() {
+		t.Fatalf("X-Proxsave-Version = %q, want %q", captured, version.String())
 	}
 }

--- a/internal/notify/telegram_registration_test.go
+++ b/internal/notify/telegram_registration_test.go
@@ -63,9 +63,10 @@ func TestCheckTelegramRegistrationResponses(t *testing.T) {
 func TestCheckTelegramRegistrationSendsVersionHeader(t *testing.T) {
 	logger := logging.New(types.LogLevelDebug, false)
 
-	var captured string
+	var captured, capturedProvision string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		captured = r.Header.Get("X-Proxsave-Version")
+		capturedProvision = r.Header.Get("X-Proxsave-Provision")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}))
@@ -78,5 +79,9 @@ func TestCheckTelegramRegistrationSendsVersionHeader(t *testing.T) {
 	}
 	if captured != version.String() {
 		t.Fatalf("X-Proxsave-Version = %q, want %q", captured, version.String())
+	}
+	// The bare status probe must never carry provision-intent.
+	if capturedProvision != "" {
+		t.Fatalf("X-Proxsave-Provision = %q, want empty on the public status path", capturedProvision)
 	}
 }

--- a/internal/notify/telegram_registration_test.go
+++ b/internal/notify/telegram_registration_test.go
@@ -15,8 +15,8 @@ func TestCheckTelegramRegistrationMissingServerID(t *testing.T) {
 	logger := logging.New(types.LogLevelDebug, false)
 	status := CheckTelegramRegistration(context.Background(), "https://central.test", "", logger)
 
-	if status.Code != 0 || status.Error == nil {
-		t.Fatalf("expected missing server ID error, got %+v", status)
+	if status.Code != StatusCodeMissingServerID || status.Error == nil {
+		t.Fatalf("expected missing server ID sentinel, got %+v", status)
 	}
 }
 

--- a/internal/notify/telegram_test.go
+++ b/internal/notify/telegram_test.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -233,5 +234,162 @@ func TestTelegramSendCentralized(t *testing.T) {
 	}
 	if !result.Success {
 		t.Fatalf("expected success, got %+v", result)
+	}
+}
+
+func TestTelegramSendCentralizedRelay(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+
+	const secret = "relay-secret-value-123456"
+	var relayCalls int
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Host, "api.telegram.org") {
+				t.Fatalf("api.telegram.org must never be contacted in relay mode")
+			}
+			if req.Method != http.MethodPost || req.URL.Path != "/api/notify" {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+			if got := req.Header.Get("X-Server-Auth"); got != secret {
+				t.Fatalf("missing/incorrect X-Server-Auth header: %q", got)
+			}
+			bodyBytes, _ := io.ReadAll(req.Body)
+			var payload struct {
+				ServerID string `json:"server_id"`
+				Message  string `json:"message"`
+			}
+			if err := json.Unmarshal(bodyBytes, &payload); err != nil {
+				t.Fatalf("invalid JSON body: %v", err)
+			}
+			if payload.ServerID != "server-123" {
+				t.Fatalf("server_id = %q, want server-123", payload.ServerID)
+			}
+			if payload.Message == "" {
+				t.Fatalf("message must not be empty")
+			}
+			relayCalls++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	notifier, err := NewTelegramNotifier(TelegramConfig{
+		Enabled:       true,
+		Mode:          TelegramModeCentralized,
+		ServerAPIHost: "https://central.test",
+		ServerID:      "server-123",
+		NotifySecret:  secret,
+	}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	notifier.client = client
+
+	result, err := notifier.Send(context.Background(), data)
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	if relayCalls != 1 {
+		t.Fatalf("expected exactly 1 relay call, got %d", relayCalls)
+	}
+}
+
+func TestTelegramRelayFallbackWhenNoSecret(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+
+	var sawGetChatID, sawTelegram bool
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path == "/api/notify" {
+				t.Fatalf("relay must not be used when NotifySecret is empty")
+			}
+			switch {
+			case strings.Contains(req.URL.Host, "central.test"):
+				sawGetChatID = true
+				body := `{"bot_token":"123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz","chat_id":"987654","status":200}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+				}, nil
+			case strings.Contains(req.URL.Host, "api.telegram.org"):
+				sawTelegram = true
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("ok")),
+					Header:     make(http.Header),
+				}, nil
+			default:
+				t.Fatalf("unexpected host: %s", req.URL.Host)
+				return nil, nil
+			}
+		}),
+	}
+
+	notifier, err := NewTelegramNotifier(TelegramConfig{
+		Enabled:       true,
+		Mode:          TelegramModeCentralized,
+		ServerAPIHost: "https://central.test",
+		ServerID:      "server-123",
+		NotifySecret:  "",
+	}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	notifier.client = client
+
+	result, err := notifier.Send(context.Background(), data)
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	if !sawGetChatID || !sawTelegram {
+		t.Fatalf("legacy path not exercised: getChatID=%v telegram=%v", sawGetChatID, sawTelegram)
+	}
+}
+
+func TestTelegramRelayErrorRedactsSecret(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	const secret = "relay-secret-value-redaction-1234"
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			// Server echoes the secret in an error body; the client must scrub it.
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("internal error: " + secret)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	notifier, err := NewTelegramNotifier(TelegramConfig{
+		Enabled:       true,
+		Mode:          TelegramModeCentralized,
+		ServerAPIHost: "https://central.test",
+		ServerID:      "server-123",
+		NotifySecret:  secret,
+	}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	notifier.client = client
+
+	relayErr := notifier.sendViaRelay(context.Background(), "hello")
+	if relayErr == nil {
+		t.Fatalf("expected an error from the relay")
+	}
+	if strings.Contains(relayErr.Error(), secret) {
+		t.Fatalf("error string leaked the NotifySecret: %q", relayErr.Error())
 	}
 }

--- a/internal/notify/telegram_tofu_test.go
+++ b/internal/notify/telegram_tofu_test.go
@@ -256,3 +256,87 @@ func TestSendCentralizedNoProvisionWhenBaseDirEmpty(t *testing.T) {
 		t.Fatalf("no confirm/relay expected when BaseDir is empty, got confirm=%d relay=%d", confirmCalls, relayCalls)
 	}
 }
+
+// TestSendCentralizedRelayAuthRejectedReprovisions pins the recovery from a stale
+// relay secret: a persisted secret that the relay rejects (403) must NOT strand
+// the client. Send drops the stale secret, reprovisions via get-chat-id, and
+// retries the relay with the fresh secret in the same run.
+func TestSendCentralizedRelayAuthRejectedReprovisions(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+	baseDir := t.TempDir()
+
+	const stale = "aaaa-bbbb-cccc-dddd"
+	const fresh = "3h64-dyi8-q3d6-wcm5"
+	if err := identity.PersistNotifySecret(context.Background(), baseDir, stale, logger); err != nil {
+		t.Fatalf("seed PersistNotifySecret: %v", err)
+	}
+
+	var relayCalls, getChatIDCalls, confirmCalls int
+	var relayAuthSeen []string
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Host, "api.telegram.org") {
+				t.Fatalf("api.telegram.org must never be contacted; recovery stays on the relay")
+			}
+			switch req.URL.Path {
+			case "/api/notify":
+				relayCalls++
+				relayAuthSeen = append(relayAuthSeen, req.Header.Get("X-Server-Auth"))
+				if relayCalls == 1 {
+					// The stale secret is rejected.
+					return &http.Response{StatusCode: http.StatusForbidden, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status":"ok"}`)), Header: make(http.Header)}, nil
+			case "/api/get-chat-id":
+				if got := req.Header.Get("X-Proxsave-Provision"); got != "1" {
+					t.Fatalf("reprovision get-chat-id X-Proxsave-Provision = %q, want 1", got)
+				}
+				getChatIDCalls++
+				body := `{"chat_id":"123","notify_secret":"` + fresh + `","status":200}`
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+			case "/api/confirm-secret":
+				confirmCalls++
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+			default:
+				t.Fatalf("unexpected request path: %s", req.URL.Path)
+				return nil, nil
+			}
+		}),
+	}
+
+	notifier, err := NewTelegramNotifier(TelegramConfig{
+		Enabled:       true,
+		Mode:          TelegramModeCentralized,
+		ServerAPIHost: "https://central.test",
+		ServerID:      "server-123",
+		BaseDir:       baseDir,
+	}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	notifier.client = client
+
+	result, err := notifier.Send(context.Background(), data)
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success after reprovision, got %+v", result)
+	}
+	if getChatIDCalls != 1 {
+		t.Fatalf("expected exactly 1 reprovision get-chat-id call, got %d", getChatIDCalls)
+	}
+	if relayCalls != 2 {
+		t.Fatalf("expected 2 relay calls (reject then retry), got %d", relayCalls)
+	}
+	if confirmCalls != 1 {
+		t.Fatalf("expected exactly 1 confirm-secret call, got %d", confirmCalls)
+	}
+	if len(relayAuthSeen) != 2 || relayAuthSeen[0] != stale || relayAuthSeen[1] != fresh {
+		t.Fatalf("relay auth progression = %v, want [%q %q]", relayAuthSeen, stale, fresh)
+	}
+	if got, _ := identity.LoadNotifySecret(baseDir); got != fresh {
+		t.Fatalf("persisted secret = %q, want %q (fresh)", got, fresh)
+	}
+}

--- a/internal/notify/telegram_tofu_test.go
+++ b/internal/notify/telegram_tofu_test.go
@@ -25,7 +25,7 @@ func TestSendCentralizedTOFUProvisionsThenRelays(t *testing.T) {
 	const secret = "3h64-dyi8-q3d6-wcm5"
 	const botToken = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
-	var getChatIDCalls, relayCalls int
+	var getChatIDCalls, relayCalls, confirmCalls int
 	client := &http.Client{
 		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			if strings.Contains(req.URL.Host, "api.telegram.org") {
@@ -36,11 +36,27 @@ func TestSendCentralizedTOFUProvisionsThenRelays(t *testing.T) {
 				if got := req.Header.Get("X-Proxsave-Version"); got != version.String() {
 					t.Fatalf("get-chat-id X-Proxsave-Version = %q, want %q", got, version.String())
 				}
+				if got := req.Header.Get("X-Proxsave-Provision"); got != "1" {
+					t.Fatalf("get-chat-id X-Proxsave-Provision = %q, want %q", got, "1")
+				}
 				getChatIDCalls++
 				body := `{"chat_id":"123","bot_token":"` + botToken + `","notify_secret":"` + secret + `","status":200}`
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+				}, nil
+			case "/api/confirm-secret":
+				if got := req.Header.Get("X-Server-Auth"); got != secret {
+					t.Fatalf("confirm X-Server-Auth = %q, want %q", got, secret)
+				}
+				if got := req.Header.Get("X-Proxsave-Version"); got != version.String() {
+					t.Fatalf("confirm X-Proxsave-Version = %q, want %q", got, version.String())
+				}
+				confirmCalls++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
 					Header:     make(http.Header),
 				}, nil
 			case "/api/notify":
@@ -87,6 +103,9 @@ func TestSendCentralizedTOFUProvisionsThenRelays(t *testing.T) {
 	}
 	if relayCalls != 1 {
 		t.Fatalf("expected exactly 1 relay call, got %d", relayCalls)
+	}
+	if confirmCalls != 1 {
+		t.Fatalf("expected exactly 1 confirm-secret call, got %d", confirmCalls)
 	}
 
 	persisted, err := identity.LoadNotifySecret(baseDir)

--- a/internal/notify/telegram_tofu_test.go
+++ b/internal/notify/telegram_tofu_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tis24dev/proxsave/internal/identity"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/types"
+	"github.com/tis24dev/proxsave/internal/version"
 )
 
 // TestSendCentralizedTOFUProvisionsThenRelays verifies the one-time provisioning:
@@ -32,6 +33,9 @@ func TestSendCentralizedTOFUProvisionsThenRelays(t *testing.T) {
 			}
 			switch req.URL.Path {
 			case "/api/get-chat-id":
+				if got := req.Header.Get("X-Proxsave-Version"); got != version.String() {
+					t.Fatalf("get-chat-id X-Proxsave-Version = %q, want %q", got, version.String())
+				}
 				getChatIDCalls++
 				body := `{"chat_id":"123","bot_token":"` + botToken + `","notify_secret":"` + secret + `","status":200}`
 				return &http.Response{
@@ -42,6 +46,9 @@ func TestSendCentralizedTOFUProvisionsThenRelays(t *testing.T) {
 			case "/api/notify":
 				if got := req.Header.Get("X-Server-Auth"); got != secret {
 					t.Fatalf("relay X-Server-Auth = %q, want %q", got, secret)
+				}
+				if got := req.Header.Get("X-Proxsave-Version"); got != version.String() {
+					t.Fatalf("notify X-Proxsave-Version = %q, want %q", got, version.String())
 				}
 				relayCalls++
 				return &http.Response{

--- a/internal/notify/telegram_tofu_test.go
+++ b/internal/notify/telegram_tofu_test.go
@@ -177,3 +177,82 @@ func TestSendCentralizedUsesPersistedSecretWithoutFetch(t *testing.T) {
 		t.Fatalf("expected exactly 1 relay call, got %d", relayCalls)
 	}
 }
+
+// TestSendCentralizedNoProvisionWhenBaseDirEmpty pins the provision-header gating:
+// with an empty BaseDir the client cannot persist a relay secret, so it must NOT
+// send X-Proxsave-Provision (which would make the server mint+store a fresh
+// unconfirmed token every run). It falls back to the legacy bot-token send and
+// never confirms/relays.
+func TestSendCentralizedNoProvisionWhenBaseDirEmpty(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+
+	const botToken = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	const secret = "3h64-dyi8-q3d6-wcm5"
+
+	var getChatIDCalls, telegramCalls, confirmCalls, relayCalls int
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case strings.Contains(req.URL.Host, "api.telegram.org"):
+				telegramCalls++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+					Header:     make(http.Header),
+				}, nil
+			case req.URL.Path == "/api/get-chat-id":
+				if got := req.Header.Get("X-Proxsave-Provision"); got != "" {
+					t.Fatalf("get-chat-id X-Proxsave-Provision = %q, want empty (no provision when BaseDir is empty)", got)
+				}
+				getChatIDCalls++
+				// The server still returns a secret; the client must ignore it
+				// because it has nowhere to persist it.
+				body := `{"chat_id":"123456789","bot_token":"` + botToken + `","notify_secret":"` + secret + `","status":200}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+				}, nil
+			case req.URL.Path == "/api/confirm-secret":
+				confirmCalls++
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+			case req.URL.Path == "/api/notify":
+				relayCalls++
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+			default:
+				t.Fatalf("unexpected request path: %s", req.URL.Path)
+				return nil, nil
+			}
+		}),
+	}
+
+	notifier, err := NewTelegramNotifier(TelegramConfig{
+		Enabled:       true,
+		Mode:          TelegramModeCentralized,
+		ServerAPIHost: "https://central.test",
+		ServerID:      "server-123",
+		BaseDir:       "", // cannot persist -> must not ask the server to provision
+	}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	notifier.client = client
+
+	result, err := notifier.Send(context.Background(), data)
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	if getChatIDCalls != 1 {
+		t.Fatalf("expected exactly 1 get-chat-id call, got %d", getChatIDCalls)
+	}
+	if telegramCalls != 1 {
+		t.Fatalf("expected the legacy bot-token send to api.telegram.org, got %d calls", telegramCalls)
+	}
+	if confirmCalls != 0 || relayCalls != 0 {
+		t.Fatalf("no confirm/relay expected when BaseDir is empty, got confirm=%d relay=%d", confirmCalls, relayCalls)
+	}
+}

--- a/internal/notify/telegram_tofu_test.go
+++ b/internal/notify/telegram_tofu_test.go
@@ -1,0 +1,153 @@
+package notify
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/identity"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// TestSendCentralizedTOFUProvisionsThenRelays verifies the one-time provisioning:
+// get-chat-id rides a fresh per-server secret back, the client persists it into
+// the immutable identity file, and delivers THIS run through the relay (never the
+// bot token to api.telegram.org).
+func TestSendCentralizedTOFUProvisionsThenRelays(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+	baseDir := t.TempDir()
+
+	const secret = "3h64-dyi8-q3d6-wcm5"
+	const botToken = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+	var getChatIDCalls, relayCalls int
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Host, "api.telegram.org") {
+				t.Fatalf("api.telegram.org must never be contacted once a relay secret is provisioned")
+			}
+			switch req.URL.Path {
+			case "/api/get-chat-id":
+				getChatIDCalls++
+				body := `{"chat_id":"123","bot_token":"` + botToken + `","notify_secret":"` + secret + `","status":200}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+				}, nil
+			case "/api/notify":
+				if got := req.Header.Get("X-Server-Auth"); got != secret {
+					t.Fatalf("relay X-Server-Auth = %q, want %q", got, secret)
+				}
+				relayCalls++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+					Header:     make(http.Header),
+				}, nil
+			default:
+				t.Fatalf("unexpected request path: %s", req.URL.Path)
+				return nil, nil
+			}
+		}),
+	}
+
+	notifier, err := NewTelegramNotifier(TelegramConfig{
+		Enabled:       true,
+		Mode:          TelegramModeCentralized,
+		ServerAPIHost: "https://central.test",
+		ServerID:      "server-123",
+		BaseDir:       baseDir,
+	}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	notifier.client = client
+
+	result, err := notifier.Send(context.Background(), data)
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	if getChatIDCalls != 1 {
+		t.Fatalf("expected exactly 1 get-chat-id call, got %d", getChatIDCalls)
+	}
+	if relayCalls != 1 {
+		t.Fatalf("expected exactly 1 relay call, got %d", relayCalls)
+	}
+
+	persisted, err := identity.LoadNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LoadNotifySecret() error = %v", err)
+	}
+	if persisted != secret {
+		t.Fatalf("persisted secret = %q, want %q", persisted, secret)
+	}
+}
+
+// TestSendCentralizedUsesPersistedSecretWithoutFetch verifies that once a secret
+// is persisted, Send adopts it lazily and goes straight to the relay, never
+// hitting get-chat-id.
+func TestSendCentralizedUsesPersistedSecretWithoutFetch(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	data := createTestNotificationData()
+	baseDir := t.TempDir()
+
+	const secret = "abcd-efgh-ijkl-mnop"
+	if err := identity.PersistNotifySecret(context.Background(), baseDir, secret, logger); err != nil {
+		t.Fatalf("PersistNotifySecret() error = %v", err)
+	}
+
+	var relayCalls int
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Host, "api.telegram.org") {
+				t.Fatalf("api.telegram.org must never be contacted in relay mode")
+			}
+			if req.URL.Path == "/api/get-chat-id" {
+				t.Fatalf("get-chat-id must not be fetched once a secret is persisted")
+			}
+			if req.URL.Path != "/api/notify" {
+				t.Fatalf("unexpected request path: %s", req.URL.Path)
+			}
+			if got := req.Header.Get("X-Server-Auth"); got != secret {
+				t.Fatalf("relay X-Server-Auth = %q, want %q", got, secret)
+			}
+			relayCalls++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	notifier, err := NewTelegramNotifier(TelegramConfig{
+		Enabled:       true,
+		Mode:          TelegramModeCentralized,
+		ServerAPIHost: "https://central.test",
+		ServerID:      "server-123",
+		BaseDir:       baseDir,
+	}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	notifier.client = client
+
+	result, err := notifier.Send(context.Background(), data)
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	if relayCalls != 1 {
+		t.Fatalf("expected exactly 1 relay call, got %d", relayCalls)
+	}
+}

--- a/internal/orchestrator/telegram_setup_classify.go
+++ b/internal/orchestrator/telegram_setup_classify.go
@@ -53,7 +53,10 @@ func ClassifyTelegramSetupResult(res notify.TelegramRegistrationResult) Telegram
 		return TelegramSetupState{Code: "connection_error",
 			Message: "Could not reach the pairing server. Check connectivity and press Check again."}
 	default:
+		// Untrusted upstream text: strip terminal/control sequences AND truncate in
+		// this shared path so both the CLI and the TUI render the same safe copy
+		// (the TUI only tview.Escapes, so control bytes must be removed here).
 		return TelegramSetupState{Code: "unexpected_response",
-			Message: TruncateTelegramSetupStatusMessage(res.Status.Message)}
+			Message: SanitizeTelegramSetupStatusMessage(res.Status.Message)}
 	}
 }

--- a/internal/orchestrator/telegram_setup_classify.go
+++ b/internal/orchestrator/telegram_setup_classify.go
@@ -1,0 +1,56 @@
+package orchestrator
+
+import "github.com/tis24dev/proxsave/internal/notify"
+
+// Shared affordance copy so the CLI and TUI render identical retry/cap guidance.
+const TelegramSetupRetryHint = "You can press Check again, or Skip verification and complete pairing later."
+const TelegramSetupMaxAttemptsHint = "Maximum verification attempts reached. Skip and complete pairing later by running proxsave."
+
+// TelegramSetupState is the UI-agnostic verdict for one registration check. It is
+// the ONLY place that maps (status, provision) -> message/policy, so the CLI and
+// TUI render identical copy and honor identical retry/skip policy.
+type TelegramSetupState struct {
+	Code     string // stable identifier (the new error-code catalog)
+	Message  string // exact user-facing copy; identical in CLI and TUI
+	Verified bool   // pairing active -> Continue/return allowed
+	Partial  bool   // verified but a local persist/confirm step is pending (distinct copy)
+	Fatal    bool   // another check cannot help -> do NOT offer Check again
+}
+
+// ClassifyTelegramSetupResult is the single source of truth for install-time
+// pairing copy and policy. Status.Code is authoritative; Provision is consulted
+// only on a 200. Both the CLI and TUI MUST render st.Message and honor st.Fatal /
+// st.Partial / st.Verified so neither UI can diverge in copy or retry policy.
+func ClassifyTelegramSetupResult(res notify.TelegramRegistrationResult) TelegramSetupState {
+	switch res.Status.Code {
+	case 200:
+		switch res.Provision {
+		case notify.TelegramProvisionPersistFailed:
+			return TelegramSetupState{Code: "linked_token_unsaved", Verified: true, Partial: true,
+				Message: "Linked, but the relay token could not be saved locally. It will be reissued on the next backup."}
+		case notify.TelegramProvisionConfirmFailed:
+			return TelegramSetupState{Code: "linked_confirm_pending", Verified: true, Partial: true,
+				Message: "Linked, but the relay-token confirmation did not complete. It will finish automatically on the next backup."}
+		default: // Confirmed, NoToken, or NotApplicable (stub zero-value)
+			return TelegramSetupState{Code: "linked_confirmed", Verified: true, Message: "Linked successfully."}
+		}
+	case 403:
+		return TelegramSetupState{Code: "bot_not_started",
+			Message: "Start the bot and send the Server ID, then press Check again."}
+	case 409:
+		return TelegramSetupState{Code: "not_associated",
+			Message: "Registration not associated yet. Send the Server ID to the bot, then press Check again."}
+	case 422:
+		return TelegramSetupState{Code: "invalid_server_id", Fatal: true,
+			Message: "Invalid Server ID. Re-run the installer or regenerate the identity file."}
+	case 426:
+		return TelegramSetupState{Code: "upgrade_required", Fatal: true,
+			Message: "Upgrade ProxSave to v0.28.0 or later to complete pairing."}
+	case 0:
+		return TelegramSetupState{Code: "connection_error",
+			Message: "Could not reach the pairing server. Check connectivity and press Check again."}
+	default:
+		return TelegramSetupState{Code: "unexpected_response",
+			Message: TruncateTelegramSetupStatusMessage(res.Status.Message)}
+	}
+}

--- a/internal/orchestrator/telegram_setup_classify.go
+++ b/internal/orchestrator/telegram_setup_classify.go
@@ -46,6 +46,9 @@ func ClassifyTelegramSetupResult(res notify.TelegramRegistrationResult) Telegram
 	case 426:
 		return TelegramSetupState{Code: "upgrade_required", Fatal: true,
 			Message: "Upgrade ProxSave to v0.28.0 or later to complete pairing."}
+	case notify.StatusCodeMissingServerID:
+		return TelegramSetupState{Code: "missing_identity", Fatal: true,
+			Message: "Server identity not found. Re-run the installer or regenerate the identity file."}
 	case 0:
 		return TelegramSetupState{Code: "connection_error",
 			Message: "Could not reach the pairing server. Check connectivity and press Check again."}

--- a/internal/orchestrator/telegram_setup_classify.go
+++ b/internal/orchestrator/telegram_setup_classify.go
@@ -31,7 +31,7 @@ func ClassifyTelegramSetupResult(res notify.TelegramRegistrationResult) Telegram
 		case notify.TelegramProvisionConfirmFailed:
 			return TelegramSetupState{Code: "linked_confirm_pending", Verified: true, Partial: true,
 				Message: "Linked, but the relay-token confirmation did not complete. It will finish automatically on the next backup."}
-		default: // Confirmed, NoToken, or NotApplicable (stub zero-value)
+		default: // Confirmed, NoToken, Clean, or the NotApplicable zero value on a bare 200 stub
 			return TelegramSetupState{Code: "linked_confirmed", Verified: true, Message: "Linked successfully."}
 		}
 	case 403:

--- a/internal/orchestrator/telegram_setup_classify_test.go
+++ b/internal/orchestrator/telegram_setup_classify_test.go
@@ -1,0 +1,155 @@
+package orchestrator
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/notify"
+)
+
+func TestClassifyTelegramSetupResult(t *testing.T) {
+	cases := []struct {
+		name         string
+		res          notify.TelegramRegistrationResult
+		wantCode     string
+		wantMessage  string
+		wantVerified bool
+		wantPartial  bool
+		wantFatal    bool
+	}{
+		{
+			name:         "200-confirmed",
+			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200}, Provision: notify.TelegramProvisionConfirmed},
+			wantCode:     "linked_confirmed",
+			wantMessage:  "Linked successfully.",
+			wantVerified: true,
+		},
+		{
+			name:         "200-no-token",
+			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200}, Provision: notify.TelegramProvisionNoToken},
+			wantCode:     "linked_confirmed",
+			wantMessage:  "Linked successfully.",
+			wantVerified: true,
+		},
+		{
+			name:         "200-zero-value-provision",
+			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200}},
+			wantCode:     "linked_confirmed",
+			wantMessage:  "Linked successfully.",
+			wantVerified: true,
+		},
+		{
+			name:         "200-persist-failed",
+			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200}, Provision: notify.TelegramProvisionPersistFailed},
+			wantCode:     "linked_token_unsaved",
+			wantMessage:  "Linked, but the relay token could not be saved locally. It will be reissued on the next backup.",
+			wantVerified: true,
+			wantPartial:  true,
+		},
+		{
+			name:         "200-confirm-failed",
+			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200}, Provision: notify.TelegramProvisionConfirmFailed},
+			wantCode:     "linked_confirm_pending",
+			wantMessage:  "Linked, but the relay-token confirmation did not complete. It will finish automatically on the next backup.",
+			wantVerified: true,
+			wantPartial:  true,
+		},
+		{
+			name:        "403",
+			res:         notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 403}},
+			wantCode:    "bot_not_started",
+			wantMessage: "Start the bot and send the Server ID, then press Check again.",
+		},
+		{
+			name:        "409",
+			res:         notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 409}},
+			wantCode:    "not_associated",
+			wantMessage: "Registration not associated yet. Send the Server ID to the bot, then press Check again.",
+		},
+		{
+			name:        "422-fatal",
+			res:         notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 422}},
+			wantCode:    "invalid_server_id",
+			wantMessage: "Invalid Server ID. Re-run the installer or regenerate the identity file.",
+			wantFatal:   true,
+		},
+		{
+			name:        "426-fatal",
+			res:         notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 426}},
+			wantCode:    "upgrade_required",
+			wantMessage: "Upgrade ProxSave to v0.28.0 or later to complete pairing.",
+			wantFatal:   true,
+		},
+		{
+			name:        "code-0-connection-error",
+			res:         notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 0, Error: errors.New("conn")}},
+			wantCode:    "connection_error",
+			wantMessage: "Could not reach the pairing server. Check connectivity and press Check again.",
+		},
+		{
+			name:        "unexpected-500",
+			res:         notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 500, Message: "x"}},
+			wantCode:    "unexpected_response",
+			wantMessage: "x",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			st := ClassifyTelegramSetupResult(tt.res)
+			if st.Code != tt.wantCode {
+				t.Fatalf("Code=%q, want %q", st.Code, tt.wantCode)
+			}
+			if st.Message != tt.wantMessage {
+				t.Fatalf("Message=%q, want %q", st.Message, tt.wantMessage)
+			}
+			if st.Verified != tt.wantVerified {
+				t.Fatalf("Verified=%v, want %v", st.Verified, tt.wantVerified)
+			}
+			if st.Partial != tt.wantPartial {
+				t.Fatalf("Partial=%v, want %v", st.Partial, tt.wantPartial)
+			}
+			if st.Fatal != tt.wantFatal {
+				t.Fatalf("Fatal=%v, want %v", st.Fatal, tt.wantFatal)
+			}
+		})
+	}
+}
+
+// TestClassifyTelegramSetupResult_ConnectionDistinctFromUnexpected pins that a
+// Code 0 (connection failure / missing server id) maps to a DISTINCT user-facing
+// state than an unexpected non-2xx response, so the user is told to check
+// connectivity rather than shown a raw upstream body.
+func TestClassifyTelegramSetupResult_ConnectionDistinctFromUnexpected(t *testing.T) {
+	conn := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 0, Error: errors.New("conn")}})
+	other := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 500, Message: "x"}})
+
+	if conn.Code == other.Code {
+		t.Fatalf("connection error and unexpected response must classify distinctly, both got %q", conn.Code)
+	}
+	if conn.Code != "connection_error" {
+		t.Fatalf("Code 0 classified as %q, want connection_error", conn.Code)
+	}
+	if other.Code != "unexpected_response" {
+		t.Fatalf("Code 500 classified as %q, want unexpected_response", other.Code)
+	}
+}
+
+// TestClassifyTelegramSetupResult_TruncatesUnexpectedMessage verifies the raw,
+// untrusted upstream message in the unexpected_response branch is truncated to the
+// shared bound before it reaches either UI.
+func TestClassifyTelegramSetupResult_TruncatesUnexpectedMessage(t *testing.T) {
+	long := strings.Repeat("x", 320)
+	st := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 599, Message: long}})
+
+	if st.Code != "unexpected_response" {
+		t.Fatalf("Code=%q, want unexpected_response", st.Code)
+	}
+	if !strings.HasSuffix(st.Message, "...(truncated)") {
+		t.Fatalf("expected truncated message, got %q", st.Message)
+	}
+	if runes := []rune(st.Message); len(runes) > TelegramSetupStatusMessageMaxRunes {
+		t.Fatalf("message length=%d runes, want <= %d", len(runes), TelegramSetupStatusMessageMaxRunes)
+	}
+}

--- a/internal/orchestrator/telegram_setup_classify_test.go
+++ b/internal/orchestrator/telegram_setup_classify_test.go
@@ -40,6 +40,13 @@ func TestClassifyTelegramSetupResult(t *testing.T) {
 			wantVerified: true,
 		},
 		{
+			name:         "200-clean",
+			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200}, Provision: notify.TelegramProvisionClean},
+			wantCode:     "linked_confirmed",
+			wantMessage:  "Linked successfully.",
+			wantVerified: true,
+		},
+		{
 			name:         "200-persist-failed",
 			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200}, Provision: notify.TelegramProvisionPersistFailed},
 			wantCode:     "linked_token_unsaved",

--- a/internal/orchestrator/telegram_setup_classify_test.go
+++ b/internal/orchestrator/telegram_setup_classify_test.go
@@ -88,6 +88,13 @@ func TestClassifyTelegramSetupResult(t *testing.T) {
 			wantMessage: "Could not reach the pairing server. Check connectivity and press Check again.",
 		},
 		{
+			name:        "missing-server-id-identity",
+			res:         notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: notify.StatusCodeMissingServerID, Error: errors.New("server ID missing")}},
+			wantCode:    "missing_identity",
+			wantMessage: "Server identity not found. Re-run the installer or regenerate the identity file.",
+			wantFatal:   true,
+		},
+		{
 			name:        "unexpected-500",
 			res:         notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 500, Message: "x"}},
 			wantCode:    "unexpected_response",
@@ -118,9 +125,10 @@ func TestClassifyTelegramSetupResult(t *testing.T) {
 }
 
 // TestClassifyTelegramSetupResult_ConnectionDistinctFromUnexpected pins that a
-// Code 0 (connection failure / missing server id) maps to a DISTINCT user-facing
-// state than an unexpected non-2xx response, so the user is told to check
-// connectivity rather than shown a raw upstream body.
+// Code 0 (genuine connection failure) maps to a DISTINCT user-facing state than an
+// unexpected non-2xx response, so the user is told to check connectivity rather
+// than shown a raw upstream body. A missing server identity is a separate sentinel
+// (StatusCodeMissingServerID), classified as missing_identity, not connection_error.
 func TestClassifyTelegramSetupResult_ConnectionDistinctFromUnexpected(t *testing.T) {
 	conn := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 0, Error: errors.New("conn")}})
 	other := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 500, Message: "x"}})

--- a/internal/orchestrator/telegram_setup_classify_test.go
+++ b/internal/orchestrator/telegram_setup_classify_test.go
@@ -161,3 +161,24 @@ func TestClassifyTelegramSetupResult_TruncatesUnexpectedMessage(t *testing.T) {
 		t.Fatalf("message length=%d runes, want <= %d", len(runes), TelegramSetupStatusMessageMaxRunes)
 	}
 }
+
+// TestClassifyTelegramSetupResult_SanitizesUnexpectedBody pins that the shared
+// classifier strips terminal/control sequences from untrusted upstream text, so
+// the TUI (which only tview.Escapes) cannot be garbled or injected by a hostile
+// relay response.
+func TestClassifyTelegramSetupResult_SanitizesUnexpectedBody(t *testing.T) {
+	raw := "weird\x1b[31m body\x07\twith\x00controls\x9b2K"
+	st := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 500, Message: raw}})
+
+	if st.Code != "unexpected_response" {
+		t.Fatalf("Code=%q, want unexpected_response", st.Code)
+	}
+	if st.Message == "" {
+		t.Fatalf("expected a non-empty sanitized message")
+	}
+	for _, r := range st.Message {
+		if r == 0x1b || r == 0x9b || r == 0x07 || r == 0x00 || r == '\t' {
+			t.Fatalf("classifier left a control/escape byte (%#x) in Message: %q", r, st.Message)
+		}
+	}
+}

--- a/internal/orchestrator/telegram_setup_sanitize.go
+++ b/internal/orchestrator/telegram_setup_sanitize.go
@@ -1,0 +1,131 @@
+package orchestrator
+
+import (
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// SanitizeTelegramSetupStatusMessage strips terminal/control sequences from an
+// untrusted upstream status message and truncates it, producing copy that is safe
+// to render in BOTH the CLI and the TUI. The classifier is the single source of
+// truth for setup copy, and the TUI only tview.Escapes the string (it does NOT
+// strip control bytes), so a hostile relay response must be scrubbed HERE so both
+// UIs consume the same safe message. Falls back to an ASCII-quoted form when
+// stripping empties the string.
+func SanitizeTelegramSetupStatusMessage(raw string) string {
+	msg := strings.TrimSpace(raw)
+	if msg == "" {
+		return ""
+	}
+
+	sanitized := stripTelegramTerminalSequences(msg)
+	sanitized = TruncateTelegramSetupStatusMessage(sanitized)
+	if sanitized != "" {
+		return sanitized
+	}
+
+	quoted := strconv.QuoteToASCII(msg)
+	quoted = strings.TrimPrefix(quoted, `"`)
+	quoted = strings.TrimSuffix(quoted, `"`)
+	return TruncateTelegramSetupStatusMessage(quoted)
+}
+
+func stripTelegramTerminalSequences(msg string) string {
+	var b strings.Builder
+	b.Grow(len(msg))
+	pendingSpace := false
+
+	for i := 0; i < len(msg); {
+		switch msg[i] {
+		case 0x1b:
+			i = skipTelegramEscapeSequence(msg, i)
+			pendingSpace = true
+			continue
+		case 0x9b:
+			i = skipTelegramCSI(msg, i+1)
+			pendingSpace = true
+			continue
+		}
+
+		r, size := utf8.DecodeRuneInString(msg[i:])
+		if r == utf8.RuneError && size == 1 {
+			i++
+			continue
+		}
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			pendingSpace = true
+			i += size
+			continue
+		}
+		if !unicode.IsPrint(r) {
+			i += size
+			continue
+		}
+		if pendingSpace && b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		pendingSpace = false
+		b.WriteRune(r)
+		i += size
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+func skipTelegramEscapeSequence(msg string, i int) int {
+	if i >= len(msg) || msg[i] != 0x1b {
+		return i + 1
+	}
+	i++
+	if i >= len(msg) {
+		return i
+	}
+	switch msg[i] {
+	case '[':
+		return skipTelegramCSI(msg, i+1)
+	case ']':
+		return skipTelegramOSC(msg, i+1)
+	case 'P', 'X', '^', '_':
+		return skipTelegramST(msg, i+1)
+	default:
+		return i + 1
+	}
+}
+
+func skipTelegramCSI(msg string, i int) int {
+	for i < len(msg) {
+		b := msg[i]
+		i++
+		if b >= 0x40 && b <= 0x7e {
+			return i
+		}
+	}
+	return i
+}
+
+func skipTelegramOSC(msg string, i int) int {
+	for i < len(msg) {
+		switch msg[i] {
+		case 0x07:
+			return i + 1
+		case 0x1b:
+			if i+1 < len(msg) && msg[i+1] == '\\' {
+				return i + 2
+			}
+		}
+		i++
+	}
+	return i
+}
+
+func skipTelegramST(msg string, i int) int {
+	for i < len(msg) {
+		if msg[i] == 0x1b && i+1 < len(msg) && msg[i+1] == '\\' {
+			return i + 2
+		}
+		i++
+	}
+	return i
+}

--- a/internal/tui/wizard/telegram_setup_tui.go
+++ b/internal/tui/wizard/telegram_setup_tui.go
@@ -3,15 +3,18 @@ package wizard
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
+	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/notify"
 	"github.com/tis24dev/proxsave/internal/orchestrator"
 	"github.com/tis24dev/proxsave/internal/tui"
+	"github.com/tis24dev/proxsave/internal/types"
 )
 
 var (
@@ -22,7 +25,7 @@ var (
 	}
 
 	telegramSetupBuildBootstrap    = orchestrator.BuildTelegramSetupBootstrap
-	telegramSetupCheckRegistration = notify.CheckTelegramRegistration
+	telegramSetupCheckRegistration = notify.CheckTelegramRegistrationAndProvision
 	telegramSetupQueueUpdateDraw   = func(app *tui.App, f func()) { app.QueueUpdateDraw(f) }
 	telegramSetupGo                = func(fn func()) { go fn() }
 )
@@ -34,6 +37,8 @@ type TelegramSetupResult struct {
 
 	CheckAttempts     int
 	Verified          bool
+	Partial           bool
+	LastStatusFatal   bool
 	LastStatusCode    int
 	LastStatusMessage string
 	LastStatusError   string
@@ -54,6 +59,12 @@ func RunTelegramSetupWizard(ctx context.Context, baseDir, configPath, buildSig s
 		result.Shown = false
 		return result, nil
 	}
+
+	// Real-but-silent logger: the reused provision path registers and masks the
+	// relay secret via this logger, but io.Discard keeps any debug line out of the
+	// tview surface so the rendering is never corrupted.
+	silentLogger := logging.New(types.LogLevelDebug, false)
+	silentLogger.SetOutput(io.Discard)
 
 	app := tui.NewApp()
 	pages := tview.NewPages()
@@ -152,7 +163,7 @@ func RunTelegramSetupWizard(ctx context.Context, baseDir, configPath, buildSig s
 		setStatus("[blue]Checking registration…[white]\n\nPlease wait.")
 		serverID := result.ServerID
 		telegramSetupGo(func() {
-			status := telegramSetupCheckRegistration(checkCtx, result.ServerAPIHost, serverID, nil)
+			res := telegramSetupCheckRegistration(checkCtx, result.ServerAPIHost, serverID, baseDir, silentLogger)
 			telegramSetupQueueUpdateDraw(app, func() {
 				mu.Lock()
 				defer mu.Unlock()
@@ -161,41 +172,37 @@ func RunTelegramSetupWizard(ctx context.Context, baseDir, configPath, buildSig s
 				}
 				checking = false
 
+				status := res.Status
 				result.CheckAttempts++
 				result.LastStatusCode = status.Code
-				result.LastStatusMessage = status.Message
+				result.LastStatusMessage = status.Message // RAW preserved (truncation/escaping tests assert raw)
 				if status.Error != nil {
 					result.LastStatusError = status.Error.Error()
 				} else {
 					result.LastStatusError = ""
 				}
 
-				if status.Code == 200 && status.Error == nil {
+				st := orchestrator.ClassifyTelegramSetupResult(res)
+				result.LastStatusFatal = st.Fatal
+				if st.Verified { // latch: a later re-check can never un-verify
 					result.Verified = true
-					setStatus(fmt.Sprintf("[green]✓ Linked successfully.[white]\n\n%s", tview.Escape(status.Message)))
-					if refreshButtons != nil {
-						refreshButtons()
-					}
-					return
+					result.Partial = st.Partial
 				}
 
-				msg := status.Message
-				if msg == "" {
-					msg = "Registration not active yet"
-				}
-				var hint string
-				switch status.Code {
-				case 403, 409:
-					hint = "\n\nStart the bot, send the Server ID, then press Check again."
-				case 422:
-					hint = "\n\nThe Server ID appears invalid. If this persists, re-run the installer or regenerate the identity file."
+				switch {
+				case st.Verified && !st.Partial:
+					setStatus(fmt.Sprintf("[green]✓ %s[white]", tview.Escape(st.Message)))
+				case st.Verified && st.Partial:
+					setStatus(fmt.Sprintf("[orange]%s[white]", tview.Escape(st.Message)))
+				case st.Fatal:
+					setStatus(fmt.Sprintf("[red]%s[white]", tview.Escape(st.Message)))
 				default:
-					hint = "\n\nYou can press Check again, or Skip verification and complete pairing later."
+					hint := "\n\n" + orchestrator.TelegramSetupRetryHint
+					if result.CheckAttempts >= orchestrator.TelegramSetupMaxVerificationAttempts {
+						hint = "\n\n" + orchestrator.TelegramSetupMaxAttemptsHint
+					}
+					setStatus(fmt.Sprintf("[yellow]%s[white]%s", tview.Escape(st.Message), hint))
 				}
-				if result.CheckAttempts >= orchestrator.TelegramSetupMaxVerificationAttempts {
-					hint = "\n\nMaximum verification attempts reached. Skip and complete pairing later by running proxsave."
-				}
-				setStatus(fmt.Sprintf("[yellow]%s[white]%s", tview.Escape(orchestrator.TruncateTelegramSetupStatusMessage(msg)), hint))
 				if refreshButtons != nil {
 					refreshButtons()
 				}
@@ -207,8 +214,10 @@ func RunTelegramSetupWizard(ctx context.Context, baseDir, configPath, buildSig s
 		form.ClearButtons()
 		// Stop offering another check once the shared attempt cap is reached (and
 		// not yet verified), matching the CLI which stops after the same number of
-		// attempts; an explicit Skip is then required to leave.
-		if result.Verified || result.CheckAttempts < orchestrator.TelegramSetupMaxVerificationAttempts {
+		// attempts; an explicit Skip is then required to leave. A fatal status
+		// (invalid Server ID / upgrade required) also removes Check: re-checking
+		// cannot help, so the user must Skip and resolve it out of band.
+		if !result.LastStatusFatal && (result.Verified || result.CheckAttempts < orchestrator.TelegramSetupMaxVerificationAttempts) {
 			form.AddButton("Check", checkHandler)
 		}
 		if result.Verified {

--- a/internal/tui/wizard/telegram_setup_tui_test.go
+++ b/internal/tui/wizard/telegram_setup_tui_test.go
@@ -288,14 +288,14 @@ func TestRunTelegramSetupWizard_CentralizedSuccess_RequiresCheckBeforeContinue(t
 		state.ServerID = "987654321"
 		return state, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		if serverAPIHost != "https://api.example.test" {
 			t.Fatalf("serverAPIHost=%q, want https://api.example.test", serverAPIHost)
 		}
 		if serverID != "987654321" {
 			t.Fatalf("serverID=%q, want 987654321", serverID)
 		}
-		return notify.TelegramRegistrationStatus{Code: 200, Message: "ok"}
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200, Message: "ok"}}
 	}
 	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
 		form := focus.(*tview.Form)
@@ -438,15 +438,17 @@ func TestRunTelegramSetupWizard_CentralizedFailure_CanRetryAndSkip(t *testing.T)
 		state.ServerID = "111222333"
 		return state, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		calls++
 		switch calls {
 		case 1:
-			return notify.TelegramRegistrationStatus{Code: 403, Error: errors.New("not registered")}
+			return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 403, Error: errors.New("not registered")}}
 		case 2:
-			return notify.TelegramRegistrationStatus{Code: 422, Message: "invalid"}
+			// 422 is now Fatal and strips the Check button; use 409 here so all
+			// three retry presses still find the Check button.
+			return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 409, Message: "invalid"}}
 		default:
-			return notify.TelegramRegistrationStatus{Code: 500, Message: "oops"}
+			return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 500, Message: "oops"}}
 		}
 	}
 	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
@@ -495,9 +497,9 @@ func TestRunTelegramSetupWizard_StopsOfferingCheckAtCap(t *testing.T) {
 		return eligibleTelegramSetupBootstrap(), nil
 	}
 	calls := 0
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		calls++
-		return notify.TelegramRegistrationStatus{Code: 403, Error: errors.New("not registered")}
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 403, Error: errors.New("not registered")}}
 	}
 	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
 		form := focus.(*tview.Form)
@@ -536,11 +538,11 @@ func TestRunTelegramSetupWizard_TruncatesLongFailureMessage(t *testing.T) {
 	telegramSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.TelegramSetupBootstrap, error) {
 		return eligibleTelegramSetupBootstrap(), nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
-		return notify.TelegramRegistrationStatus{
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{
 			Code:    500,
 			Message: "  " + longMessage + "  ",
-		}
+		}}
 	}
 	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
 		_, statusView, form := extractTelegramSetupViews(t, root)
@@ -587,11 +589,11 @@ func TestRunTelegramSetupWizard_EscapesBracketedStatusMessage(t *testing.T) {
 	telegramSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.TelegramSetupBootstrap, error) {
 		return eligibleTelegramSetupBootstrap(), nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
-		return notify.TelegramRegistrationStatus{
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{
 			Code:    500,
 			Message: bracketedMessage,
-		}
+		}}
 	}
 	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
 		_, statusView, form := extractTelegramSetupViews(t, root)
@@ -663,8 +665,8 @@ func TestRunTelegramSetupWizard_CentralizedEscAfterVerificationDoesNotSkip(t *te
 	telegramSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.TelegramSetupBootstrap, error) {
 		return eligibleTelegramSetupBootstrap(), nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
-		return notify.TelegramRegistrationStatus{Code: 200, Message: "ok"}
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200, Message: "ok"}}
 	}
 	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
 		_, _, form := extractTelegramSetupViews(t, root)
@@ -731,9 +733,9 @@ func TestRunTelegramSetupWizard_CheckIgnoredWhileChecking_AndUpdateSuppressedAft
 		state.ServerID = "999888777"
 		return state, nil
 	}
-	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID string, logger *logging.Logger) notify.TelegramRegistrationStatus {
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
 		checkCalls++
-		return notify.TelegramRegistrationStatus{Code: 200, Message: "ok"}
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200, Message: "ok"}}
 	}
 	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
 		form := focus.(*tview.Form)
@@ -765,6 +767,110 @@ func TestRunTelegramSetupWizard_CheckIgnoredWhileChecking_AndUpdateSuppressedAft
 	}
 	if checkCalls != 1 {
 		t.Fatalf("checkCalls=%d, want 1", checkCalls)
+	}
+}
+
+// TestRunTelegramSetupWizard_UpgradeRequiredStopsRetry pins that a 426 (upgrade
+// required) is fatal: the Check button is removed after the first press (a re-check
+// cannot help), the distinct upgrade message is shown, and the user must Skip.
+func TestRunTelegramSetupWizard_UpgradeRequiredStopsRetry(t *testing.T) {
+	stubTelegramSetupDeps(t)
+
+	telegramSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.TelegramSetupBootstrap, error) {
+		return eligibleTelegramSetupBootstrap(), nil
+	}
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
+		return notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{
+			Code:    426,
+			Message: "426 - Upgrade ProxSave to v0.28.0 or later to complete pairing",
+			Error:   errors.New("upgrade"),
+		}}
+	}
+	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
+		_, statusView, form := extractTelegramSetupViews(t, root)
+
+		pressFormButton(t, form, "Check")
+
+		if form.GetButtonIndex("Check") != -1 {
+			t.Fatalf("expected Check button to be removed after a fatal upgrade-required status")
+		}
+		if form.GetButtonIndex("Continue") != -1 {
+			t.Fatalf("expected no Continue button when not verified")
+		}
+		if form.GetButtonIndex("Skip") == -1 {
+			t.Fatalf("expected Skip button after a fatal status")
+		}
+		text := statusView.GetText(true)
+		if !strings.Contains(text, "Upgrade ProxSave to v0.28.0 or later to complete pairing.") {
+			t.Fatalf("expected upgrade-required message, got %q", text)
+		}
+
+		pressFormButton(t, form, "Skip")
+		return nil
+	}
+
+	result, err := RunTelegramSetupWizard(context.Background(), t.TempDir(), "/fake/backup.env", "sig")
+	if err != nil {
+		t.Fatalf("RunTelegramSetupWizard error: %v", err)
+	}
+	if result.Verified {
+		t.Fatalf("expected Verified=false")
+	}
+	if !result.LastStatusFatal {
+		t.Fatalf("expected LastStatusFatal=true")
+	}
+	if result.LastStatusCode != 426 {
+		t.Fatalf("LastStatusCode=%d, want 426", result.LastStatusCode)
+	}
+	if !result.SkippedVerification {
+		t.Fatalf("expected SkippedVerification=true")
+	}
+}
+
+// TestRunTelegramSetupWizard_PartialShownDistinct pins that a 200 with a failed
+// confirm counts as verified (Continue is offered, pairing self-heals next backup)
+// but shows a distinct partial message rather than the clean "Linked successfully."
+func TestRunTelegramSetupWizard_PartialShownDistinct(t *testing.T) {
+	stubTelegramSetupDeps(t)
+
+	telegramSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.TelegramSetupBootstrap, error) {
+		return eligibleTelegramSetupBootstrap(), nil
+	}
+	telegramSetupCheckRegistration = func(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) notify.TelegramRegistrationResult {
+		return notify.TelegramRegistrationResult{
+			Status:    notify.TelegramRegistrationStatus{Code: 200, Message: "ok"},
+			Provision: notify.TelegramProvisionConfirmFailed,
+		}
+	}
+	telegramSetupWizardRunner = func(ctx context.Context, app *tui.App, root, focus tview.Primitive) error {
+		_, statusView, form := extractTelegramSetupViews(t, root)
+
+		pressFormButton(t, form, "Check")
+
+		text := statusView.GetText(true)
+		if !strings.Contains(text, "confirmation did not complete") {
+			t.Fatalf("expected distinct partial message, got %q", text)
+		}
+		if form.GetButtonIndex("Continue") == -1 {
+			t.Fatalf("expected Continue button after partial verification")
+		}
+
+		pressFormButton(t, form, "Continue")
+		return nil
+	}
+
+	result, err := RunTelegramSetupWizard(context.Background(), t.TempDir(), "/fake/backup.env", "sig")
+	if err != nil {
+		t.Fatalf("RunTelegramSetupWizard error: %v", err)
+	}
+	if !result.Verified {
+		t.Fatalf("expected Verified=true")
+	}
+	if !result.Partial {
+		t.Fatalf("expected Partial=true")
+	}
+	if result.SkippedVerification {
+		t.Fatalf("expected SkippedVerification=false")
 	}
 }
 


### PR DESCRIPTION
Automated release PR for `v0.28.0`.

<!-- release-tag: v0.28.0 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded Telegram setup verification to provide consistent messaging for verified, partially verified, and “upgrade required” outcomes, with improved retry/continue behavior.
  * Telegram notifications can now use a centrally managed relay with one-time provisioning and securely persisted relay secrets.

* **Bug Fixes**
  * Reduced the chance of leaking sensitive Telegram secrets in logs and error text.
  * Improved handling when relay provisioning, persistence, or confirmation partially fails—verification can still succeed when safe.

* **Documentation**
  * Added clarification about where the relay secret is provisioned and stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a centralized relay-secret provisioning mechanism for Telegram notifications, replacing direct bot-token delivery with a TOFU (Trust On First Use) per-server secret stored immutably under `<BASE_DIR>/identity/.notify_secret`. The setup CLI/TUI verification flow is unified through a new `ClassifyTelegramSetupResult` classifier, ensuring identical copy and retry/fatal policy across both surfaces.

- **Relay provisioning (`internal/notify/telegram.go`, `telegram_registration.go`)**: A `CheckTelegramRegistrationAndProvision` function performs the registration check, persists the server-issued relay secret via `identity.PersistNotifySecret`, and confirms it back to the server. `Send` lazily loads an existing secret and uses it for relay delivery, falling back to the legacy bot-token path if none is present. A stale-secret recovery loop is bounded to two relay attempts per run.
- **Secret containment (`internal/identity/identity.go`)**: `LoadNotifySecret` and `PersistNotifySecret` use `os.OpenRoot` (Go 1.24+, supported by `go 1.25.11`) for directory-confined reads, resolving gosec G304 structurally, with a symlink-escape containment test.
- **Classifier unification (`internal/orchestrator/telegram_setup_classify.go`, `telegram_setup_sanitize.go`)**: The sanitizer and classifier are moved to the orchestrator package so CLI, TUI, and the status probe all render identical safe copy. Fatal states (422/426) suppress the "Check again?" button/prompt in both UIs.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge. The relay provisioning, secret persistence, and stale-secret recovery paths are all well-tested end-to-end, including symlink-escape containment and secret-redaction cases.

The relay provisioning flow is carefully constructed: secrets are registered with the logger masker before any log line that could include the raw body, the stale-secret recovery loop is provably bounded to two relay attempts per Send call, and path containment via os.OpenRoot is verified by a dedicated test. The classifier unification removes the divergence between CLI and TUI copy that existed before. The single observation (bot token not pre-registered in fetchCentralizedCredentials) has no current impact because the debug line at that point uses only a boolean flag, not the token value.

internal/notify/telegram.go — the fetchCentralizedCredentials provisioning block is the most complex new path and worth a second read, particularly the conditional around BaseDir and the in-memory NotifySecret mutation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/notify/telegram.go | Adds relay delivery path, lazy secret loading, TOFU provisioning in fetchCentralizedCredentials, and stale-secret recovery; response.BotToken is not pre-registered with the masker before the boolean debug line (no current leak, but pattern diverges from the registration path). |
| internal/identity/identity.go | Adds PersistNotifySecret/LoadNotifySecret with os.OpenRoot path containment (Go 1.24+, compatible with go 1.25.11) and migrates loadServerID/maybeUpgradeIdentityFileWithContext to the same containment helper. |
| internal/notify/telegram_registration.go | Adds StatusCodeMissingServerID sentinel, TelegramProvisionOutcome enum, TelegramRegistrationResult, CheckTelegramRegistrationAndProvision, and confirmTelegramRelaySecret; secret and bot-token are registered before body-preview log on 200. |
| internal/orchestrator/telegram_setup_classify.go | New classifier mapping (status, provision) -> TelegramSetupState with stable Code, Message, Verified, Partial, and Fatal fields; shared retry/max-attempts copy constants ensure CLI/TUI parity. |
| cmd/proxsave/telegram_setup_cli.go | Refactored to use ClassifyTelegramSetupResult and CheckTelegramRegistrationAndProvision; fatal states (422/426) now return without offering "Check again?"; sanitizer delegated to orchestrator package. |
| internal/tui/wizard/telegram_setup_tui.go | Updated to use ClassifyTelegramSetupResult; adds Partial and LastStatusFatal to TelegramSetupResult; fatal status removes Check button; partial verification shows orange distinct message. |
| internal/orchestrator/telegram_setup_sanitize.go | Sanitizer logic moved verbatim from telegram_setup_cli.go to the orchestrator package and exported as SanitizeTelegramSetupStatusMessage for shared use by CLI, TUI, and classifier. |
| cmd/proxsave/backup_notifications.go | Registers TelegramNotifySecret with the logger and threads NotifySecret + BaseDir into TelegramConfig for the backup notification path. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Send as TelegramNotifier.Send
    participant Disk as identity/.notify_secret
    participant Relay as Central Server (/api/notify)
    participant GetChatID as Central Server (/api/get-chat-id)
    participant Confirm as Central Server (/api/confirm-secret)
    participant TgAPI as api.telegram.org

    alt Secret persisted on disk
        Send->>Disk: LoadNotifySecret(baseDir)
        Disk-->>Send: secret
        Send->>Send: RegisterSecret(secret)
    end

    alt NotifySecret set
        Send->>Relay: POST /api/notify (X-Server-Auth: secret)
        Relay-->>Send: 200 OK
        Send-->>Send: success
    else Relay rejects (401/403)
        Relay-->>Send: errRelayAuthRejected
        Send->>Send: drop stale secret
    end

    alt No secret OR stale secret dropped
        Send->>GetChatID: GET /api/get-chat-id (X-Proxsave-Provision: 1)
        GetChatID-->>Send: "200 {bot_token, chat_id, notify_secret}"
        Send->>Send: RegisterSecret(notify_secret)
        Send->>Disk: PersistNotifySecret(baseDir, secret)
        Send->>Confirm: POST /api/confirm-secret (X-Server-Auth: secret)
        Confirm-->>Send: 200 OK
        Send->>Relay: POST /api/notify (X-Server-Auth: fresh secret)
        Relay-->>Send: 200 OK
        Send-->>Send: success
    else No secret in 200 body (legacy)
        Send->>TgAPI: POST sendMessage (bot_token, chat_id, message)
        TgAPI-->>Send: 200 OK
        Send-->>Send: success
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Send as TelegramNotifier.Send
    participant Disk as identity/.notify_secret
    participant Relay as Central Server (/api/notify)
    participant GetChatID as Central Server (/api/get-chat-id)
    participant Confirm as Central Server (/api/confirm-secret)
    participant TgAPI as api.telegram.org

    alt Secret persisted on disk
        Send->>Disk: LoadNotifySecret(baseDir)
        Disk-->>Send: secret
        Send->>Send: RegisterSecret(secret)
    end

    alt NotifySecret set
        Send->>Relay: POST /api/notify (X-Server-Auth: secret)
        Relay-->>Send: 200 OK
        Send-->>Send: success
    else Relay rejects (401/403)
        Relay-->>Send: errRelayAuthRejected
        Send->>Send: drop stale secret
    end

    alt No secret OR stale secret dropped
        Send->>GetChatID: GET /api/get-chat-id (X-Proxsave-Provision: 1)
        GetChatID-->>Send: "200 {bot_token, chat_id, notify_secret}"
        Send->>Send: RegisterSecret(notify_secret)
        Send->>Disk: PersistNotifySecret(baseDir, secret)
        Send->>Confirm: POST /api/confirm-secret (X-Server-Auth: secret)
        Confirm-->>Send: 200 OK
        Send->>Relay: POST /api/notify (X-Server-Auth: fresh secret)
        Relay-->>Send: 200 OK
        Send-->>Send: success
    else No secret in 200 body (legacy)
        Send->>TgAPI: POST sendMessage (bot_token, chat_id, message)
        TgAPI-->>Send: 200 OK
        Send-->>Send: success
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["refactor(notify): add TelegramProvisionC..."](https://github.com/tis24dev/proxsave/commit/9a2615b388d2d24a0bc43e467c8568e50d66e2df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40958005)</sub>

<!-- /greptile_comment -->