### PR TITLE
Release v0.29.0

### DIFF
--- a/cmd/proxsave/backup_notifications.go
+++ b/cmd/proxsave/backup_notifications.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/logging"
@@ -104,6 +105,10 @@ func initializeTelegramNotification(opts backupModeOptions, orch *orchestrator.O
 		ServerID:      cfg.ServerID,
 		NotifySecret:  cfg.TelegramNotifySecret,
 		BaseDir:       cfg.BaseDir,
+
+		ConfirmDelivery: cfg.TelegramConfirmDelivery,
+		ConfirmTimeout:  time.Duration(cfg.TelegramConfirmTimeoutS) * time.Second,
+		ConfirmInterval: time.Duration(cfg.TelegramConfirmIntervalS) * time.Second,
 	}
 	telegramNotifier, err := notify.NewTelegramNotifier(telegramConfig, logger)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,6 +194,12 @@ type Config struct {
 	ServerID              string // Server identifier for centralized mode
 	TelegramNotifySecret  string // Deprecated: no longer read from backup.env; the relay secret is provisioned via TOFU into the immutable identity file. Kept "" for compatibility.
 
+	// Telegram delivery confirmation (two-response CLI): poll the server for the
+	// real Telegram delivery outcome after the relay accepts the notification.
+	TelegramConfirmDelivery  bool
+	TelegramConfirmTimeoutS  int
+	TelegramConfirmIntervalS int
+
 	// Email Notifications
 	EmailEnabled          bool
 	EmailDeliveryMethod   string // "relay", "sendmail", or "pmf"
@@ -731,6 +737,9 @@ func (c *Config) parseNotificationSettings() {
 	c.TelegramServerAPIHost = "https://bot.tis24.it:1443"
 	c.ServerID = ""
 	c.TelegramNotifySecret = "" // no longer read from backup.env; provisioned via TOFU into the immutable identity file
+	c.TelegramConfirmDelivery = c.getBool("TELEGRAM_CONFIRM_DELIVERY", true)
+	c.TelegramConfirmTimeoutS = c.getInt("TELEGRAM_CONFIRM_TIMEOUT_SECONDS", 10)
+	c.TelegramConfirmIntervalS = c.getInt("TELEGRAM_CONFIRM_INTERVAL_SECONDS", 1)
 
 	c.EmailEnabled = c.getBoolWithLegacyAlias(emailEnabledKey, emailEnableLegacyKey, false)
 	c.EmailDeliveryMethod = NormalizeEmailDeliveryMethod(c.getString("EMAIL_DELIVERY_METHOD", "relay"))

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -508,9 +508,15 @@ func (t *TelegramNotifier) pollCfg() deliveryPollConfig {
 	if interval <= 0 {
 		interval = time.Second
 	}
+	if interval > 5*time.Second {
+		interval = 5 * time.Second // ceiling: a mis-set interval must not starve the poll
+	}
 	timeout := t.config.ConfirmTimeout
 	if timeout <= 0 {
 		timeout = 10 * time.Second
+	}
+	if timeout > 60*time.Second {
+		timeout = 60 * time.Second // ceiling: never hang end-of-backup for minutes
 	}
 	return deliveryPollConfig{
 		Timeout:      timeout,

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -215,7 +215,7 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 		message := t.buildMessage(data)
 		status, err := t.sendViaRelay(ctx, message, notifyID)
 		if err == nil {
-			t.recordRelayAcceptedAndPoll(ctx, result, notifyID, status)
+			t.recordRelayAcceptedAndPoll(ctx, result, notifyID, status, time.Since(startTime))
 			result.Success = true
 			result.Duration = time.Since(startTime)
 			return result, nil
@@ -267,7 +267,7 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 				result.Duration = time.Since(startTime)
 				return result, nil // Non-critical error, don't abort backup
 			}
-			t.recordRelayAcceptedAndPoll(ctx, result, notifyID, status)
+			t.recordRelayAcceptedAndPoll(ctx, result, notifyID, status, time.Since(startTime))
 			result.Success = true
 			result.Duration = time.Since(startTime)
 			return result, nil
@@ -469,9 +469,12 @@ func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message, notifyID s
 // result.Metadata (relay_accepted, notify_id, telegram_state, telegram_message_id,
 // telegram_reason); it NEVER changes result.Success -- server acceptance is the
 // success signal, the delivery outcome is a separate best-effort line.
-func (t *TelegramNotifier) recordRelayAcceptedAndPoll(ctx context.Context, result *NotificationResult, notifyID string, httpStatus int) {
+func (t *TelegramNotifier) recordRelayAcceptedAndPoll(ctx context.Context, result *NotificationResult, notifyID string, httpStatus int, acceptDuration time.Duration) {
 	result.Metadata["relay_accepted"] = true
 	result.Metadata["notify_id"] = notifyID
+	// Time to server ACCEPTANCE only (before any delivery poll), so the adapter's
+	// first line reports true relay latency, not latency + the poll budget.
+	result.Metadata["relay_accept_duration"] = acceptDuration
 
 	// HTTP 200 = legacy synchronous relay (outbox kill-switch off): the server
 	// already delivered inside the request, so there is nothing to poll.
@@ -480,7 +483,10 @@ func (t *TelegramNotifier) recordRelayAcceptedAndPoll(ctx context.Context, resul
 		return
 	}
 	if !t.config.ConfirmDelivery {
-		result.Metadata["telegram_state"] = "pending" // confirmation disabled by config
+		// Confirmation disabled by config: this is NOT a pending delivery, so use a
+		// distinct state and let the adapter stay quiet (no "delivery in progress"
+		// warning on every backup).
+		result.Metadata["telegram_state"] = "unconfirmed"
 		return
 	}
 
@@ -507,7 +513,6 @@ func (t *TelegramNotifier) pollCfg() deliveryPollConfig {
 		timeout = 10 * time.Second
 	}
 	return deliveryPollConfig{
-		Enabled:      t.config.ConfirmDelivery,
 		Timeout:      timeout,
 		Interval:     interval,
 		InitialDelay: interval,

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -3,6 +3,8 @@ package notify
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,6 +33,23 @@ const proxsaveVersionHeader = "X-Proxsave-Version"
 // secret). Sent ONLY by the two provisioning paths, never the bare status probe.
 const proxsaveProvisionHeader = "X-Proxsave-Provision"
 
+// proxsaveNotifyIDHeader carries a client-generated id that makes the enqueue
+// idempotent and is the handle the client polls for the real delivery outcome.
+const proxsaveNotifyIDHeader = "X-Notify-Id"
+
+// newNotifyID returns a random 32-hex-char id (<=128, matching the server's cap).
+// Generated ONCE per Send and reused across the relay POST + status poll (and any
+// relay retry) so the server-side idempotency dedupe never double-queues.
+func newNotifyID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand effectively never fails; on the impossible error fall back to
+		// a time-derived id so the poll still has a usable handle.
+		return fmt.Sprintf("t%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
 // setProxsaveVersionHeader stamps an outbound central-server request with the
 // normalized ProxSave version (e.g. "0.28.0").
 func setProxsaveVersionHeader(req *http.Request) string {
@@ -57,6 +76,12 @@ type TelegramConfig struct {
 	ServerID      string // Server identifier for centralized mode
 	NotifySecret  string // Per-server relay secret; when set, use the server-side relay
 	BaseDir       string // Identity store root for lazy-load / persist of the relay secret
+
+	// Delivery confirmation (two-response CLI): after the relay accepts (202), poll
+	// GET /api/notify/status until Telegram confirms delivery or the budget elapses.
+	ConfirmDelivery bool
+	ConfirmTimeout  time.Duration
+	ConfirmInterval time.Duration
 }
 
 // TelegramNotifier implements the Notifier interface for Telegram
@@ -152,6 +177,10 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 		Method:   "telegram",
 		Metadata: make(map[string]interface{}),
 	}
+	// One idempotent id per notification, reused across the relay POST and the
+	// delivery-status poll (and any relay retry after a stale-secret reprovision) so
+	// the server-side idempotency dedupe never double-queues this notification.
+	notifyID := newNotifyID()
 
 	if !t.config.Enabled {
 		t.logger.Debug("Telegram notifications disabled")
@@ -184,15 +213,16 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 	if t.config.Mode == TelegramModeCentralized && t.config.NotifySecret != "" {
 		t.logger.Debug("Telegram: using server-side relay path (bot token stays on host)")
 		message := t.buildMessage(data)
-		err := t.sendViaRelay(ctx, message)
+		status, err := t.sendViaRelay(ctx, message, notifyID)
 		if err == nil {
-			t.logger.Debug("Telegram relay confirmed delivery")
+			t.recordRelayAcceptedAndPoll(ctx, result, notifyID, status)
 			result.Success = true
 			result.Duration = time.Since(startTime)
 			return result, nil
 		}
 		if !errors.Is(err, errRelayAuthRejected) {
 			t.logger.Warning("WARNING: Failed to send Telegram notification via relay: %v", err)
+			result.Metadata["relay_accepted"] = false
 			result.Success = false
 			result.Error = err
 			result.Duration = time.Since(startTime)
@@ -228,14 +258,16 @@ func (t *TelegramNotifier) Send(ctx context.Context, data *NotificationData) (*N
 		if t.config.NotifySecret != "" {
 			t.logger.Debug("Telegram: fetch provisioned a fresh relay secret; relaying this run")
 			message := t.buildMessage(data)
-			if err := t.sendViaRelay(ctx, message); err != nil {
+			status, err := t.sendViaRelay(ctx, message, notifyID)
+			if err != nil {
 				t.logger.Warning("WARNING: Failed to send Telegram notification via relay: %v", err)
+				result.Metadata["relay_accepted"] = false
 				result.Success = false
 				result.Error = err
 				result.Duration = time.Since(startTime)
 				return result, nil // Non-critical error, don't abort backup
 			}
-			t.logger.Debug("Telegram relay confirmed delivery (first-run provisioning)")
+			t.recordRelayAcceptedAndPoll(ctx, result, notifyID, status)
 			result.Success = true
 			result.Duration = time.Since(startTime)
 			return result, nil
@@ -368,7 +400,7 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 // sendViaRelay sends a message through the authenticated server-side relay so
 // the bot token never leaves this host. The per-server secret is sent only in
 // the X-Server-Auth header; any returned error string is scrubbed of it.
-func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message string) error {
+func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message, notifyID string) (int, error) {
 	endpoint := strings.TrimRight(t.config.ServerAPIHost, "/") + "/api/notify"
 
 	payload := struct {
@@ -380,7 +412,7 @@ func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message string) err
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("failed to encode relay request: %w", err)
+		return 0, fmt.Errorf("failed to encode relay request: %w", err)
 	}
 
 	// 5-second timeout, mirroring fetchCentralizedCredentials.
@@ -389,39 +421,96 @@ func (t *TelegramNotifier) sendViaRelay(ctx context.Context, message string) err
 
 	req, err := http.NewRequestWithContext(reqCtx, "POST", endpoint, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("failed to create relay request: %w", err)
+		return 0, fmt.Errorf("failed to create relay request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Server-Auth", t.config.NotifySecret)
+	if notifyID != "" {
+		req.Header.Set(proxsaveNotifyIDHeader, notifyID)
+	}
 	pv := setProxsaveVersionHeader(req)
-	t.logger.Debug("Telegram: relay POST %s (serverID=%q msgLen=%d X-Proxsave-Version=%q)", endpoint, t.config.ServerID, len(message), pv)
+	t.logger.Debug("Telegram: relay POST %s (serverID=%q msgLen=%d notifyID=%q X-Proxsave-Version=%q)", endpoint, t.config.ServerID, len(message), notifyID, pv)
 
 	resp, err := t.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("relay request failed: %s", logging.RedactSecrets(err.Error(), t.config.NotifySecret))
+		return 0, fmt.Errorf("relay request failed: %s", logging.RedactSecrets(err.Error(), t.config.NotifySecret))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
-	case 200:
-		t.logger.Debug("Telegram: relay delivered (HTTP 200)")
-		return nil
+	case 200, 202:
+		// 200 = legacy synchronous relay (outbox kill-switch off) = already
+		// delivered. 202 = accepted onto the durable outbox; the real delivery
+		// outcome is learned via the status poll.
+		t.logger.Debug("Telegram: relay accepted (HTTP %d notifyID=%q)", resp.StatusCode, notifyID)
+		return resp.StatusCode, nil
 	case 401, 403:
-		return fmt.Errorf("%w (HTTP %d)", errRelayAuthRejected, resp.StatusCode)
+		return resp.StatusCode, fmt.Errorf("%w (HTTP %d)", errRelayAuthRejected, resp.StatusCode)
 	case 404:
-		return fmt.Errorf("server unknown (HTTP 404)")
+		return resp.StatusCode, fmt.Errorf("server unknown (HTTP 404)")
 	case 409:
-		return fmt.Errorf("registration missing (HTTP 409)")
+		return resp.StatusCode, fmt.Errorf("registration missing (HTTP 409)")
 	case 413:
-		return fmt.Errorf("message too long (HTTP 413)")
+		return resp.StatusCode, fmt.Errorf("message too long (HTTP 413)")
 	default:
 		respBody, _ := io.ReadAll(resp.Body)
 		snippet := string(respBody)
 		if len(snippet) > 200 {
 			snippet = snippet[:200]
 		}
-		return fmt.Errorf("relay returned status %d: %s",
+		return resp.StatusCode, fmt.Errorf("relay returned status %d: %s",
 			resp.StatusCode, logging.RedactSecrets(snippet, t.config.NotifySecret))
+	}
+}
+
+// recordRelayAcceptedAndPoll records that the ProxSave server accepted the
+// notification (first response) and, when confirmation is enabled, polls for the
+// real Telegram delivery outcome (second response). Everything lands in
+// result.Metadata (relay_accepted, notify_id, telegram_state, telegram_message_id,
+// telegram_reason); it NEVER changes result.Success -- server acceptance is the
+// success signal, the delivery outcome is a separate best-effort line.
+func (t *TelegramNotifier) recordRelayAcceptedAndPoll(ctx context.Context, result *NotificationResult, notifyID string, httpStatus int) {
+	result.Metadata["relay_accepted"] = true
+	result.Metadata["notify_id"] = notifyID
+
+	// HTTP 200 = legacy synchronous relay (outbox kill-switch off): the server
+	// already delivered inside the request, so there is nothing to poll.
+	if httpStatus == 200 {
+		result.Metadata["telegram_state"] = "delivered"
+		return
+	}
+	if !t.config.ConfirmDelivery {
+		result.Metadata["telegram_state"] = "pending" // confirmation disabled by config
+		return
+	}
+
+	ds := pollTelegramDeliveryStatus(ctx, t.client, t.config.ServerAPIHost,
+		t.config.ServerID, t.config.NotifySecret, notifyID, t.pollCfg(), t.logger)
+	result.Metadata["telegram_state"] = ds.State
+	if ds.State == "delivered" && ds.MessageID != 0 {
+		result.Metadata["telegram_message_id"] = ds.MessageID
+	}
+	if ds.State == "failed" {
+		result.Metadata["telegram_reason"] = ds.Reason
+	}
+}
+
+// pollCfg builds the delivery-status poll config from the notifier config, applying
+// sane floors so a mis-set interval/timeout can never spin.
+func (t *TelegramNotifier) pollCfg() deliveryPollConfig {
+	interval := t.config.ConfirmInterval
+	if interval <= 0 {
+		interval = time.Second
+	}
+	timeout := t.config.ConfirmTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return deliveryPollConfig{
+		Enabled:      t.config.ConfirmDelivery,
+		Timeout:      timeout,
+		Interval:     interval,
+		InitialDelay: interval,
 	}
 }
 

--- a/internal/notify/telegram_delivery_status.go
+++ b/internal/notify/telegram_delivery_status.go
@@ -1,0 +1,198 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+// deliveryPollConfig tunes the post-send delivery-status poll.
+type deliveryPollConfig struct {
+	Enabled      bool
+	Timeout      time.Duration // total budget across all attempts
+	Interval     time.Duration // base gap between attempts (grows with backoff)
+	InitialDelay time.Duration // wait before the first poll (delivery needs >=1s)
+}
+
+// deliveryStatus is the resolved outcome of the poll.
+type deliveryStatus struct {
+	State     string // "delivered" | "failed" | "pending" | "unknown"
+	MessageID int64
+	Reason    string
+	Attempts  int
+	Err       error
+}
+
+// notifyStatusResponse mirrors the GET /api/notify/status success body.
+type notifyStatusResponse struct {
+	State             string `json:"state"`
+	Attempts          int    `json:"attempts"`
+	Reason            string `json:"reason"`
+	TelegramMessageID int64  `json:"telegram_message_id"`
+}
+
+// pollTelegramDeliveryStatus polls GET /api/notify/status until the notification
+// leaves pending/sending (delivered or failed) or the time budget elapses. It NEVER
+// fails the caller: a still-pending row at the deadline returns "pending" (the
+// durable outbox keeps retrying), a definitive lookup miss/auth issue returns
+// "unknown", and transient network/5xx errors are retried until the deadline and
+// then reported as "pending" (accepted, delivery unconfirmed). Only X-Server-Auth is
+// sent; the bot token never appears here.
+func pollTelegramDeliveryStatus(ctx context.Context, client *http.Client, serverAPIHost, serverID, notifySecret, notifyID string, cfg deliveryPollConfig, logger *logging.Logger) deliveryStatus {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	done := logging.DebugStart(logger, "telegram delivery poll", "notifyID=%q timeout=%s interval=%s", notifyID, cfg.Timeout, cfg.Interval)
+
+	endpoint := strings.TrimRight(serverAPIHost, "/") + "/api/notify/status" +
+		"?server_id=" + url.QueryEscape(serverID) + "&notify_id=" + url.QueryEscape(notifyID)
+
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = time.Second
+	}
+	deadline := time.Now().Add(cfg.Timeout)
+
+	// Initial wait (+ per-notification jitter derived from notifyID so a burst of
+	// clients does not poll in lockstep). Deterministic -> test-stable.
+	if !sleepCtx(ctx, cfg.InitialDelay+notifyJitter(notifyID)) {
+		done(ctx.Err())
+		return deliveryStatus{State: "unknown", Err: ctx.Err()}
+	}
+
+	attempt := 0
+	result := deliveryStatus{State: "pending"}
+	for {
+		attempt++
+		st, retryable := fetchDeliveryStatusOnce(ctx, client, endpoint, notifySecret, deadline)
+		if logger != nil {
+			logger.Debug("Telegram: delivery poll attempt %d -> state=%s", attempt, st.State)
+		}
+		switch st.State {
+		case "delivered", "failed":
+			done(nil)
+			return st
+		case "pending":
+			result = st
+		default: // "unknown"
+			if !retryable {
+				// Definitive: old server (no route), row absent, stale secret, or
+				// relay disabled -> stop, nothing to gain by retrying.
+				done(nil)
+				return st
+			}
+			// Transient error: keep the accepted-but-unconfirmed "pending" result.
+		}
+
+		if !time.Now().Add(interval).Before(deadline) {
+			break // next sleep would overrun the budget
+		}
+		if !sleepCtx(ctx, interval) {
+			result.Err = ctx.Err()
+			done(result.Err)
+			return result
+		}
+		if interval < 3*time.Second { // gentle backoff, capped ~3s
+			interval *= 2
+			if interval > 3*time.Second {
+				interval = 3 * time.Second
+			}
+		}
+	}
+
+	done(nil)
+	if logger != nil {
+		logger.Debug("Telegram: delivery poll still pending after %s; treating as queued", cfg.Timeout)
+	}
+	return result
+}
+
+// fetchDeliveryStatusOnce does ONE GET. Returns the parsed status and whether an
+// "unknown" outcome is worth retrying (true for transient network/5xx, false for a
+// definitive 404/401/403/503).
+func fetchDeliveryStatusOnce(ctx context.Context, client *http.Client, endpoint, notifySecret string, deadline time.Time) (deliveryStatus, bool) {
+	// Cap the per-request timeout at the remaining budget so a hung server cannot
+	// overrun ConfirmTimeout by a whole 5s; keep a small floor so a near-expired
+	// budget still allows one real attempt.
+	reqTimeout := 5 * time.Second
+	if rem := time.Until(deadline); rem > 0 && rem < reqTimeout {
+		reqTimeout = rem
+	}
+	if reqTimeout < 250*time.Millisecond {
+		reqTimeout = 250 * time.Millisecond
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, reqTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, "GET", endpoint, nil)
+	if err != nil {
+		return deliveryStatus{State: "unknown", Err: err}, false
+	}
+	req.Header.Set("X-Server-Auth", notifySecret)
+	setProxsaveVersionHeader(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return deliveryStatus{State: "unknown", Err: err}, true // transient -> retry
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == 200:
+		var body notifyStatusResponse
+		if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&body); err != nil {
+			return deliveryStatus{State: "unknown", Err: err}, true
+		}
+		state := body.State
+		if state != "delivered" && state != "failed" && state != "pending" {
+			state = "pending"
+		}
+		return deliveryStatus{
+			State:     state,
+			MessageID: body.TelegramMessageID,
+			Reason:    body.Reason,
+			Attempts:  body.Attempts,
+		}, false
+	case resp.StatusCode == 404 || resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 503:
+		// Old server without the route, row not found, stale secret, or relay off:
+		// definitive, do not retry.
+		return deliveryStatus{State: "unknown", Err: fmt.Errorf("status HTTP %d", resp.StatusCode)}, false
+	default:
+		// 5xx or anything unexpected: transient, retry.
+		return deliveryStatus{State: "unknown", Err: fmt.Errorf("status HTTP %d", resp.StatusCode)}, true
+	}
+}
+
+// sleepCtx sleeps for d, returning false if the context is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// notifyJitter derives a small deterministic delay (0..499ms) from the notifyID so a
+// midnight burst of clients desynchronizes its first poll without needing a RNG.
+func notifyJitter(notifyID string) time.Duration {
+	if notifyID == "" {
+		return 0
+	}
+	sum := 0
+	for i := 0; i < len(notifyID); i++ {
+		sum += int(notifyID[i])
+	}
+	return time.Duration(sum%500) * time.Millisecond
+}

--- a/internal/notify/telegram_delivery_status.go
+++ b/internal/notify/telegram_delivery_status.go
@@ -142,8 +142,8 @@ func fetchDeliveryStatusOnce(ctx context.Context, client *http.Client, endpoint,
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	switch {
-	case resp.StatusCode == 200:
+	switch resp.StatusCode {
+	case 200:
 		var body notifyStatusResponse
 		if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&body); err != nil {
 			return deliveryStatus{State: "unknown", Err: err}, true
@@ -158,7 +158,7 @@ func fetchDeliveryStatusOnce(ctx context.Context, client *http.Client, endpoint,
 			Reason:    body.Reason,
 			Attempts:  body.Attempts,
 		}, false
-	case resp.StatusCode == 404 || resp.StatusCode == 401 || resp.StatusCode == 403:
+	case 404, 401, 403:
 		// Old server without the route, row not found, or stale secret: definitive,
 		// do not retry.
 		return deliveryStatus{State: "unknown", Err: fmt.Errorf("status HTTP %d", resp.StatusCode)}, false

--- a/internal/notify/telegram_delivery_status.go
+++ b/internal/notify/telegram_delivery_status.go
@@ -15,7 +15,6 @@ import (
 
 // deliveryPollConfig tunes the post-send delivery-status poll.
 type deliveryPollConfig struct {
-	Enabled      bool
 	Timeout      time.Duration // total budget across all attempts
 	Interval     time.Duration // base gap between attempts (grows with backoff)
 	InitialDelay time.Duration // wait before the first poll (delivery needs >=1s)
@@ -159,12 +158,14 @@ func fetchDeliveryStatusOnce(ctx context.Context, client *http.Client, endpoint,
 			Reason:    body.Reason,
 			Attempts:  body.Attempts,
 		}, false
-	case resp.StatusCode == 404 || resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 503:
-		// Old server without the route, row not found, stale secret, or relay off:
-		// definitive, do not retry.
+	case resp.StatusCode == 404 || resp.StatusCode == 401 || resp.StatusCode == 403:
+		// Old server without the route, row not found, or stale secret: definitive,
+		// do not retry.
 		return deliveryStatus{State: "unknown", Err: fmt.Errorf("status HTTP %d", resp.StatusCode)}, false
 	default:
-		// 5xx or anything unexpected: transient, retry.
+		// 5xx (incl. 503 overload / rolling-restart / relay killswitch) or anything
+		// unexpected: transient, retry within the budget (the message is already
+		// accepted on the durable outbox, so pending is the honest fallback).
 		return deliveryStatus{State: "unknown", Err: fmt.Errorf("status HTTP %d", resp.StatusCode)}, true
 	}
 }

--- a/internal/notify/telegram_delivery_status_test.go
+++ b/internal/notify/telegram_delivery_status_test.go
@@ -155,6 +155,30 @@ func TestPollDeliveryStatus503IsTransientRetriesThenDelivers(t *testing.T) {
 	}
 }
 
+func TestPollCfgAppliesFloorsAndCeilings(t *testing.T) {
+	// Oversized config must be capped so a mis-set knob cannot hang end-of-backup.
+	n, err := NewTelegramNotifier(TelegramConfig{
+		Enabled: true, Mode: TelegramModeCentralized, ServerAPIHost: "https://c.test",
+		ServerID: "server-123", NotifySecret: "sek",
+		ConfirmDelivery: true, ConfirmTimeout: time.Hour, ConfirmInterval: 100 * time.Second,
+	}, dsTestLogger())
+	if err != nil {
+		t.Fatalf("notifier: %v", err)
+	}
+	if cfg := n.pollCfg(); cfg.Timeout != 60*time.Second || cfg.Interval != 5*time.Second {
+		t.Fatalf("ceilings: got timeout=%v interval=%v, want 60s/5s", cfg.Timeout, cfg.Interval)
+	}
+	// Zero/negative -> floors.
+	n2, _ := NewTelegramNotifier(TelegramConfig{
+		Enabled: true, Mode: TelegramModeCentralized, ServerAPIHost: "https://c.test",
+		ServerID: "server-123", NotifySecret: "sek",
+		ConfirmDelivery: true, ConfirmTimeout: 0, ConfirmInterval: 0,
+	}, dsTestLogger())
+	if cfg := n2.pollCfg(); cfg.Timeout != 10*time.Second || cfg.Interval != time.Second {
+		t.Fatalf("floors: got timeout=%v interval=%v, want 10s/1s", cfg.Timeout, cfg.Interval)
+	}
+}
+
 // --- Send() integration: relay 202 + poll ---
 
 func dsRelayNotifier(t *testing.T, client *http.Client, confirm bool) *TelegramNotifier {

--- a/internal/notify/telegram_delivery_status_test.go
+++ b/internal/notify/telegram_delivery_status_test.go
@@ -30,7 +30,7 @@ func dsJSONResp(code int, body string) *http.Response {
 
 // notifyID "" -> zero jitter, so these unit tests are fast and deterministic.
 func dsFastPollCfg() deliveryPollConfig {
-	return deliveryPollConfig{Enabled: true, Timeout: 300 * time.Millisecond, Interval: 2 * time.Millisecond, InitialDelay: 0}
+	return deliveryPollConfig{Timeout: 300 * time.Millisecond, Interval: 2 * time.Millisecond, InitialDelay: 0}
 }
 
 func TestPollDeliveryStatusDelivered(t *testing.T) {
@@ -68,7 +68,7 @@ func TestPollDeliveryStatusPendingTimesOutAsQueued(t *testing.T) {
 		atomic.AddInt32(&calls, 1)
 		return dsJSONResp(200, `{"state":"pending","attempts":0}`), nil
 	})}
-	cfg := deliveryPollConfig{Enabled: true, Timeout: 40 * time.Millisecond, Interval: 5 * time.Millisecond, InitialDelay: 0}
+	cfg := deliveryPollConfig{Timeout: 40 * time.Millisecond, Interval: 5 * time.Millisecond, InitialDelay: 0}
 	ds := pollTelegramDeliveryStatus(context.Background(), client, "https://c.test", "srv", "sek", "", cfg, dsTestLogger())
 	if ds.State != "pending" {
 		t.Fatalf("got %+v, want pending (queued)", ds)
@@ -131,10 +131,27 @@ func TestPollDeliveryStatusRespectsContextCancel(t *testing.T) {
 	})}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled
-	cfg := deliveryPollConfig{Enabled: true, Timeout: time.Second, Interval: 5 * time.Millisecond, InitialDelay: 10 * time.Millisecond}
+	cfg := deliveryPollConfig{Timeout: time.Second, Interval: 5 * time.Millisecond, InitialDelay: 10 * time.Millisecond}
 	ds := pollTelegramDeliveryStatus(ctx, client, "https://c.test", "srv", "sek", "notify-x", cfg, dsTestLogger())
 	if ds.State != "unknown" {
 		t.Fatalf("got %+v, want unknown on cancel", ds)
+	}
+}
+
+func TestPollDeliveryStatus503IsTransientRetriesThenDelivers(t *testing.T) {
+	var calls int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return dsJSONResp(503, `{"error":"OUTBOX_UNAVAILABLE"}`), nil // transient overload
+		}
+		return dsJSONResp(200, `{"state":"delivered","telegram_message_id":7}`), nil
+	})}
+	ds := pollTelegramDeliveryStatus(context.Background(), client, "https://c.test", "srv", "sek", "", dsFastPollCfg(), dsTestLogger())
+	if ds.State != "delivered" {
+		t.Fatalf("got %+v, want delivered after a transient 503", ds)
+	}
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("503 must be retried within the budget, got %d calls", calls)
 	}
 }
 
@@ -250,8 +267,8 @@ func TestSendRelay202NoPollWhenConfirmDisabled(t *testing.T) {
 	if got := atomic.LoadInt32(&statusCalls); got != 0 {
 		t.Fatalf("ConfirmDelivery=false must NOT poll, got %d status calls", got)
 	}
-	if result.Metadata["telegram_state"] != "pending" {
-		t.Fatalf("telegram_state=%v, want pending", result.Metadata["telegram_state"])
+	if result.Metadata["telegram_state"] != "unconfirmed" {
+		t.Fatalf("telegram_state=%v, want unconfirmed", result.Metadata["telegram_state"])
 	}
 }
 

--- a/internal/notify/telegram_delivery_status_test.go
+++ b/internal/notify/telegram_delivery_status_test.go
@@ -1,0 +1,282 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func dsTestLogger() *logging.Logger {
+	l := logging.New(types.LogLevelDebug, false)
+	l.SetOutput(io.Discard)
+	return l
+}
+
+func dsJSONResp(code int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+// notifyID "" -> zero jitter, so these unit tests are fast and deterministic.
+func dsFastPollCfg() deliveryPollConfig {
+	return deliveryPollConfig{Enabled: true, Timeout: 300 * time.Millisecond, Interval: 2 * time.Millisecond, InitialDelay: 0}
+}
+
+func TestPollDeliveryStatusDelivered(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/api/notify/status" {
+			t.Fatalf("unexpected path %s", req.URL.Path)
+		}
+		if req.Header.Get("X-Server-Auth") != "sek" {
+			t.Fatalf("missing/incorrect X-Server-Auth: %q", req.Header.Get("X-Server-Auth"))
+		}
+		if strings.Contains(req.URL.Host, "api.telegram.org") {
+			t.Fatalf("must never contact api.telegram.org")
+		}
+		return dsJSONResp(200, `{"state":"delivered","telegram_message_id":4242,"attempts":1}`), nil
+	})}
+	ds := pollTelegramDeliveryStatus(context.Background(), client, "https://c.test", "srv", "sek", "", dsFastPollCfg(), dsTestLogger())
+	if ds.State != "delivered" || ds.MessageID != 4242 {
+		t.Fatalf("got %+v, want delivered/4242", ds)
+	}
+}
+
+func TestPollDeliveryStatusFailed(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return dsJSONResp(200, `{"state":"failed","reason":"http_403","attempts":1}`), nil
+	})}
+	ds := pollTelegramDeliveryStatus(context.Background(), client, "https://c.test", "srv", "sek", "", dsFastPollCfg(), dsTestLogger())
+	if ds.State != "failed" || ds.Reason != "http_403" {
+		t.Fatalf("got %+v, want failed/http_403", ds)
+	}
+}
+
+func TestPollDeliveryStatusPendingTimesOutAsQueued(t *testing.T) {
+	var calls int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return dsJSONResp(200, `{"state":"pending","attempts":0}`), nil
+	})}
+	cfg := deliveryPollConfig{Enabled: true, Timeout: 40 * time.Millisecond, Interval: 5 * time.Millisecond, InitialDelay: 0}
+	ds := pollTelegramDeliveryStatus(context.Background(), client, "https://c.test", "srv", "sek", "", cfg, dsTestLogger())
+	if ds.State != "pending" {
+		t.Fatalf("got %+v, want pending (queued)", ds)
+	}
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("expected multiple polls before timeout, got %d", calls)
+	}
+}
+
+func TestPollDeliveryStatus404IsUnknownAndDoesNotRetry(t *testing.T) {
+	var calls int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return dsJSONResp(404, `{"error":"NOTIFY_NOT_FOUND"}`), nil
+	})}
+	ds := pollTelegramDeliveryStatus(context.Background(), client, "https://c.test", "srv", "sek", "", dsFastPollCfg(), dsTestLogger())
+	if ds.State != "unknown" {
+		t.Fatalf("got %+v, want unknown", ds)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("404 must not be retried, got %d calls", got)
+	}
+}
+
+func TestPollDeliveryStatus401IsUnknownAndDoesNotReprovision(t *testing.T) {
+	var calls int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return dsJSONResp(401, `{"error":"AUTH_REQUIRED"}`), nil
+	})}
+	ds := pollTelegramDeliveryStatus(context.Background(), client, "https://c.test", "srv", "stale", "", dsFastPollCfg(), dsTestLogger())
+	if ds.State != "unknown" {
+		t.Fatalf("got %+v, want unknown", ds)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("401 must stop immediately, got %d calls", got)
+	}
+}
+
+func TestPollDeliveryStatusTransientErrorRetriesThenDelivers(t *testing.T) {
+	var calls int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return nil, errors.New("connection refused") // transient
+		}
+		return dsJSONResp(200, `{"state":"delivered","telegram_message_id":7}`), nil
+	})}
+	ds := pollTelegramDeliveryStatus(context.Background(), client, "https://c.test", "srv", "sek", "", dsFastPollCfg(), dsTestLogger())
+	if ds.State != "delivered" || ds.MessageID != 7 {
+		t.Fatalf("got %+v, want delivered/7", ds)
+	}
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("expected a retry after the transient error, got %d", calls)
+	}
+}
+
+func TestPollDeliveryStatusRespectsContextCancel(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return dsJSONResp(200, `{"state":"pending"}`), nil
+	})}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	cfg := deliveryPollConfig{Enabled: true, Timeout: time.Second, Interval: 5 * time.Millisecond, InitialDelay: 10 * time.Millisecond}
+	ds := pollTelegramDeliveryStatus(ctx, client, "https://c.test", "srv", "sek", "notify-x", cfg, dsTestLogger())
+	if ds.State != "unknown" {
+		t.Fatalf("got %+v, want unknown on cancel", ds)
+	}
+}
+
+// --- Send() integration: relay 202 + poll ---
+
+func dsRelayNotifier(t *testing.T, client *http.Client, confirm bool) *TelegramNotifier {
+	t.Helper()
+	n, err := NewTelegramNotifier(TelegramConfig{
+		Enabled:         true,
+		Mode:            TelegramModeCentralized,
+		ServerAPIHost:   "https://c.test",
+		ServerID:        "server-123",
+		NotifySecret:    "sek",
+		ConfirmDelivery: confirm,
+		ConfirmTimeout:  300 * time.Millisecond,
+		ConfirmInterval: 2 * time.Millisecond,
+	}, dsTestLogger())
+	if err != nil {
+		t.Fatalf("notifier: %v", err)
+	}
+	n.client = client
+	return n
+}
+
+func TestSendRelay202ThenPollDelivered(t *testing.T) {
+	var notifyID string
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/api/notify":
+			notifyID = req.Header.Get("X-Notify-Id")
+			if notifyID == "" {
+				t.Fatalf("relay POST missing X-Notify-Id")
+			}
+			return dsJSONResp(202, `{"status":"accepted","notify_id":"`+notifyID+`"}`), nil
+		case "/api/notify/status":
+			if req.URL.Query().Get("notify_id") != notifyID {
+				t.Fatalf("status poll notify_id=%q, want %q", req.URL.Query().Get("notify_id"), notifyID)
+			}
+			return dsJSONResp(200, `{"state":"delivered","telegram_message_id":99}`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})}
+	result, err := dsRelayNotifier(t, client, true).Send(context.Background(), createTestNotificationData())
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("want Success=true")
+	}
+	if result.Metadata["relay_accepted"] != true {
+		t.Fatalf("relay_accepted=%v", result.Metadata["relay_accepted"])
+	}
+	if result.Metadata["telegram_state"] != "delivered" {
+		t.Fatalf("telegram_state=%v", result.Metadata["telegram_state"])
+	}
+	if result.Metadata["telegram_message_id"] != int64(99) {
+		t.Fatalf("telegram_message_id=%v", result.Metadata["telegram_message_id"])
+	}
+}
+
+func TestSendRelay202PollFailedKeepsSuccessTrue(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/api/notify":
+			return dsJSONResp(202, `{"status":"accepted"}`), nil
+		case "/api/notify/status":
+			return dsJSONResp(200, `{"state":"failed","reason":"http_403"}`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})}
+	result, err := dsRelayNotifier(t, client, true).Send(context.Background(), createTestNotificationData())
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	// A Telegram delivery failure must NOT flip the notification result: server
+	// acceptance is the success signal.
+	if !result.Success {
+		t.Fatalf("Success must stay true even when Telegram delivery failed")
+	}
+	if result.Metadata["telegram_state"] != "failed" {
+		t.Fatalf("telegram_state=%v, want failed", result.Metadata["telegram_state"])
+	}
+	if result.Metadata["telegram_reason"] != "http_403" {
+		t.Fatalf("telegram_reason=%v", result.Metadata["telegram_reason"])
+	}
+}
+
+func TestSendRelay202NoPollWhenConfirmDisabled(t *testing.T) {
+	var statusCalls int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/api/notify":
+			return dsJSONResp(202, `{"status":"accepted"}`), nil
+		case "/api/notify/status":
+			atomic.AddInt32(&statusCalls, 1)
+			return dsJSONResp(200, `{"state":"delivered"}`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})}
+	result, err := dsRelayNotifier(t, client, false).Send(context.Background(), createTestNotificationData())
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("want Success=true")
+	}
+	if got := atomic.LoadInt32(&statusCalls); got != 0 {
+		t.Fatalf("ConfirmDelivery=false must NOT poll, got %d status calls", got)
+	}
+	if result.Metadata["telegram_state"] != "pending" {
+		t.Fatalf("telegram_state=%v, want pending", result.Metadata["telegram_state"])
+	}
+}
+
+func TestSendRelay200SyncLegacySkipsPoll(t *testing.T) {
+	var statusCalls int32
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/api/notify":
+			return dsJSONResp(200, `{"status":"ok"}`), nil // sync legacy (killswitch off)
+		case "/api/notify/status":
+			atomic.AddInt32(&statusCalls, 1)
+			return dsJSONResp(200, `{"state":"delivered"}`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})}
+	result, err := dsRelayNotifier(t, client, true).Send(context.Background(), createTestNotificationData())
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := atomic.LoadInt32(&statusCalls); got != 0 {
+		t.Fatalf("HTTP 200 (sync legacy) must NOT poll, got %d status calls", got)
+	}
+	if result.Metadata["telegram_state"] != "delivered" {
+		t.Fatalf("telegram_state=%v, want delivered", result.Metadata["telegram_state"])
+	}
+}

--- a/internal/notify/telegram_test.go
+++ b/internal/notify/telegram_test.go
@@ -385,7 +385,7 @@ func TestTelegramRelayErrorRedactsSecret(t *testing.T) {
 	}
 	notifier.client = client
 
-	relayErr := notifier.sendViaRelay(context.Background(), "hello")
+	_, relayErr := notifier.sendViaRelay(context.Background(), "hello", "notify-red-1")
 	if relayErr == nil {
 		t.Fatalf("expected an error from the relay")
 	}

--- a/internal/orchestrator/notification_adapter.go
+++ b/internal/orchestrator/notification_adapter.go
@@ -69,8 +69,11 @@ func (n *NotificationAdapter) Notify(ctx context.Context, stats *BackupStats) er
 	n.logger.Debug("Notifier '%s' returned result: success=%v, method=%s, duration=%s",
 		n.notifier.Name(), result.Success, result.Method, result.Duration)
 
-	// Handle three cases: success, fallback success, or failure
-	if !result.Success {
+	// The Telegram relay path prints its own two-line result (server acceptance +
+	// real Telegram delivery); everything else keeps the generic single line.
+	if n.notifier.Name() == "Telegram" && n.logTelegramOutcome(result) {
+		// handled by the relay-aware two-line logger
+	} else if !result.Success {
 		// Complete failure
 		n.logger.Warning("%s: failure reported", n.notifier.Name())
 		if result.Error != nil {
@@ -378,6 +381,9 @@ func (n *NotificationAdapter) recordNotifierStatus(stats *BackupStats, result *n
 			base = "unknown"
 		}
 		statusDetail := describeNotificationResult(result)
+		if sub := telegramDeliverySubstate(result); sub != "" {
+			statusDetail = statusDetail + ", " + sub
+		}
 		if statusDetail != "" {
 			stats.TelegramStatus = fmt.Sprintf("%s (%s)", base, statusDetail)
 		} else {
@@ -421,4 +427,95 @@ func describeNotificationSeverity(result *notify.NotificationResult) string {
 		return "warning"
 	}
 	return "ok"
+}
+
+// logTelegramOutcome prints the two-response result for the Telegram RELAY path:
+// line 1 = accepted by the ProxSave server, line 2 = delivered to Telegram. It
+// returns false (logging nothing) when the notification did NOT go through the relay
+// (personal mode / legacy direct bot-token send), so the caller falls back to the
+// generic single line. Every second-line non-success is WARNING level with a ❌/⚠️
+// in the text: the delivery outcome must be VISIBLE but must never block the backup
+// (the exit code is frozen before the notification phase; a WARNING is counted as a
+// warning, never an error, in the run summary).
+func (n *NotificationAdapter) logTelegramOutcome(result *notify.NotificationResult) bool {
+	if result == nil || result.Metadata == nil {
+		return false
+	}
+	accVal, ok := result.Metadata["relay_accepted"]
+	if !ok {
+		return false // no relay path involved -> generic single line
+	}
+	name := n.notifier.Name()
+	accepted, _ := accVal.(bool)
+
+	// First response: did the ProxSave server accept it?
+	if !accepted {
+		if result.Error != nil {
+			n.logger.Warning("❌ %s: could not send to ProxSave server: %v", name, result.Error)
+		} else {
+			n.logger.Warning("❌ %s: could not send to ProxSave server", name)
+		}
+		return true // no second line: nothing was accepted
+	}
+	n.logger.Info("✓ %s: sent to ProxSave server (in %v)", name, result.Duration)
+
+	// Second response: did Telegram confirm delivery?
+	state, _ := result.Metadata["telegram_state"].(string)
+	switch state {
+	case "delivered":
+		if id, ok := result.Metadata["telegram_message_id"].(int64); ok && id != 0 {
+			n.logger.Debug("Telegram: message_id=%d", id)
+		}
+		n.logger.Info("✓ %s: delivered to Telegram", name)
+	case "failed":
+		reason, _ := result.Metadata["telegram_reason"].(string)
+		n.logger.Warning("❌ %s: not delivered (%s)", name, mapTelegramReason(reason))
+	case "pending":
+		n.logger.Warning("⚠️ %s: accepted; delivery in progress (auto-retry)", name)
+	default: // "unknown" or missing
+		n.logger.Warning("⚠️ %s: accepted; delivery not confirmed", name)
+	}
+	return true
+}
+
+// mapTelegramReason turns a server-side outbox reason into user-facing copy.
+func mapTelegramReason(reason string) string {
+	switch {
+	case reason == "":
+		return "rejected by Telegram"
+	case reason == "http_403":
+		return "bot blocked by the user"
+	case reason == "http_400", reason == "http_404":
+		return "invalid chat"
+	case reason == "http_413":
+		return "message too long"
+	case strings.HasPrefix(reason, "gave_up_after_ttl"):
+		return "Telegram unreachable too long (expired)"
+	case strings.HasPrefix(reason, "gave_up_after_"):
+		return "too many failed attempts"
+	default:
+		return reason
+	}
+}
+
+// telegramDeliverySubstate is the short delivery tag appended to stats.TelegramStatus
+// (which is echoed into the notification body). Empty for the non-relay path.
+func telegramDeliverySubstate(result *notify.NotificationResult) string {
+	if result == nil || result.Metadata == nil {
+		return ""
+	}
+	if _, ok := result.Metadata["relay_accepted"]; !ok {
+		return ""
+	}
+	switch s, _ := result.Metadata["telegram_state"].(string); s {
+	case "delivered":
+		return "delivered"
+	case "failed":
+		reason, _ := result.Metadata["telegram_reason"].(string)
+		return "not delivered: " + mapTelegramReason(reason)
+	case "pending":
+		return "queued"
+	default:
+		return "delivery unconfirmed"
+	}
 }

--- a/internal/orchestrator/notification_adapter.go
+++ b/internal/orchestrator/notification_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/notify"
@@ -457,7 +458,13 @@ func (n *NotificationAdapter) logTelegramOutcome(result *notify.NotificationResu
 		}
 		return true // no second line: nothing was accepted
 	}
-	n.logger.Info("✓ %s: sent to ProxSave server (in %v)", name, result.Duration)
+	// First-line latency is the time to server ACCEPTANCE (recorded before any poll),
+	// falling back to the total duration if absent.
+	acceptDur := result.Duration
+	if d, ok := result.Metadata["relay_accept_duration"].(time.Duration); ok {
+		acceptDur = d
+	}
+	n.logger.Info("✓ %s: sent to ProxSave server (in %v)", name, acceptDur)
 
 	// Second response: did Telegram confirm delivery?
 	state, _ := result.Metadata["telegram_state"].(string)
@@ -472,6 +479,9 @@ func (n *NotificationAdapter) logTelegramOutcome(result *notify.NotificationResu
 		n.logger.Warning("❌ %s: not delivered (%s)", name, mapTelegramReason(reason))
 	case "pending":
 		n.logger.Warning("⚠️ %s: accepted; delivery in progress (auto-retry)", name)
+	case "unconfirmed":
+		// Confirmation disabled by config: accepted is enough, stay quiet.
+		n.logger.Debug("Telegram: delivery confirmation disabled (accepted by server)")
 	default: // "unknown" or missing
 		n.logger.Warning("⚠️ %s: accepted; delivery not confirmed", name)
 	}
@@ -504,7 +514,10 @@ func telegramDeliverySubstate(result *notify.NotificationResult) string {
 	if result == nil || result.Metadata == nil {
 		return ""
 	}
-	if _, ok := result.Metadata["relay_accepted"]; !ok {
+	// Gate on the VALUE, not mere presence: a relay POST that failed sets
+	// relay_accepted=false with no telegram_state and must NOT be labelled
+	// "delivery unconfirmed" (it was never accepted).
+	if accepted, _ := result.Metadata["relay_accepted"].(bool); !accepted {
 		return ""
 	}
 	switch s, _ := result.Metadata["telegram_state"].(string); s {
@@ -515,6 +528,8 @@ func telegramDeliverySubstate(result *notify.NotificationResult) string {
 		return "not delivered: " + mapTelegramReason(reason)
 	case "pending":
 		return "queued"
+	case "unconfirmed":
+		return "" // confirmation disabled -> no substate noise in the body
 	default:
 		return "delivery unconfirmed"
 	}

--- a/internal/orchestrator/notification_adapter_telegram_test.go
+++ b/internal/orchestrator/notification_adapter_telegram_test.go
@@ -1,0 +1,133 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/notify"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// telegramOutcome runs Notify() for a Telegram stub with the given result and
+// returns the captured log output plus the logger (for warning/error counters).
+func telegramOutcome(t *testing.T, result *notify.NotificationResult) (string, *logging.Logger) {
+	t.Helper()
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	notifier := &stubNotifier{name: "Telegram", enabled: true, result: result}
+	adapter := NewNotificationAdapter(notifier, logger)
+	if err := adapter.Notify(context.Background(), sampleBackupStats()); err != nil {
+		t.Fatalf("Notify returned error: %v", err)
+	}
+	return buf.String(), logger
+}
+
+func TestTelegramOutcome_Delivered(t *testing.T) {
+	out, logger := telegramOutcome(t, &notify.NotificationResult{
+		Success:  true,
+		Method:   "telegram",
+		Duration: 50 * time.Millisecond,
+		Metadata: map[string]interface{}{
+			"relay_accepted":      true,
+			"telegram_state":      "delivered",
+			"telegram_message_id": int64(7),
+		},
+	})
+	if !strings.Contains(out, "sent to ProxSave server") {
+		t.Fatalf("missing first line (server acceptance): %q", out)
+	}
+	if !strings.Contains(out, "delivered to Telegram") {
+		t.Fatalf("missing second line (delivered): %q", out)
+	}
+	if logger.ErrorCount() != 0 {
+		t.Fatalf("delivered must produce no errors, got %d", logger.ErrorCount())
+	}
+}
+
+// The key requirement: a permanent Telegram delivery failure shows a ❌ on the
+// Telegram line, but ProxSave counts it as a WARNING (never an error) so the backup
+// flow is not blocked.
+func TestTelegramOutcome_FailedIsWarningNotError(t *testing.T) {
+	out, logger := telegramOutcome(t, &notify.NotificationResult{
+		Success:  true,
+		Method:   "telegram",
+		Duration: 50 * time.Millisecond,
+		Metadata: map[string]interface{}{
+			"relay_accepted": true,
+			"telegram_state": "failed",
+			"telegram_reason": "http_403",
+		},
+	})
+	if !strings.Contains(out, "sent to ProxSave server") {
+		t.Fatalf("missing first line: %q", out)
+	}
+	if !strings.Contains(out, "not delivered (bot blocked by the user)") {
+		t.Fatalf("missing/incorrect failure line: %q", out)
+	}
+	if logger.ErrorCount() != 0 {
+		t.Fatalf("Telegram delivery failure must NOT be an error (got %d): it must not block the backup", logger.ErrorCount())
+	}
+	if logger.WarningCount() < 1 {
+		t.Fatalf("Telegram delivery failure must be counted as a warning, got %d", logger.WarningCount())
+	}
+}
+
+func TestTelegramOutcome_PendingIsInProgress(t *testing.T) {
+	out, logger := telegramOutcome(t, &notify.NotificationResult{
+		Success:  true,
+		Method:   "telegram",
+		Metadata: map[string]interface{}{
+			"relay_accepted": true,
+			"telegram_state": "pending",
+		},
+	})
+	if !strings.Contains(out, "sent to ProxSave server") || !strings.Contains(out, "delivery in progress") {
+		t.Fatalf("missing pending two-line output: %q", out)
+	}
+	if logger.ErrorCount() != 0 {
+		t.Fatalf("pending must not be an error, got %d", logger.ErrorCount())
+	}
+}
+
+func TestTelegramOutcome_RelayUnreachableIsWarning(t *testing.T) {
+	out, logger := telegramOutcome(t, &notify.NotificationResult{
+		Success: false,
+		Method:  "telegram",
+		Error:   errors.New("relay request failed"),
+		Metadata: map[string]interface{}{
+			"relay_accepted": false,
+		},
+	})
+	if !strings.Contains(out, "could not send to ProxSave server") {
+		t.Fatalf("missing server-unreachable line: %q", out)
+	}
+	if strings.Contains(out, "delivered to Telegram") {
+		t.Fatalf("must not print a delivery line when the server did not accept: %q", out)
+	}
+	if logger.ErrorCount() != 0 {
+		t.Fatalf("a failed notification must not block the backup (error count %d)", logger.ErrorCount())
+	}
+}
+
+// No relay metadata (personal mode / legacy direct bot-token send) keeps the old
+// generic single line.
+func TestTelegramOutcome_NonRelayKeepsGenericLine(t *testing.T) {
+	out, _ := telegramOutcome(t, &notify.NotificationResult{
+		Success:  true,
+		Method:   "telegram",
+		Duration: 10 * time.Millisecond,
+		Metadata: map[string]interface{}{}, // no relay_accepted key
+	})
+	if !strings.Contains(out, "notification completed successfully") {
+		t.Fatalf("expected generic single line for the non-relay path: %q", out)
+	}
+	if strings.Contains(out, "sent to ProxSave server") {
+		t.Fatalf("must not print the relay two-line output for the non-relay path: %q", out)
+	}
+}

--- a/internal/orchestrator/notification_adapter_telegram_test.go
+++ b/internal/orchestrator/notification_adapter_telegram_test.go
@@ -115,6 +115,70 @@ func TestTelegramOutcome_RelayUnreachableIsWarning(t *testing.T) {
 	}
 }
 
+// F1: the first line reports the ACCEPTANCE latency (recorded before the poll), not
+// the total duration (which includes up to the whole poll budget).
+func TestTelegramOutcome_FirstLineUsesAcceptanceDuration(t *testing.T) {
+	out, _ := telegramOutcome(t, &notify.NotificationResult{
+		Success:  true,
+		Method:   "telegram",
+		Duration: 10 * time.Second, // total incl. poll
+		Metadata: map[string]interface{}{
+			"relay_accepted":        true,
+			"relay_accept_duration": 42 * time.Millisecond,
+			"telegram_state":        "delivered",
+		},
+	})
+	if !strings.Contains(out, "sent to ProxSave server (in 42ms)") {
+		t.Fatalf("first line must show acceptance latency (42ms): %q", out)
+	}
+	if strings.Contains(out, "in 10s") {
+		t.Fatalf("first line must NOT show the poll-inflated total (10s): %q", out)
+	}
+}
+
+// F2: with confirmation disabled the state is "unconfirmed" -> quiet, no warning.
+func TestTelegramOutcome_UnconfirmedIsQuietNotWarning(t *testing.T) {
+	out, logger := telegramOutcome(t, &notify.NotificationResult{
+		Success:  true,
+		Method:   "telegram",
+		Metadata: map[string]interface{}{
+			"relay_accepted": true,
+			"telegram_state": "unconfirmed",
+		},
+	})
+	if !strings.Contains(out, "sent to ProxSave server") {
+		t.Fatalf("missing first line: %q", out)
+	}
+	if strings.Contains(out, "delivery in progress") {
+		t.Fatalf("confirmation-disabled must NOT warn 'delivery in progress': %q", out)
+	}
+	if logger.WarningCount() != 0 {
+		t.Fatalf("confirmation-disabled must emit no warning, got %d", logger.WarningCount())
+	}
+}
+
+// F5: telegramDeliverySubstate must gate on the relay_accepted VALUE, so a failed
+// relay (accepted=false) gets no substate, not a misleading "delivery unconfirmed".
+func TestTelegramDeliverySubstate_ValueGated(t *testing.T) {
+	cases := []struct {
+		name string
+		meta map[string]interface{}
+		want string
+	}{
+		{"failed relay", map[string]interface{}{"relay_accepted": false}, ""},
+		{"confirmation disabled", map[string]interface{}{"relay_accepted": true, "telegram_state": "unconfirmed"}, ""},
+		{"delivered", map[string]interface{}{"relay_accepted": true, "telegram_state": "delivered"}, "delivered"},
+		{"pending", map[string]interface{}{"relay_accepted": true, "telegram_state": "pending"}, "queued"},
+		{"non-relay path", map[string]interface{}{}, ""},
+	}
+	for _, c := range cases {
+		got := telegramDeliverySubstate(&notify.NotificationResult{Metadata: c.meta})
+		if got != c.want {
+			t.Fatalf("%s: telegramDeliverySubstate=%q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
 // No relay metadata (personal mode / legacy direct bot-token send) keeps the old
 // generic single line.
 func TestTelegramOutcome_NonRelayKeepsGenericLine(t *testing.T) {


### PR DESCRIPTION
Automated release PR for `v0.29.0`.

<!-- release-tag: v0.29.0 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Telegram delivery confirmation with configurable timeout and polling interval (via environment settings).
  * Notification results now separate server acceptance from final Telegram delivery status.

* **Bug Fixes**
  * Improved Telegram relay handling and error recovery when relay credentials/auth are rejected.
  * Delivery polling now better categorizes outcomes (delivered, pending, failed/unconfirmed) and reflects them in results.

* **Tests**
  * Added unit and integration coverage for delivery polling, retry/timeout behavior, and Telegram outcome logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds optional Telegram delivery confirmation to the relay path. After the ProxSave relay server accepts a notification (HTTP 202), the client can now poll `GET /api/notify/status` until Telegram confirms delivery or a configurable budget elapses. The feature is controlled by three env vars (`TELEGRAM_CONFIRM_DELIVERY`, defaults to `true`; `TELEGRAM_CONFIRM_TIMEOUT_SECONDS`, defaults to 10; `TELEGRAM_CONFIRM_INTERVAL_SECONDS`, defaults to 1).

- **Two-response logging**: relay acceptance and Telegram delivery are now reported on separate log lines. Delivery failures are WARNING-level and never block the backup exit code.
- **Idempotency**: a per-send `X-Notify-Id` header is generated once and reused across any relay retry, preventing double-queueing on the server's durable outbox.
- **Polling engine** (`telegram_delivery_status.go`): deadline-bounded poll with exponential backoff (capped at 3 s), per-notification jitter for burst desynchronisation, and correct transient-vs-definitive error classification (5xx including 503 = retryable; 401/403/404 = stop).

<h3>Confidence Score: 5/5</h3>

Safe to merge — delivery failures are correctly surfaced as warnings and never affect the backup exit code.

The two-response relay flow is well-implemented: idempotency key reuse across retries is correct, the polling engine has a bounded deadline, backoff is capped, and 503 is now correctly treated as transient. The only finding is a one-line docstring that still says '403/503' instead of '403' after the retryability change. Test coverage is thorough across all delivery outcomes, timeout behaviour, and the non-relay fallback path.

The docstring on fetchDeliveryStatusOnce in telegram_delivery_status.go has a stale 503 reference; everything else is clean.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/notify/telegram_delivery_status.go | New polling engine; 503 is correctly treated as retryable in the default branch, but the docstring on fetchDeliveryStatusOnce still lists it as non-retryable alongside 404/401/403. |
| internal/notify/telegram.go | Adds newNotifyID(), changes sendViaRelay to return HTTP status, and adds recordRelayAcceptedAndPoll/pollCfg; idempotency key is correctly reused across relay retries. |
| internal/orchestrator/notification_adapter.go | Adds logTelegramOutcome (two-line relay logging), telegramDeliverySubstate, and mapTelegramReason; relay_accepted is gated by value so a failed relay POST never prints 'delivery unconfirmed'. |
| internal/notify/telegram_delivery_status_test.go | Comprehensive tests for polling: delivered, failed, timeout-as-pending, 404/401 non-retry, transient network retry, context cancel, and 503-as-retryable. |
| internal/orchestrator/notification_adapter_telegram_test.go | New test file covering all logTelegramOutcome outcomes: delivered, failed-is-warning, pending, relay-unreachable, acceptance-duration, unconfirmed-no-warning, non-relay generic line. |
| internal/config/config.go | Adds TelegramConfirmDelivery (default true), TelegramConfirmTimeoutS (default 10), TelegramConfirmIntervalS (default 1) fields with env-var parsing; defaults are sane. |
| cmd/proxsave/backup_notifications.go | Wires three new TelegramConfig fields (ConfirmDelivery, ConfirmTimeout, ConfirmInterval) from config values; straightforward plumbing. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as proxsave client
    participant R as ProxSave relay

    C->>R: POST /api/notify (X-Notify-Id: id)
    alt HTTP 200 (legacy sync)
        R-->>C: 200 OK
        Note over C: telegram_state=delivered, no poll
    else HTTP 202 (durable outbox)
        R-->>C: 202 Accepted
        Note over C: relay_accepted=true
        alt "ConfirmDelivery=false"
            Note over C: telegram_state=unconfirmed
        else "ConfirmDelivery=true"
            loop until delivered/failed/timeout
                C->>R: "GET /api/notify/status?notify_id=id"
                R-->>C: "200 {state: pending|delivered|failed}"
            end
            Note over C: telegram_state=poll result
        end
    else 4xx/5xx error
        R-->>C: error
        Note over C: relay_accepted=false, Success=false
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as proxsave client
    participant R as ProxSave relay

    C->>R: POST /api/notify (X-Notify-Id: id)
    alt HTTP 200 (legacy sync)
        R-->>C: 200 OK
        Note over C: telegram_state=delivered, no poll
    else HTTP 202 (durable outbox)
        R-->>C: 202 Accepted
        Note over C: relay_accepted=true
        alt "ConfirmDelivery=false"
            Note over C: telegram_state=unconfirmed
        else "ConfirmDelivery=true"
            loop until delivered/failed/timeout
                C->>R: "GET /api/notify/status?notify_id=id"
                R-->>C: "200 {state: pending|delivered|failed}"
            end
            Note over C: telegram_state=poll result
        end
    else 4xx/5xx error
        R-->>C: error
        Note over C: relay_accepted=false, Success=false
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/notification_adapter.go`, line 888-906 ([link](https://github.com/tis24dev/proxsave/blob/3604da1bb44c871a8812142db0ea86dae3197558/internal/orchestrator/notification_adapter.go#L888-L906)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `telegramDeliverySubstate` defaults to `"delivery unconfirmed"` whenever `relay_accepted` is present but `telegram_state` is absent or unrecognised. When `relay_accepted = false` (the server rejected or was unreachable), `telegram_state` is never written to `Metadata`, so this branch fires and appends `"delivery unconfirmed"` to `stats.TelegramStatus`. The resulting string (e.g. `"error (failed: …, delivery unconfirmed)"`) is misleading because the message was never submitted to the outbox — there is nothing to confirm. A check for the `relay_accepted` bool would let the default branch return `""` (empty, no substate) in the rejection case.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fnotification_adapter.go%0ALine%3A%20888-906%0A%0AComment%3A%0A%60telegramDeliverySubstate%60%20defaults%20to%20%60%22delivery%20unconfirmed%22%60%20whenever%20%60relay_accepted%60%20is%20present%20but%20%60telegram_state%60%20is%20absent%20or%20unrecognised.%20When%20%60relay_accepted%20%3D%20false%60%20%28the%20server%20rejected%20or%20was%20unreachable%29%2C%20%60telegram_state%60%20is%20never%20written%20to%20%60Metadata%60%2C%20so%20this%20branch%20fires%20and%20appends%20%60%22delivery%20unconfirmed%22%60%20to%20%60stats.TelegramStatus%60.%20The%20resulting%20string%20%28e.g.%20%60%22error%20%28failed%3A%20%E2%80%A6%2C%20delivery%20unconfirmed%29%22%60%29%20is%20misleading%20because%20the%20message%20was%20never%20submitted%20to%20the%20outbox%20%E2%80%94%20there%20is%20nothing%20to%20confirm.%20A%20check%20for%20the%20%60relay_accepted%60%20bool%20would%20let%20the%20default%20branch%20return%20%60%22%22%60%20%28empty%2C%20no%20substate%29%20in%20the%20rejection%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fnotification_adapter.go%0ALine%3A%20888-906%0A%0AComment%3A%0A%60telegramDeliverySubstate%60%20defaults%20to%20%60%22delivery%20unconfirmed%22%60%20whenever%20%60relay_accepted%60%20is%20present%20but%20%60telegram_state%60%20is%20absent%20or%20unrecognised.%20When%20%60relay_accepted%20%3D%20false%60%20%28the%20server%20rejected%20or%20was%20unreachable%29%2C%20%60telegram_state%60%20is%20never%20written%20to%20%60Metadata%60%2C%20so%20this%20branch%20fires%20and%20appends%20%60%22delivery%20unconfirmed%22%60%20to%20%60stats.TelegramStatus%60.%20The%20resulting%20string%20%28e.g.%20%60%22error%20%28failed%3A%20%E2%80%A6%2C%20delivery%20unconfirmed%29%22%60%29%20is%20misleading%20because%20the%20message%20was%20never%20submitted%20to%20the%20outbox%20%E2%80%94%20there%20is%20nothing%20to%20confirm.%20A%20check%20for%20the%20%60relay_accepted%60%20bool%20would%20let%20the%20default%20branch%20return%20%60%22%22%60%20%28empty%2C%20no%20substate%29%20in%20the%20rejection%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Fproxsave%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Forchestrator%2Fnotification_adapter.go%0ALine%3A%20888-906%0A%0AComment%3A%0A%60telegramDeliverySubstate%60%20defaults%20to%20%60%22delivery%20unconfirmed%22%60%20whenever%20%60relay_accepted%60%20is%20present%20but%20%60telegram_state%60%20is%20absent%20or%20unrecognised.%20When%20%60relay_accepted%20%3D%20false%60%20%28the%20server%20rejected%20or%20was%20unreachable%29%2C%20%60telegram_state%60%20is%20never%20written%20to%20%60Metadata%60%2C%20so%20this%20branch%20fires%20and%20appends%20%60%22delivery%20unconfirmed%22%60%20to%20%60stats.TelegramStatus%60.%20The%20resulting%20string%20%28e.g.%20%60%22error%20%28failed%3A%20%E2%80%A6%2C%20delivery%20unconfirmed%29%22%60%29%20is%20misleading%20because%20the%20message%20was%20never%20submitted%20to%20the%20outbox%20%E2%80%94%20there%20is%20nothing%20to%20confirm.%20A%20check%20for%20the%20%60relay_accepted%60%20bool%20would%20let%20the%20default%20branch%20return%20%60%22%22%60%20%28empty%2C%20no%20substate%29%20in%20the%20rejection%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(notify): address PR 248 CodeRab..."](https://github.com/tis24dev/proxsave/commit/86bc29b51937c9a3aa2856c67966dc9efff640d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41436138)</sub>

<!-- /greptile_comment -->