### PR TITLE
Review slice 1 (backup): backup engine + storage

### DIFF
--- a/cmd/proxsave/backup_execution.go
+++ b/cmd/proxsave/backup_execution.go
@@ -43,8 +43,9 @@ func runConfiguredBackup(opts backupModeOptions, orch *orchestrator.Orchestrator
 
 	persistBackupStats(orch, stats)
 	logBackupStatistics(stats)
-	logging.Info("✓ Go backup orchestration completed")
+	logging.Info("✓ Backup completed")
 	logServerIdentityValues(opts.serverIDValue, opts.serverMACValue)
+	logMonitoringPortalLink(stats)
 
 	if opts.heapProfilePath != "" {
 		logging.Info("Heap profiling saved: %s", opts.heapProfilePath)
@@ -106,58 +107,90 @@ func persistBackupStats(orch *orchestrator.Orchestrator, stats *orchestrator.Bac
 }
 
 func logBackupStatistics(stats *orchestrator.BackupStats) {
+	// The block is now debug-only; a standard run shows it in the graphical
+	// outcome recap (buildBackupOutcomePrompt) instead. Guard before the blank
+	// spacers too, so a standard run shows no orphan blank lines.
+	if logging.GetDefaultLogger().GetLevel() < types.LogLevelDebug {
+		return
+	}
 	fmt.Println()
-	logging.Info("=== Backup Statistics ===")
-	logging.Info("Files collected: %d", stats.FilesCollected)
+	logging.Debug("=== Backup Statistics ===")
+	logging.Debug("Files collected: %d", stats.FilesCollected)
 	if stats.FilesFailed > 0 {
-		logging.Warning("Files failed: %d", stats.FilesFailed)
+		// The PVE/PBS collection summary carries the Files-failed warning now.
+		logging.Debug("Files failed: %d", stats.FilesFailed)
 	}
-	logging.Info("Directories created: %d", stats.DirsCreated)
-	logging.Info("Data collected: %s", formatBytes(stats.BytesCollected))
-	logging.Info("Archive size: %s", formatBytes(stats.ArchiveSize))
+	logging.Debug("Directories created: %d", stats.DirsCreated)
+	logging.Debug("Data collected: %s", formatBytes(stats.BytesCollected))
+	logging.Debug("Archive size: %s", formatBytes(stats.ArchiveSize))
 	logCompressionRatio(stats)
-	logging.Info("Compression used: %s (level %d, mode %s)", stats.Compression, stats.CompressionLevel, stats.CompressionMode)
+	logging.Debug("Compression used: %s (level %d, mode %s)", stats.Compression, stats.CompressionLevel, stats.CompressionMode)
 	if stats.RequestedCompression != stats.Compression {
-		logging.Info("Requested compression: %s", stats.RequestedCompression)
+		logging.Debug("Requested compression: %s", stats.RequestedCompression)
 	}
-	logging.Info("Duration: %s", formatDuration(stats.Duration))
+	logging.Debug("Duration: %s", formatDuration(stats.Duration))
 	logBackupArtifactPaths(stats)
 	fmt.Println()
 }
 
 func logCompressionRatio(stats *orchestrator.BackupStats) {
+	logging.Debug("Compression ratio: %s", compressionRatioText(stats))
+}
+
+// compressionRatioText renders the compression-ratio value shared by the
+// debug-only log block (logCompressionRatio) and the graphical outcome recap
+// (appendBackupStatsBlock), so the two never drift.
+func compressionRatioText(stats *orchestrator.BackupStats) string {
 	switch {
 	case stats.CompressionSavingsPercent > 0:
-		logging.Info("Compression ratio: %.1f%%", stats.CompressionSavingsPercent)
+		return fmt.Sprintf("%.1f%%", stats.CompressionSavingsPercent)
 	case stats.CompressionRatioPercent > 0:
-		logging.Info("Compression ratio: %.1f%%", stats.CompressionRatioPercent)
+		return fmt.Sprintf("%.1f%%", stats.CompressionRatioPercent)
 	case stats.BytesCollected > 0:
 		ratio := float64(stats.ArchiveSize) / float64(stats.BytesCollected) * 100
-		logging.Info("Compression ratio: %.1f%%", ratio)
+		return fmt.Sprintf("%.1f%%", ratio)
 	default:
-		logging.Info("Compression ratio: N/A")
+		return "N/A"
 	}
 }
 
 func logBackupArtifactPaths(stats *orchestrator.BackupStats) {
 	if stats.BundleCreated {
-		logging.Info("Bundle path: %s", stats.ArchivePath)
-		logging.Info("Bundle contents: archive + checksum + metadata")
+		logging.Debug("Bundle path: %s", stats.ArchivePath)
+		logging.Debug("Bundle contents: archive + checksum + metadata")
 		return
 	}
 
-	logging.Info("Archive path: %s", stats.ArchivePath)
+	logging.Debug("Archive path: %s", stats.ArchivePath)
 	if stats.ManifestPath != "" {
-		logging.Info("Manifest path: %s", stats.ManifestPath)
+		logging.Debug("Manifest path: %s", stats.ManifestPath)
 	}
 	if stats.Checksum != "" {
-		logging.Info("Archive checksum (SHA256): %s", stats.Checksum)
+		logging.Debug("Archive checksum (SHA256): %s", stats.Checksum)
+	}
+}
+
+// consoleStatusGlyph returns a TEXT-presentation glyph (all width 1, terminal-stable)
+// for the console "Exit status" line, matching the plain checkmarks used everywhere
+// else in the run output. It deliberately avoids notify.GetStatusEmoji, whose
+// emoji-presentation glyphs (e.g. "⚠️" = U+26A0 U+FE0F) render at a width the terminal
+// and lipgloss disagree on, shifting the framed graphical panel's border by one column.
+func consoleStatusGlyph(status notify.NotificationStatus) string {
+	switch status {
+	case notify.StatusSuccess:
+		return "✓"
+	case notify.StatusWarning:
+		return "⚠"
+	case notify.StatusFailure:
+		return "✗"
+	default:
+		return "•"
 	}
 }
 
 func logBackupExitStatus(exitCode int) {
 	status := notify.StatusFromExitCode(exitCode)
 	statusLabel := strings.ToUpper(status.String())
-	emoji := notify.GetStatusEmoji(status)
-	logging.Info("Exit status: %s %s (code=%d)", emoji, statusLabel, exitCode)
+	glyph := consoleStatusGlyph(status)
+	logging.Info("Exit status: %s %s (code=%d)", glyph, statusLabel, exitCode)
 }

--- a/cmd/proxsave/backup_execution_test.go
+++ b/cmd/proxsave/backup_execution_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// TestLogBackupStatisticsDebugGating asserts the "=== Backup Statistics ==="
+// block is debug-only: at LogLevelInfo logBackupStatistics emits nothing, and at
+// LogLevelDebug it emits the full block. The block moved to the graphical outcome
+// recap (buildBackupOutcomePrompt) for standard runs.
+func TestLogBackupStatisticsDebugGating(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	stats := &orchestrator.BackupStats{
+		FilesCollected: 42,
+		DirsCreated:    7,
+		ArchivePath:    "/var/backup/proxsave.tar.zst",
+	}
+
+	// At Info level the block (and its blank spacers) is skipped entirely.
+	infoBuf := &bytes.Buffer{}
+	infoLogger := logging.New(types.LogLevelInfo, false)
+	infoLogger.SetOutput(infoBuf)
+	logging.SetDefaultLogger(infoLogger)
+	logBackupStatistics(stats)
+	if strings.Contains(infoBuf.String(), "=== Backup Statistics ===") {
+		t.Fatalf("stats block must be absent at Info level:\n%s", infoBuf.String())
+	}
+
+	// At Debug level the full block is emitted.
+	debugBuf := &bytes.Buffer{}
+	debugLogger := logging.New(types.LogLevelDebug, false)
+	debugLogger.SetOutput(debugBuf)
+	logging.SetDefaultLogger(debugLogger)
+	logBackupStatistics(stats)
+	if !strings.Contains(debugBuf.String(), "=== Backup Statistics ===") {
+		t.Fatalf("stats block must be present at Debug level:\n%s", debugBuf.String())
+	}
+	if !strings.Contains(debugBuf.String(), "Files collected: 42") {
+		t.Fatalf("stats block content missing at Debug level:\n%s", debugBuf.String())
+	}
+}

--- a/cmd/proxsave/backup_exit_glyph_test.go
+++ b/cmd/proxsave/backup_exit_glyph_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/notify"
+)
+
+// TestConsoleStatusGlyphIsTextNotEmoji locks the fix for the framed-panel border
+// misalignment: the console "Exit status" line must use single-rune TEXT glyphs,
+// never an emoji-presentation glyph carrying the U+FE0F variation selector (whose
+// terminal width disagrees with lipgloss and shifts the panel border one column).
+func TestConsoleStatusGlyphIsTextNotEmoji(t *testing.T) {
+	const emojiVariationSelector rune = 0xFE0F
+	for _, st := range []notify.NotificationStatus{
+		notify.StatusSuccess, notify.StatusWarning, notify.StatusFailure,
+	} {
+		g := consoleStatusGlyph(st)
+		if len([]rune(g)) != 1 {
+			t.Fatalf("status %v glyph %q must be a single text rune", st, g)
+		}
+		for _, r := range g {
+			if r == emojiVariationSelector {
+				t.Fatalf("status %v glyph %q carries U+FE0F (emoji presentation) - misaligns the panel", st, g)
+			}
+		}
+	}
+}

--- a/cmd/proxsave/backup_healthcheck.go
+++ b/cmd/proxsave/backup_healthcheck.go
@@ -1,0 +1,112 @@
+// Package main contains the proxsave command entrypoint.
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+// daemonAliveProbe reports whether pid is a LIVE proxsave --daemon process. It is a package var so
+// a test can override the probe: verifying a real fork is neither portable nor safe in unit tests,
+// so the decision helper is tested against a fake probe. Production uses
+// probeProxsaveDaemonAlive.
+var daemonAliveProbe = probeProxsaveDaemonAlive
+
+// maybeHandoffManualBackup hands a STANDALONE backup's outcome to the resident daemon (the SOLE
+// pinger) and wakes it with SIGUSR1, so the daemon pings + records the backup-outcome check
+// through its own finish path -- WITHOUT this run ever building a Reporter or writing the status
+// file. It hands off ONLY when:
+//   - a backup was actually ATTEMPTED (supportStats or an earlyError present; the disabled and
+//     benign-concurrency-skip paths leave BOTH nil, so they never hand off);
+//   - this is a STANDALONE run (health.EnvRunID unset). When it is set THIS run is the daemon's
+//     own supervised child and the daemon already pings that run's outcome in runOnce -- handing
+//     off again would DOUBLE-ping;
+//   - healthchecks AND backups are both enabled.
+//
+// It then finds the daemon's recorded pid and verifies it is a LIVE proxsave --daemon before
+// signalling (never SIGUSR1 an unrelated process that reused the pid -- SIGUSR1's default action
+// would KILL it). With no live daemon it does nothing (coherent: without the daemon, nothing
+// pings anyway). Every step is best-effort: a hiccup here must never change the backup exit code,
+// so failures are logged at Debug and swallowed.
+func maybeHandoffManualBackup(opts backupModeOptions, res backupModeResult) {
+	if opts.dryRun {
+		// A dry-run is a TEST, never a real backup outcome, so it must not touch the
+		// backup-outcome check. The post-install audit runs `proxsave --dry-run` as a
+		// subprocess (installer.runPostInstallAuditDryRun) and exits 1 on warnings --
+		// without this gate that probe would ping the monitor with a phantom exit=1.
+		return
+	}
+	if res.supportStats == nil && res.earlyErrorState == nil {
+		return // no backup attempted (disabled / benign concurrency skip): nothing to report
+	}
+	if strings.TrimSpace(os.Getenv(health.EnvRunID)) != "" {
+		return // supervised child: the daemon already pings this run's outcome in runOnce
+	}
+	if opts.cfg == nil || !opts.cfg.HealthcheckEnabled || !opts.cfg.BackupEnabled {
+		return
+	}
+	baseDir := opts.cfg.BaseDir
+
+	pid, err := health.ReadDaemonPID(baseDir)
+	if err != nil {
+		logging.Debug("manual backup handoff: read daemon pid failed: %v", err)
+		return
+	}
+	if pid <= 0 || !daemonAliveProbe(pid) {
+		logging.Debug("manual backup handoff: no live proxsave daemon to signal (pid=%d)", pid)
+		return
+	}
+
+	if err := health.WriteManualOutcome(baseDir, health.NewRunID(), time.Now().Unix(), res.exitCode); err != nil {
+		logging.Debug("manual backup handoff: write outcome failed: %v", err)
+		return
+	}
+	if err := syscall.Kill(pid, syscall.SIGUSR1); err != nil {
+		logging.Debug("manual backup handoff: signal daemon pid=%d failed: %v", pid, err)
+		return
+	}
+	logging.Debug("manual backup handoff: handed outcome to daemon pid=%d (exit=%d)", pid, res.exitCode)
+}
+
+// probeProxsaveDaemonAlive reports whether pid is alive AND its /proc/<pid>/cmdline identifies a
+// proxsave --daemon process. Liveness is checked with signal 0 (no signal delivered, just an errno
+// probe: nil => alive; ESRCH => gone; EPERM => alive but not ours -> treated as "not signallable",
+// which is also what a later Kill would hit). The cmdline match is the SAFETY gate: "is pid alive"
+// alone is not enough because the OS reuses pids, and signalling a recycled pid with SIGUSR1 could
+// KILL an unrelated process (SIGUSR1's default action is terminate). Requiring BOTH a "proxsave"
+// token AND the exact "--daemon" arg means we only ever wake our own daemon.
+func probeProxsaveDaemonAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return false // ESRCH (gone) or EPERM (not ours): do not signal it
+	}
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/cmdline")
+	if err != nil {
+		return false
+	}
+	// /proc/<pid>/cmdline is NUL-separated argv; split to whole args so the match is on a real
+	// argument, not a coincidental "proxsave" substring buried inside an unrelated path.
+	args := strings.Split(string(data), "\x00")
+	var hasProxsave, hasDaemon bool
+	for _, a := range args {
+		if strings.Contains(a, "proxsave") {
+			hasProxsave = true
+		}
+		if a == "--daemon" {
+			hasDaemon = true
+		}
+	}
+	return hasProxsave && hasDaemon
+}

--- a/cmd/proxsave/backup_healthcheck_test.go
+++ b/cmd/proxsave/backup_healthcheck_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/orchestrator"
+)
+
+// handoffOpts builds backupModeOptions for the run-side decision helper: a temp BaseDir keeps the
+// handoff write out of the source tree; healthchecks + backups enabled so gating passes.
+func handoffOpts(base string) backupModeOptions {
+	return backupModeOptions{
+		cfg: &config.Config{BaseDir: base, HealthcheckEnabled: true, BackupEnabled: true},
+	}
+}
+
+// attemptedResult is a backupModeResult that looks like a real backup attempt (supportStats set),
+// so the handoff gate ("a backup was attempted") passes.
+func attemptedResult(exit int) backupModeResult {
+	return backupModeResult{supportStats: &orchestrator.BackupStats{}, exitCode: exit}
+}
+
+// withProbe swaps the daemonAliveProbe seam for the duration of a test.
+func withProbe(t *testing.T, fn func(pid int) bool) {
+	t.Helper()
+	prev := daemonAliveProbe
+	daemonAliveProbe = fn
+	t.Cleanup(func() { daemonAliveProbe = prev })
+}
+
+// A STANDALONE run whose "daemon alive" probe returns true writes the handoff file with the run's
+// exit code (the daemon then pings it on SIGUSR1).
+func TestMaybeHandoffWritesWhenDaemonAlive(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv(health.EnvRunID, "") // standalone (PROXSAVE_RUN_ID unset)
+
+	// The pid we record is our own; the probe is faked, but the helper still SIGUSR1s the pid, so
+	// catch that self-directed wake instead of taking the default terminate action.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR1)
+	defer signal.Stop(sigCh)
+
+	if err := health.WriteDaemonPID(base, os.Getpid()); err != nil {
+		t.Fatalf("WriteDaemonPID: %v", err)
+	}
+	withProbe(t, func(int) bool { return true })
+
+	maybeHandoffManualBackup(handoffOpts(base), attemptedResult(5))
+
+	// Consume the self-directed wake before the handler is removed so it never hits the default.
+	select {
+	case <-sigCh:
+	case <-time.After(time.Second):
+		t.Fatal("expected the helper to SIGUSR1 the daemon pid")
+	}
+
+	mo, err := health.LoadManualOutcome(base)
+	if err != nil {
+		t.Fatalf("LoadManualOutcome: %v", err)
+	}
+	if mo.RID == "" {
+		t.Fatal("handoff file must be written when the daemon is alive")
+	}
+	if mo.ExitCode != 5 {
+		t.Fatalf("handoff exit code = %d, want 5", mo.ExitCode)
+	}
+}
+
+// A STANDALONE run whose probe returns false (pid recorded but not a live proxsave daemon) writes
+// NOTHING and sends no signal.
+func TestMaybeHandoffSkipsWhenDaemonDead(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv(health.EnvRunID, "")
+
+	if err := health.WriteDaemonPID(base, 4242); err != nil {
+		t.Fatalf("WriteDaemonPID: %v", err)
+	}
+	withProbe(t, func(int) bool { return false })
+
+	maybeHandoffManualBackup(handoffOpts(base), attemptedResult(0))
+
+	if mo, _ := health.LoadManualOutcome(base); mo.RID != "" {
+		t.Fatalf("no handoff must be written when the daemon is not alive, got %+v", mo)
+	}
+}
+
+// The daemon's OWN supervised child (PROXSAVE_RUN_ID set) must NOT hand off -- the daemon already
+// pings that run's outcome in runOnce, so a handoff would double-ping. The probe must not even be
+// consulted.
+func TestMaybeHandoffSkipsSupervisedChild(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv(health.EnvRunID, "child-rid-123")
+
+	if err := health.WriteDaemonPID(base, os.Getpid()); err != nil {
+		t.Fatalf("WriteDaemonPID: %v", err)
+	}
+	withProbe(t, func(int) bool {
+		t.Fatal("a supervised child must return before probing the daemon")
+		return false
+	})
+
+	maybeHandoffManualBackup(handoffOpts(base), attemptedResult(0))
+
+	if mo, _ := health.LoadManualOutcome(base); mo.RID != "" {
+		t.Fatalf("a supervised child must write nothing, got %+v", mo)
+	}
+}
+
+// A DRY-RUN backup (e.g. the post-install audit's `proxsave --dry-run` probe, which exits 1 on
+// warnings) is a TEST, never a real outcome: it must write NOTHING and never touch the monitor.
+// The probe must not even be consulted.
+func TestMaybeHandoffSkipsDryRun(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv(health.EnvRunID, "") // standalone, so only the dry-run gate can stop it
+
+	if err := health.WriteDaemonPID(base, os.Getpid()); err != nil {
+		t.Fatalf("WriteDaemonPID: %v", err)
+	}
+	withProbe(t, func(int) bool {
+		t.Fatal("a dry-run must return before probing the daemon")
+		return false
+	})
+
+	opts := handoffOpts(base)
+	opts.dryRun = true
+	maybeHandoffManualBackup(opts, attemptedResult(1)) // exit 1 like the post-install audit warnings
+
+	if mo, _ := health.LoadManualOutcome(base); mo.RID != "" {
+		t.Fatalf("a dry-run must write nothing, got %+v", mo)
+	}
+}
+
+// A run that did NOT attempt a backup (disabled / benign concurrency skip: supportStats AND
+// earlyErrorState both nil) never hands off, regardless of the daemon being alive.
+func TestMaybeHandoffSkipsWhenNoBackupAttempted(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv(health.EnvRunID, "")
+
+	if err := health.WriteDaemonPID(base, os.Getpid()); err != nil {
+		t.Fatalf("WriteDaemonPID: %v", err)
+	}
+	withProbe(t, func(int) bool {
+		t.Fatal("a run that attempted no backup must return before probing")
+		return false
+	})
+
+	// Both supportStats and earlyErrorState nil = disabled/concurrency-skip.
+	maybeHandoffManualBackup(handoffOpts(base), backupModeResult{exitCode: 0})
+
+	if mo, _ := health.LoadManualOutcome(base); mo.RID != "" {
+		t.Fatalf("no backup attempted must write nothing, got %+v", mo)
+	}
+}

--- a/cmd/proxsave/backup_mode.go
+++ b/cmd/proxsave/backup_mode.go
@@ -14,11 +14,13 @@ import (
 	"github.com/tis24dev/proxsave/internal/environment"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/support"
 	"github.com/tis24dev/proxsave/internal/types"
 )
 
 type backupModeOptions struct {
 	ctx              context.Context
+	bootstrap        *logging.BootstrapLogger
 	cfg              *config.Config
 	logger           *logging.Logger
 	envInfo          *environment.EnvironmentInfo
@@ -30,6 +32,13 @@ type backupModeOptions struct {
 	heapProfilePath  string
 	serverIDValue    string
 	serverMACValue   string
+	// support arms support mode for this run: when set, the STREAMED path sends the
+	// maintainer email inside the viewport (see runBackupStreamed) instead of after
+	// the screen closes. supportMeta carries the GitHub nickname + issue the
+	// dashboard collected. The plain (CLI) path leaves these zero and relies on the
+	// deferred sender.
+	support     bool
+	supportMeta support.Meta
 }
 
 type backupModeResult struct {
@@ -37,9 +46,35 @@ type backupModeResult struct {
 	earlyErrorState *orchestrator.EarlyErrorState
 	supportStats    *orchestrator.BackupStats
 	exitCode        int
+	// supportEmailSent is set once the streamed run has already sent the support
+	// email (inside the viewport), so the deferred sender skips it - no double send.
+	supportEmailSent bool
 }
 
+// runBackupMode runs the backup, then (for a STANDALONE run) hands the outcome to the resident
+// daemon to ping. The steps live in runBackupModeSteps; this wrapper adds the handoff so every
+// return path of the backup is covered by exactly one handoff decision (which itself no-ops on the
+// disabled/concurrency-skip/supervised-child/daemon-down paths).
 func runBackupMode(opts backupModeOptions) backupModeResult {
+	// A pending dashboard handoff means the interactive dashboard kept its
+	// graphical session open for this backup: adopt it and stream the run
+	// in-graphics (runBackupStreamed). Every non-dashboard path (CLI, cron,
+	// daemon-supervised child) has no stashed session, so it runs the plain
+	// steps unchanged.
+	//
+	// The manual-backup daemon handoff runs for both, but the streamed path runs
+	// it ITSELF, inside the viewport capture (runBackupStreamed), so its debug
+	// trace streams into the panel instead of printing to the plain scrollback
+	// after the session closes. Only the plain path hands off here.
+	if dashboardHandoffPending() {
+		return runBackupStreamed(opts)
+	}
+	res := runBackupModeSteps(opts)
+	maybeHandoffManualBackup(opts, res)
+	return res
+}
+
+func runBackupModeSteps(opts backupModeOptions) backupModeResult {
 	orch, earlyErrorState, exitCode := initializeBackupOrchestrator(opts)
 	if earlyErrorState != nil {
 		return finishBackupMode(orch, earlyErrorState, nil, exitCode)
@@ -63,7 +98,7 @@ func runBackupMode(opts backupModeOptions) backupModeResult {
 		return finishBackupMode(orch, earlyErrorState, nil, exitCode)
 	}
 
-	logBackupRuntimeSummary(opts.cfg, storageState)
+	logBackupRuntimeSummary(opts.cfg, opts.logger, storageState)
 
 	stats, earlyErrorState, exitCode := runConfiguredBackup(opts, orch)
 	return finishBackupMode(orch, earlyErrorState, stats, exitCode)

--- a/cmd/proxsave/backup_notifications.go
+++ b/cmd/proxsave/backup_notifications.go
@@ -2,11 +2,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/health"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/notify"
 	"github.com/tis24dev/proxsave/internal/orchestrator"
@@ -25,6 +27,7 @@ func initializeBackupNotifications(opts backupModeOptions, orch *orchestrator.Or
 	initializeTelegramNotification(opts, orch)
 	initializeGotifyNotification(opts, orch)
 	initializeWebhookNotification(opts, orch)
+	initializeHealthcheckSection(opts, orch)
 	notifyDone(nil)
 
 	fmt.Println()
@@ -86,6 +89,125 @@ func initializeEmailNotification(opts backupModeOptions, orch *orchestrator.Orch
 	logging.Info("✓ Email initialized (method: %s)", cfg.EmailDeliveryMethod)
 }
 
+// initializeHealthcheckSection verifies the healthchecks config at run start and
+// registers the Phase-7 section, EXACTLY like the other notification channels: it prints
+// a real init line (SKIP when disabled, a WARNING that disables the section on a config
+// problem, or a "✓ initialized" when usable) instead of being silent. This is a
+// CONFIG-only check (no network); the REAL transmission state is reported later by the
+// Phase-7 section from the daemon status file. Registering only when usable keeps a
+// disabled/broken section out of the dispatch, and the Phase-7 entries loop renders the
+// matching "disabled" / "enabled but not initialized" line just as it does for the others.
+func initializeHealthcheckSection(opts backupModeOptions, orch *orchestrator.Orchestrator) {
+	cfg := opts.cfg
+	logger := opts.logger
+	if cfg == nil || !cfg.HealthcheckEnabled {
+		logging.DebugStep(logger, "notifications init", "healthchecks disabled")
+		logging.Skip("Healthchecks: disabled")
+		return
+	}
+	// Verify config, then that the monitoring daemon (the ONLY pinger) is actually alive -
+	// a valid config is worthless if the daemon is down. On ANY problem, switch the
+	// channel to disabled EXACTLY like checkTelegramServerStatus does for a failed
+	// centralized handshake (main_identity.go): so the whole flow treats it as disabled.
+	if problem := healthcheckConfigProblem(cfg); problem != "" {
+		disableHealthchecks(cfg, logger, problem)
+		return
+	}
+	if problem := healthcheckDaemonProblem(opts.ctx, cfg, logger); problem != "" {
+		disableHealthchecks(cfg, logger, problem)
+		return
+	}
+	logging.DebugStep(logger, "notifications init", "healthchecks enabled (mode=%s, daemon up)", cfg.HealthcheckMode)
+	orch.RegisterNotificationChannel(orchestrator.NewHealthchecksChannel(cfg, logger))
+	logging.Info("✓ Healthchecks initialized (mode: %s)", cfg.HealthcheckMode)
+}
+
+// disableHealthchecks switches the section to disabled with a reason, mirroring
+// checkTelegramServerStatus (cmd/proxsave/main_identity.go): a WARNING naming the
+// problem, a clean "Healthchecks: disabled" SKIP, and flipping cfg.HealthcheckEnabled so
+// the downstream Phase-7 dispatch entries loop renders "Healthchecks: disabled" instead
+// of "enabled but not initialized". cfg is the same pointer the dispatcher reads.
+func disableHealthchecks(cfg *config.Config, logger *logging.Logger, reason string) {
+	logging.DebugStep(logger, "notifications init", "healthchecks disabled: %s", reason)
+	logging.Warning("Healthchecks: %s", reason)
+	logging.Skip("Healthchecks: disabled")
+	cfg.HealthcheckEnabled = false
+}
+
+// healthcheckDaemonProblem verifies the monitoring daemon is actually alive by reading
+// its persisted heartbeat (the daemon records its first beat immediately on startup, so
+// a fresh beat proves it is running). Returns a specific reason when the daemon is not
+// usable (unreadable status, not running, or down/stuck), or "" when it is up. It never
+// transmits - it only inspects the local status file the daemon writes.
+func healthcheckDaemonProblem(ctx context.Context, cfg *config.Config, logger *logging.Logger) string {
+	// The status file answers "is it transmitting?"; systemd answers "does the process
+	// exist and run?". Refine the heartbeat diagnosis with the systemd verdict so a
+	// running-but-silent daemon (stale binary) is not misreported as "daemon not running".
+	presence := daemonPresenceProbe(ctx)
+	st, err := health.LoadStatus(cfg.BaseDir)
+	if err != nil {
+		if presence.Probed {
+			d := health.RefineWithPresence(health.Diagnosis{State: health.TxNoHeartbeat}, presence)
+			logging.DebugStep(logger, "notifications init",
+				"healthchecks status unreadable, presence state=%s installed=%t active=%t", d.State, presence.Installed, presence.Active)
+			return daemonProblemForState(d)
+		}
+		logging.DebugStep(logger, "notifications init", "healthchecks status unreadable: %v", err)
+		return "status file unreadable"
+	}
+	d := health.Diagnose(st, cfg.HealthcheckHeartbeatInterval, time.Now())
+	d = health.RefineWithPresence(d, presence)
+	// Shape-only debug, mirroring the Phase-7 section's diagnose line so the init verdict
+	// and the run-time section can be cross-read at debug (no URL/secret, just state).
+	logging.DebugStep(logger, "notifications init",
+		"healthchecks daemon diagnose state=%s daemon_up=%t hb_age=%s installed=%t active=%t",
+		d.State, d.DaemonUp, d.HbAge, presence.Installed, presence.Active)
+	return daemonProblemForState(d)
+}
+
+// daemonProblemForState maps a presence-refined diagnosis to a terse SYNTHETIC reason
+// (bare fact, never an instruction) or "" when the daemon is up. Shares the exact state
+// vocabulary the Phase-7 section renders so the init verdict and the section never drift.
+func daemonProblemForState(d health.Diagnosis) string {
+	switch d.State {
+	case health.TxNotInstalled:
+		return "daemon not installed"
+	case health.TxNotActive:
+		return "daemon not running"
+	case health.TxRunningNoReport:
+		return "daemon running, not reporting"
+	case health.TxStale:
+		return "daemon stale (last beat " + health.HumanizeAge(d.HbAge) + ")"
+	}
+	if d.DaemonUp {
+		return ""
+	}
+	return "daemon not running"
+}
+
+// healthcheckConfigProblem returns a short reason when the healthcheck config is
+// structurally unusable, or "" when it is fine. Config-only (mirrors how the other
+// notifiers validate at init) - it never touches the network or the on-disk secret;
+// runtime provisioning/transmission is the Phase-7 section's job (the daemon status file).
+func healthcheckConfigProblem(cfg *config.Config) string {
+	switch cfg.HealthcheckMode {
+	case "self":
+		// Self mode needs a check to ping: a full alive URL, or an alive check id (the
+		// ping endpoint defaults to a public host, so the id/URL is the discriminator).
+		// The service-alive (heartbeat / dead-man) check is the mandatory one; a
+		// backup-only self config has no liveness signal. Name it precisely so the
+		// message is not mistaken for "no monitoring at all".
+		if cfg.HealthcheckAliveURL == "" && cfg.HealthcheckAliveID == "" {
+			return "no alive check configured"
+		}
+	default: // centralized
+		if strings.TrimSpace(cfg.ServerID) == "" {
+			return "no SERVER_ID"
+		}
+	}
+	return ""
+}
+
 func initializeTelegramNotification(opts backupModeOptions, orch *orchestrator.Orchestrator) {
 	cfg := opts.cfg
 	logger := opts.logger
@@ -101,7 +223,7 @@ func initializeTelegramNotification(opts backupModeOptions, orch *orchestrator.O
 		Mode:          notify.TelegramMode(cfg.TelegramBotType),
 		BotToken:      cfg.TelegramBotToken,
 		ChatID:        cfg.TelegramChatID,
-		ServerAPIHost: cfg.TelegramServerAPIHost,
+		ServerAPIHost: cfg.ServerAPIHost,
 		ServerID:      cfg.ServerID,
 		NotifySecret:  cfg.TelegramNotifySecret,
 		BaseDir:       cfg.BaseDir,
@@ -175,10 +297,10 @@ func initializeWebhookNotification(opts backupModeOptions, orch *orchestrator.Or
 	logging.Info("✓ Webhook initialized (%d endpoint(s))", len(webhookConfig.Endpoints))
 }
 
-func logBackupRuntimeSummary(cfg *config.Config, storageState backupStorageState) {
+func logBackupRuntimeSummary(cfg *config.Config, logger *logging.Logger, storageState backupStorageState) {
 	logBackupStorageSummary(cfg, storageState)
 	logBackupLogSummary(cfg)
-	logBackupNotificationSummary(cfg)
+	logBackupNotificationSummary(cfg, logger)
 }
 
 func logBackupStorageSummary(cfg *config.Config, storageState backupStorageState) {
@@ -221,12 +343,25 @@ func logBackupLogSummary(cfg *config.Config) {
 	fmt.Println()
 }
 
-func logBackupNotificationSummary(cfg *config.Config) {
+// logBackupNotificationSummary prints the EFFECTIVE per-channel state for THIS run, not
+// the raw config: every flag has already absorbed the network-preflight, Telegram-handshake
+// and Healthchecks-daemon flips, all of which run earlier on this same cfg pointer (proof:
+// runNetworkPreflight and initializeServerIdentity precede runBackupMode, and
+// initializeBackupNotifications precedes this summary). Healthchecks is listed so the set is
+// not silently short a channel; Metrics has no runtime flip, so its effective value always
+// equals the configured one.
+func logBackupNotificationSummary(cfg *config.Config, logger *logging.Logger) {
+	done := logging.DebugStart(logger, "notification summary", "effective post-flip state")
 	logging.Info("Notification configuration:")
 	logging.Info("  Telegram: %v", cfg.TelegramEnabled)
 	logging.Info("  Email: %v", cfg.EmailEnabled)
 	logging.Info("  Gotify: %v", cfg.GotifyEnabled)
 	logging.Info("  Webhook: %v", cfg.WebhookEnabled)
+	logging.Info("  Healthchecks: %v", cfg.HealthcheckEnabled)
 	logging.Info("  Metrics: %v", cfg.MetricsEnabled)
+	logging.DebugStep(logger, "notification summary",
+		"telegram=%t email=%t gotify=%t webhook=%t healthchecks=%t metrics=%t",
+		cfg.TelegramEnabled, cfg.EmailEnabled, cfg.GotifyEnabled, cfg.WebhookEnabled, cfg.HealthcheckEnabled, cfg.MetricsEnabled)
+	done(nil)
 	fmt.Println()
 }

--- a/cmd/proxsave/backup_notifications_healthcheck_test.go
+++ b/cmd/proxsave/backup_notifications_healthcheck_test.go
@@ -1,0 +1,136 @@
+// Package main contains the proxsave command entrypoint.
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func TestHealthcheckConfigProblem(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     *config.Config
+		wantHas string // substring the problem must contain; "" means "no problem"
+	}{
+		{"centralized ok", &config.Config{HealthcheckMode: "centralized", ServerID: "srv1"}, ""},
+		{"centralized no server id", &config.Config{HealthcheckMode: "centralized"}, "SERVER_ID"},
+		{"centralized blank server id", &config.Config{HealthcheckMode: "centralized", ServerID: "   "}, "SERVER_ID"},
+		{"self via alive url", &config.Config{HealthcheckMode: "self", HealthcheckAliveURL: "https://hc/x"}, ""},
+		{"self via alive id", &config.Config{HealthcheckMode: "self", HealthcheckAliveID: "uuid-1"}, ""},
+		{"self no check", &config.Config{HealthcheckMode: "self"}, "no alive check"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := healthcheckConfigProblem(tc.cfg)
+			if tc.wantHas == "" {
+				if got != "" {
+					t.Fatalf("want no problem, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantHas) {
+				t.Fatalf("problem=%q want substring %q", got, tc.wantHas)
+			}
+		})
+	}
+}
+
+// TestInitializeHealthcheckSectionLines pins that Healthchecks emits a REAL init line at
+// run start, consistent with the other channels: SKIP when disabled, a WARNING that
+// disables the section on a config problem OR when the monitoring daemon is not
+// running/down, and a "✓ initialized" line ONLY when config is usable AND the daemon is
+// actually alive (fresh heartbeat in its status file).
+func TestInitializeHealthcheckSectionLines(t *testing.T) {
+	orig := logging.GetDefaultLogger()
+	t.Cleanup(func() { logging.SetDefaultLogger(orig) })
+
+	origProbe := daemonPresenceProbe
+	t.Cleanup(func() { daemonPresenceProbe = origProbe })
+
+	discard := logging.New(types.LogLevelInfo, false)
+	discard.SetOutput(io.Discard)
+
+	// run drives the init with an explicit systemd presence. The default (unprobed) keeps
+	// the heartbeat-only behaviour the pre-existing cases assert; the presence cases below
+	// pin the systemd-refined verdicts.
+	run := func(cfg *config.Config, p health.DaemonPresence) string {
+		daemonPresenceProbe = func(context.Context) health.DaemonPresence { return p }
+		var buf bytes.Buffer
+		def := logging.New(types.LogLevelDebug, false)
+		def.SetOutput(&buf)
+		logging.SetDefaultLogger(def)
+		orch := orchestrator.New(discard, false)
+		initializeHealthcheckSection(backupModeOptions{ctx: context.Background(), cfg: cfg, logger: discard}, orch)
+		return buf.String()
+	}
+	unprobed := health.DaemonPresence{}
+	activeDaemon := health.DaemonPresence{Probed: true, Installed: true, Active: true}
+	// writeHeartbeat records a heartbeat into a fresh temp BaseDir at the given age.
+	usableCfg := func(t *testing.T, hbAge time.Duration, hasBeat bool) *config.Config {
+		t.Helper()
+		base := t.TempDir()
+		if hasBeat {
+			if err := health.RecordPing(base, "centralized", health.KindHeartbeat, time.Now().Add(-hbAge).Unix(), true, nil); err != nil {
+				t.Fatalf("seed heartbeat: %v", err)
+			}
+		}
+		return &config.Config{HealthcheckEnabled: true, HealthcheckMode: "centralized", ServerID: "srv1", BaseDir: base}
+	}
+
+	// disabled -> a SKIP line, exactly like Email/Gotify/Webhook.
+	if out := run(&config.Config{HealthcheckEnabled: false}, unprobed); !strings.Contains(out, "Healthchecks: disabled") {
+		t.Fatalf("disabled must print a SKIP line, out=%q", out)
+	}
+
+	// On ANY problem the section must (like Telegram): WARN the reason, SKIP a clean
+	// "Healthchecks: disabled", flip cfg.HealthcheckEnabled=false, and NOT print "✓".
+	assertDisabled := func(t *testing.T, name string, c *config.Config, p health.DaemonPresence, wantReason string) {
+		t.Helper()
+		out := run(c, p)
+		if !strings.Contains(out, wantReason) {
+			t.Fatalf("%s: want reason %q, out=%q", name, wantReason, out)
+		}
+		if !strings.Contains(out, "Healthchecks: disabled") {
+			t.Fatalf("%s: want a clean 'Healthchecks: disabled' SKIP, out=%q", name, out)
+		}
+		if strings.Contains(out, "Healthchecks initialized") {
+			t.Fatalf("%s: must NOT print initialized, out=%q", name, out)
+		}
+		if c.HealthcheckEnabled {
+			t.Fatalf("%s: must flip HealthcheckEnabled=false so the flow treats it as disabled", name)
+		}
+	}
+
+	// enabled + centralized without SERVER_ID -> config problem.
+	assertDisabled(t, "no-server-id", &config.Config{HealthcheckEnabled: true, HealthcheckMode: "centralized"}, unprobed, "SERVER_ID")
+	// Heartbeat-only fallback (systemctl unavailable): no beat -> "daemon not running".
+	assertDisabled(t, "no-daemon", usableCfg(t, 0, false), unprobed, "daemon not running")
+	// Heartbeat-only fallback: STALE heartbeat -> "daemon stale".
+	assertDisabled(t, "stale-daemon", usableCfg(t, time.Hour, true), unprobed, "daemon stale")
+
+	// Systemd-refined verdicts (the completeness fix): presence dominates the heartbeat.
+	// Unit absent -> "daemon not installed", even with a fresh beat seeded.
+	assertDisabled(t, "not-installed", usableCfg(t, 30*time.Second, true),
+		health.DaemonPresence{Probed: true, Installed: false}, "daemon not installed")
+	// Installed but systemd inactive -> "daemon not running" (truly stopped).
+	assertDisabled(t, "not-active", usableCfg(t, 30*time.Second, true),
+		health.DaemonPresence{Probed: true, Installed: true, Active: false}, "daemon not running")
+	// systemd ACTIVE but no fresh beat -> "daemon running, not reporting" (stale binary).
+	assertDisabled(t, "running-not-reporting", usableCfg(t, 0, false), activeDaemon, "daemon running, not reporting")
+
+	// usable config + FRESH heartbeat + systemd active -> initialized.
+	out := run(usableCfg(t, 30*time.Second, true), activeDaemon)
+	if !strings.Contains(out, "✓ Healthchecks initialized (mode: centralized)") {
+		t.Fatalf("usable config + live daemon must print the initialized line, out=%q", out)
+	}
+}

--- a/cmd/proxsave/backup_stream.go
+++ b/cmd/proxsave/backup_stream.go
@@ -1,0 +1,359 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/serverbot"
+	"github.com/tis24dev/proxsave/internal/ui/components"
+	"github.com/tis24dev/proxsave/internal/ui/shell"
+	"github.com/tis24dev/proxsave/internal/ui/theme"
+)
+
+// backupStreamSteps is the seam runBackupStreamed drives to run the real backup.
+// It points at runBackupModeSteps in production; tests override it with a stub
+// that emits a couple of log lines (captured -> streamed) and returns a canned
+// result, so the capture->stream plumbing can be exercised without a real backup.
+var backupStreamSteps = runBackupModeSteps
+
+// backupAdoptSession is the seam runBackupStreamed uses to adopt the altscreen
+// session the dashboard stashed on the "Backup" choice. Production uses
+// adoptDashboardSession; tests override it with an output-observing altscreen
+// session so the emitted lines and the outcome can be asserted.
+var backupAdoptSession = adoptDashboardSession
+
+// captureRunOutput routes BOTH the loggers (default + colored bootstrap mirror)
+// AND raw os.Stdout through a SINGLE pipe into emit, so everything a run prints -
+// colored logger lines AND the raw fmt.Println blank spacers between sections -
+// streams into the panel in the SAME order as the CLI. The bubbletea program
+// renders to its own saved fd (captured at program start), so redirecting the
+// os.Stdout variable here never touches the altscreen. restore() (call via defer)
+// undoes the logger swap + restores os.Stdout, closes the pipe, and drains it.
+// If os.Pipe fails it degrades to logger-only capture (no stdout spacers).
+func captureRunOutput(bootstrap *logging.BootstrapLogger, emit func(line string)) func() {
+	sink := logging.NewLineWriterRaw(emit)
+	r, w, err := os.Pipe()
+	if err != nil {
+		return logging.CaptureConsoleWithColor(bootstrap, sink)
+	}
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(sink, r)
+		close(done)
+	}()
+	origStdout := os.Stdout
+	os.Stdout = w
+	restoreLoggers := logging.CaptureConsoleWithColor(bootstrap, w)
+	return func() {
+		restoreLoggers()
+		os.Stdout = origStdout
+		_ = w.Close()
+		<-done
+		_ = r.Close()
+	}
+}
+
+// runStreamedEndOfRunActions runs the backup side effects that must appear
+// INSIDE the streamed viewport, in ONE place, so the RunStreamTask closure has a
+// single call and any future in-stream end-of-run action is added here:
+//   - the support email (support mode only): sent HERE inside the capture so its
+//     outcome streams into the viewport instead of printing to a screen already
+//     closed after Continue. The log-management phase (in backupStreamSteps) has
+//     closed the log file, so the email attaches the COMPLETE log. It sets
+//     res.supportEmailSent so the deferred sender skips it (no double send).
+//     envInfo is always set for a real run; guarded to never deref.
+//   - the daemon handoff: its debug trace streams into the viewport instead of
+//     the plain scrollback after the session closes (visible in support mode,
+//     where the run forces DEBUG logging).
+//
+// This is the in-STREAM case only. The fallback (session vanished) and the CLI
+// path hand off directly, without an in-viewport email.
+func runStreamedEndOfRunActions(ctx context.Context, opts backupModeOptions, res *backupModeResult) {
+	if opts.support && res.supportStats != nil && opts.envInfo != nil {
+		emitSupportEmail(ctx, opts.cfg, opts.logger, opts.envInfo.Type, res.supportStats, opts.supportMeta)
+		res.supportEmailSent = true
+	}
+	maybeHandoffManualBackup(opts, *res)
+}
+
+// runBackupStreamed runs the backup INSIDE the graphical dashboard ALTSCREEN
+// session, streaming its [ts] LEVEL log lines into a CONTAINED, scrollable,
+// COLORED viewport panel (components.RunStreamTask) so scrolling stays within the
+// box and the whole run is contained in the frame -- exactly what a long run
+// needs. It adopts the session the dashboard stashed on the "Backup" choice; if
+// that handoff has vanished (already adopted, or never stashed -- a CLI/cron/
+// daemon backup) it falls back to the plain steps so the backup always runs.
+//
+// The captured console (logging.CaptureConsoleWithColor) routes the default
+// logger + the COLORED bootstrap mirror into the raw sink, so both the run's
+// logging.Info lines and the bootstrap finalization lines flow (colored) into the
+// viewport. taskCtx is threaded into the backup so Esc cancels the run; the
+// session is closed only after the user presses Continue.
+func runBackupStreamed(opts backupModeOptions) backupModeResult {
+	useColor := true
+	if opts.cfg != nil {
+		useColor = opts.cfg.UseColor
+	}
+	session := backupAdoptSession(shell.Config{
+		AppName:  "ProxSave",
+		Subtitle: "Backup",
+		UseColor: useColor,
+	})
+	if session == nil {
+		// The handoff vanished (CLI/cron/daemon): run the backup plain, then hand
+		// the outcome to the daemon (plain console, like the CLI path).
+		res := backupStreamSteps(opts)
+		maybeHandoffManualBackup(opts, res)
+		return res
+	}
+
+	var res backupModeResult
+	streamErr := components.RunStreamTask(opts.ctx, session, "Running backup",
+		func(taskCtx context.Context, emit func(line string)) (string, error) {
+			// Route the default + COLORED bootstrap-mirror loggers AND raw os.Stdout
+			// (the fmt.Println section spacers the CLI prints) through one pipe into
+			// the panel; restored on return/panic. So the panel shows the SAME lines -
+			// colored logs + the blank spacer rows between sections - in the same
+			// order as the CLI, instead of losing them to the raw altscreen.
+			defer captureRunOutput(opts.bootstrap, emit)()
+
+			// Thread taskCtx so an Esc cancel propagates into the running backup.
+			stepOpts := opts
+			stepOpts.ctx = taskCtx
+			res = backupStreamSteps(stepOpts)
+			runStreamedEndOfRunActions(taskCtx, opts, &res)
+			return buildBackupOutcomePrompt(res), nil
+		})
+	if streamErr != nil {
+		// The stream is best-effort UI: an abort/UI-death never changes the
+		// backup outcome (res already holds it), so only trace it.
+		logging.DebugStepBootstrap(opts.bootstrap, "dashboard", "backup stream: %v", streamErr)
+	}
+
+	// The user pressed Continue: release the terminal so any deferred output
+	// prints to the plain scrollback (the in-graphics viewport vanishes with the
+	// alternate screen, matching the install finalization).
+	if closeErr := session.Close(); closeErr != nil {
+		logging.DebugStepBootstrap(opts.bootstrap, "dashboard", "session close: %v", closeErr)
+	}
+	return res
+}
+
+// renderBackupBanner renders the pre-styled backup outcome banner for a given
+// display severity, mapping each severity to its (style, symbol, title). It
+// classifies with the SHARED exitCodeSeverity so the banner colors res.exitCode
+// EXACTLY like the CLI final summary footer: a non-fatal generic error (exit 1,
+// ExitGenericError) reads yellow "completed with warnings", NOT red "failed".
+// The interrupted case uses the magenta InterruptedText matching the footer's
+// Ctrl+C color; there is no altscreen banner level for it.
+func renderBackupBanner(sev exitSeverity) string {
+	switch sev {
+	case severityOK:
+		return theme.SuccessText.Render(theme.SymbolSuccess + " " + "Backup completed")
+	case severityWarning:
+		return theme.WarningText.Render(theme.SymbolWarning + " " + "Backup completed with warnings")
+	case severityInterrupted:
+		return theme.InterruptedText.Render(theme.SymbolWarning + " " + "Backup interrupted")
+	default: // severityError
+		return theme.ErrorText.Render(theme.SymbolError + " " + "Backup failed")
+	}
+}
+
+// buildBackupOutcomePrompt composes the pre-styled outcome block shown at the
+// bottom of the streamed backup screen (StreamDoneMsg.Outcome), mirroring
+// buildInstallOutcomePrompt. It opens with renderBackupBanner classified via the
+// shared exitCodeSeverity (same logger the footer reads, so HasWarnings agrees),
+// then adds themed stat lines from the run's BackupStats when present. The
+// display classification only colors the banner - res.exitCode is untouched and
+// still drives finalize, byte-identical to the CLI. Missing/nil data is skipped
+// (never panics).
+func buildBackupOutcomePrompt(res backupModeResult) string {
+	var b strings.Builder
+
+	logger := logging.GetDefaultLogger()
+	sev := exitCodeSeverity(res.exitCode, logger)
+	b.WriteString(renderBackupBanner(sev))
+
+	if st := res.supportStats; st != nil {
+		// The backup-statistics block (headerless); the log block is now debug-only.
+		b.WriteString("\n")
+		appendBackupStatsBlock(&b, st)
+
+		// Appended at the BOTTOM of the block: the run log path, then storage status,
+		// then centralized-mode identity.
+		//
+		// The run log file is CLOSED during the log-management phase before this
+		// outcome is built, so GetLogFilePath may be "" by now; runLogPath falls back
+		// to the LOG_FILE the runtime exports at startup.
+		if lp := runLogPath(); lp != "" {
+			b.WriteString("\n")
+			b.WriteString(theme.Text.Render("Log: " + lp))
+		}
+
+		// Secondary/Cloud storage status, only when they carry a meaningful
+		// (non-disabled) status, so a single-destination run stays terse.
+		if s := strings.TrimSpace(st.SecondaryStatus); s != "" && s != "disabled" {
+			appendBackupStatusLine(&b, "Secondary", st.SecondaryStatus)
+		}
+		if s := strings.TrimSpace(st.CloudStatus); s != "" && s != "disabled" {
+			appendBackupStatusLine(&b, "Cloud", st.CloudStatus)
+		}
+
+		// Centralized-mode identity: the Telegram/relay pairing id and the sanitized
+		// Healthchecks portal link, each shown only when present. The link mirrors the
+		// sole-display discipline of logMonitoringPortalLink: sanitized once with
+		// serverbot.SanitizeLoginURL, printed ONLY if it survives, NEVER raw and never
+		// registered as a secret.
+		if id := strings.TrimSpace(st.ServerID); id != "" {
+			b.WriteString("\n")
+			b.WriteString(theme.Text.Render("Server ID Telegram: " + id))
+		}
+		if link := serverbot.SanitizeLoginURL(st.HealthcheckLink); link != "" {
+			b.WriteString("\n")
+			b.WriteString(theme.Text.Render("Healthchecks link: " + link))
+		}
+	}
+
+	// Warnings/errors recap - the theme counterpart of the CLI footer's
+	// printRunIssueSummary - shown whenever the run logged issues (even a failed run
+	// with no stats), so the graphical outcome states them as clearly as the CLI.
+	appendRunIssueSummary(&b, logger)
+
+	return b.String()
+}
+
+// appendBackupStatsBlock renders the backup-statistics block into the graphical
+// outcome recap. Its first line is the enriched "Files: N collected - K missing
+// (M failed)" moved down from the upper recap; the remaining lines mirror the
+// debug-only log block in logBackupStatistics (same lines, conditionals and
+// formatters - formatBytes/formatDuration and the shared compressionRatioText),
+// just THEME-styled instead of logged.
+func appendBackupStatsBlock(b *strings.Builder, st *orchestrator.BackupStats) {
+	// Files: N collected - K missing (M failed) - moved down from the upper recap.
+	// "missing" reuses st.FilesMissing (the field the notifications report), always
+	// shown (yellow when >0); the failed count only when non-zero.
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render(fmt.Sprintf("Files: %d collected - ", st.FilesCollected)))
+	missingStyle := theme.Text
+	if st.FilesMissing > 0 {
+		missingStyle = theme.WarningText
+	}
+	b.WriteString(missingStyle.Render(fmt.Sprintf("%d missing", st.FilesMissing)))
+	if st.FilesFailed > 0 {
+		b.WriteString(theme.WarningText.Render(fmt.Sprintf(" (%d failed)", st.FilesFailed)))
+	}
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render(fmt.Sprintf("Directories created: %d", st.DirsCreated)))
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render("Data collected: " + formatBytes(st.BytesCollected)))
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render("Archive size: " + formatBytes(st.ArchiveSize)))
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render("Compression ratio: " + compressionRatioText(st)))
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render(fmt.Sprintf("Compression used: %s (level %d, mode %s)", st.Compression, st.CompressionLevel, st.CompressionMode)))
+	if st.RequestedCompression != st.Compression {
+		b.WriteString("\n")
+		b.WriteString(theme.Text.Render(fmt.Sprintf("Requested compression: %s", st.RequestedCompression)))
+	}
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render("Duration: " + formatDuration(st.Duration)))
+
+	// Mirror logBackupArtifactPaths (bundle case shown contents-then-path). A base
+	// (non-bundle) run has no "Bundle contents" line: it shows "Archive path" plus
+	// the manifest/checksum, so this line adapts to the configured mode.
+	if st.BundleCreated {
+		b.WriteString("\n")
+		b.WriteString(theme.Text.Render("Bundle contents: archive + checksum + metadata"))
+		b.WriteString("\n")
+		b.WriteString(theme.Text.Render("Bundle path: " + st.ArchivePath))
+		return
+	}
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render("Archive path: " + st.ArchivePath))
+	if st.ManifestPath != "" {
+		b.WriteString("\n")
+		b.WriteString(theme.Text.Render("Manifest path: " + st.ManifestPath))
+	}
+	if st.Checksum != "" {
+		b.WriteString("\n")
+		b.WriteString(theme.Text.Render("Archive checksum (SHA256): " + st.Checksum))
+	}
+}
+
+// runLogPath returns the path of the run's log file for the outcome "Log:" line.
+// It prefers the live default logger's path, but that logger's file is CLOSED
+// during the backup log-management phase before the outcome is built, so
+// GetLogFilePath may be "" by then; it then falls back to the LOG_FILE env var the
+// runtime exports at startup (main_runtime.go os.Setenv("LOG_FILE", logFilePath)).
+func runLogPath() string {
+	if p := logging.GetDefaultLogger().GetLogFilePath(); p != "" {
+		return p
+	}
+	return strings.TrimSpace(os.Getenv("LOG_FILE"))
+}
+
+// appendRunIssueSummary appends a warnings/errors recap to the backup outcome: a
+// colored count header (yellow when only warnings, red once any error was logged)
+// followed by the captured "[ts] LEVEL msg" issue lines. Nothing is emitted for a
+// clean run. The list is capped so a noisy run cannot overflow the outcome block;
+// the full list stays scrollable in the panel above. It reads the SAME logger the
+// CLI footer's printRunIssueSummary reads, so the counts and lines match exactly.
+func appendRunIssueSummary(b *strings.Builder, logger *logging.Logger) {
+	if logger == nil {
+		return
+	}
+	issues := logger.IssueLines()
+	if len(issues) == 0 {
+		return
+	}
+
+	headerStyle := theme.WarningText
+	if logger.ErrorCount() > 0 {
+		headerStyle = theme.ErrorText
+	}
+	b.WriteString("\n\n")
+	b.WriteString(headerStyle.Render(fmt.Sprintf("%s Warnings/errors during run: %d warning(s), %d error(s)",
+		theme.SymbolWarning, logger.WarningCount(), logger.ErrorCount())))
+
+	const maxLines = 10
+	shown := issues
+	if len(shown) > maxLines {
+		shown = shown[:maxLines]
+	}
+	for _, line := range shown {
+		b.WriteString("\n")
+		b.WriteString(theme.Subtle.Render("  " + line))
+	}
+	if extra := len(issues) - len(shown); extra > 0 {
+		b.WriteString("\n")
+		b.WriteString(theme.Subtle.Render(fmt.Sprintf("  ... and %d more (scroll up to review)", extra)))
+	}
+}
+
+// appendBackupStatusLine writes a themed "<label>: <status>" storage line, colored
+// by the orchestrator's status vocabulary (ok/error/warning/disabled). An empty
+// status is skipped so no blank line is emitted.
+func appendBackupStatusLine(b *strings.Builder, label, status string) {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return
+	}
+	b.WriteString("\n")
+	b.WriteString(theme.Text.Render(label + ": "))
+	switch status {
+	case "ok":
+		b.WriteString(theme.SuccessText.Render(status))
+	case "error":
+		b.WriteString(theme.ErrorText.Render(status))
+	case "warning":
+		b.WriteString(theme.WarningText.Render(status))
+	default: // disabled / unknown: neutral
+		b.WriteString(theme.Subtle.Render(status))
+	}
+}

--- a/cmd/proxsave/backup_stream_test.go
+++ b/cmd/proxsave/backup_stream_test.go
@@ -1,0 +1,516 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/environment"
+	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/support"
+	"github.com/tis24dev/proxsave/internal/types"
+	"github.com/tis24dev/proxsave/internal/ui/shell"
+	"github.com/tis24dev/proxsave/internal/uitest"
+)
+
+// TestBuildBackupOutcomePromptSuccess asserts a successful run renders the green
+// "Backup completed" banner plus themed stat lines from the run's BackupStats.
+func TestBuildBackupOutcomePromptSuccess(t *testing.T) {
+	// A clean (no-warnings) default logger so the exit-0 run classifies OK, not
+	// Warning (buildBackupOutcomePrompt reads GetDefaultLogger().HasWarnings()).
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	res := backupModeResult{
+		exitCode: types.ExitSuccess.Int(),
+		supportStats: &orchestrator.BackupStats{
+			FilesCollected:   42,
+			FilesFailed:      3,
+			DirsCreated:      7,
+			BytesCollected:   8192,
+			ArchiveSize:      4096,
+			Compression:      "zstd",
+			CompressionLevel: 3,
+			CompressionMode:  "standard",
+			BundleCreated:    true,
+			Duration:         90 * time.Second,
+			ArchivePath:      "/var/backup/proxsave-2026.tar.zst",
+			LocalStatus:      "ok",
+			SecondaryStatus:  "warning",
+			CloudStatus:      "disabled",
+		},
+	}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+
+	if !strings.Contains(out, "Backup completed") {
+		t.Fatalf("missing completion banner:\n%s", out)
+	}
+	if strings.Contains(out, "Backup failed") {
+		t.Fatalf("a successful run must not say 'failed':\n%s", out)
+	}
+	// The enriched Files line (collected + missing + failed) now lives in the lower
+	// stats block, not the upper recap.
+	if !strings.Contains(out, "Files: 42 collected - 0 missing") || !strings.Contains(out, "(3 failed)") {
+		t.Fatalf("missing files line:\n%s", out)
+	}
+	// PARTE ALTA dropped Size / Duration / Archive / Local: Size/Duration/Archive
+	// now live only in the stats block below, Local is removed entirely. Secondary
+	// stays; a disabled Cloud is skipped.
+	if !strings.Contains(out, "Secondary: warning") {
+		t.Fatalf("missing secondary status line:\n%s", out)
+	}
+	if strings.Contains(out, "Local:") {
+		t.Fatalf("the Local status line must be removed:\n%s", out)
+	}
+	if strings.Contains(out, "Cloud:") {
+		t.Fatalf("disabled cloud must be skipped:\n%s", out)
+	}
+
+	// The recap carries the backup-statistics lines (mirroring the debug-only log
+	// block) WITHOUT the "=== Backup Statistics ===" header.
+	if strings.Contains(out, "=== Backup Statistics ===") {
+		t.Fatalf("the stats header must be removed:\n%s", out)
+	}
+	for _, want := range []string{
+		"Directories created: 7",
+		"Data collected: 8.0 KiB",
+		"Archive size: 4.0 KiB",
+		"Compression ratio: 50.0%",
+		"Compression used: zstd (level 3, mode standard)",
+		"Bundle path: /var/backup/proxsave-2026.tar.zst",
+		"Bundle contents: archive + checksum + metadata",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stats block missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestBuildBackupOutcomePromptFilesMissing asserts the Files line renders the
+// "- N missing" count from st.FilesMissing (the SAME field the notifications
+// report) when non-zero.
+func TestBuildBackupOutcomePromptFilesMissing(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	res := backupModeResult{
+		exitCode: types.ExitSuccess.Int(),
+		supportStats: &orchestrator.BackupStats{
+			FilesCollected: 40,
+			FilesMissing:   5,
+			LocalStatus:    "ok",
+		},
+	}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+	if !strings.Contains(out, "Files: 40 collected - 5 missing") {
+		t.Fatalf("missing files-missing count:\n%s", out)
+	}
+}
+
+// TestBuildBackupOutcomePromptLogLine asserts the "Log:" line falls back to the
+// LOG_FILE env var when the default logger has no file path (as in tests).
+func TestBuildBackupOutcomePromptLogLine(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	t.Setenv("LOG_FILE", "/tmp/run.log")
+
+	res := backupModeResult{
+		exitCode:     types.ExitSuccess.Int(),
+		supportStats: &orchestrator.BackupStats{FilesCollected: 1, LocalStatus: "ok"},
+	}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+	if !strings.Contains(out, "Log: /tmp/run.log") {
+		t.Fatalf("missing log line (env fallback):\n%s", out)
+	}
+}
+
+// TestBuildBackupOutcomePromptCentralizedIdentity asserts the centralized-mode
+// lines: the Telegram/relay ServerID and the SANITIZED Healthchecks link. A
+// hostile link is stripped by serverbot.SanitizeLoginURL (no line printed), and
+// empty ServerID/link produce no lines.
+func TestBuildBackupOutcomePromptCentralizedIdentity(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	// Present + clean: both lines shown, link passed through verbatim (sanitized OK).
+	res := backupModeResult{
+		exitCode: types.ExitSuccess.Int(),
+		supportStats: &orchestrator.BackupStats{
+			FilesCollected:  1,
+			LocalStatus:     "ok",
+			ServerID:        "srv-42",
+			HealthcheckLink: "https://hc/accounts/check_token/u/CAP/",
+		},
+	}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+	if !strings.Contains(out, "Server ID Telegram: srv-42") {
+		t.Fatalf("missing server id line:\n%s", out)
+	}
+	if !strings.Contains(out, "Healthchecks link: https://hc/accounts/check_token/u/CAP/") {
+		t.Fatalf("missing sanitized healthchecks link line:\n%s", out)
+	}
+
+	// Hostile link (space injection): sanitized away -> NO link line, raw never shown.
+	resHostile := backupModeResult{
+		exitCode: types.ExitSuccess.Int(),
+		supportStats: &orchestrator.BackupStats{
+			FilesCollected:  1,
+			LocalStatus:     "ok",
+			HealthcheckLink: "https://hc/ x",
+		},
+	}
+	outHostile := ansi.Strip(buildBackupOutcomePrompt(resHostile))
+	if strings.Contains(outHostile, "Healthchecks link:") {
+		t.Fatalf("hostile link must be sanitized away:\n%s", outHostile)
+	}
+	if strings.Contains(outHostile, "https://hc/ x") {
+		t.Fatalf("raw hostile link must never be shown:\n%s", outHostile)
+	}
+
+	// javascript: scheme is not http(s) -> stripped.
+	resJS := backupModeResult{
+		exitCode: types.ExitSuccess.Int(),
+		supportStats: &orchestrator.BackupStats{
+			FilesCollected:  1,
+			LocalStatus:     "ok",
+			HealthcheckLink: "javascript:alert(1)",
+		},
+	}
+	if strings.Contains(ansi.Strip(buildBackupOutcomePrompt(resJS)), "Healthchecks link:") {
+		t.Fatalf("javascript: scheme must be sanitized away")
+	}
+
+	// Empty ServerID/link: neither line present.
+	resEmpty := backupModeResult{
+		exitCode:     types.ExitSuccess.Int(),
+		supportStats: &orchestrator.BackupStats{FilesCollected: 1, LocalStatus: "ok"},
+	}
+	outEmpty := ansi.Strip(buildBackupOutcomePrompt(resEmpty))
+	if strings.Contains(outEmpty, "Server ID Telegram:") {
+		t.Fatalf("empty server id must produce no line:\n%s", outEmpty)
+	}
+	if strings.Contains(outEmpty, "Healthchecks link:") {
+		t.Fatalf("empty link must produce no line:\n%s", outEmpty)
+	}
+}
+
+// TestBuildBackupOutcomePromptWarning is the visible proof of fix #4: exit 1
+// (ExitGenericError, a NON-FATAL generic error) must classify as a WARNING and
+// read "Backup completed with warnings", NOT the old red "Backup failed" - the
+// same yellow the CLI final summary gives that exit code.
+func TestBuildBackupOutcomePromptWarning(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	res := backupModeResult{
+		exitCode:     types.ExitGenericError.Int(),
+		supportStats: &orchestrator.BackupStats{FilesCollected: 1, LocalStatus: "error"},
+	}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+
+	if !strings.Contains(out, "Backup completed with warnings") {
+		t.Fatalf("exit 1 (non-fatal) must read as completed-with-warnings:\n%s", out)
+	}
+	if strings.Contains(out, "Backup failed") {
+		t.Fatalf("exit 1 must NOT read as failed (that is the fix #4 flip):\n%s", out)
+	}
+	if strings.Contains(out, "Local:") {
+		t.Fatalf("the Local status line must be removed:\n%s", out)
+	}
+}
+
+// TestBuildBackupOutcomePromptIncludesIssueSummary asserts the graphical outcome
+// carries the same warnings/errors recap the CLI footer prints: a count header plus
+// the captured issue lines, from the same default logger.
+func TestBuildBackupOutcomePromptIncludesIssueSummary(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	lg := logging.New(types.LogLevelInfo, false)
+	lg.SetOutput(io.Discard)
+	lg.Warning("disk almost full")
+	lg.Error("failed to upload chunk 7")
+	logging.SetDefaultLogger(lg)
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	res := backupModeResult{
+		exitCode:     types.ExitGenericError.Int(),
+		supportStats: &orchestrator.BackupStats{FilesCollected: 1, LocalStatus: "ok"},
+	}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+
+	if !strings.Contains(out, "Warnings/errors during run: 1 warning(s), 1 error(s)") {
+		t.Fatalf("missing warnings/errors recap header:\n%s", out)
+	}
+	if !strings.Contains(out, "disk almost full") || !strings.Contains(out, "failed to upload chunk 7") {
+		t.Fatalf("recap must list the captured issue lines:\n%s", out)
+	}
+}
+
+// TestBuildBackupOutcomePromptNoIssueSummaryWhenClean asserts a clean run (no
+// warnings/errors logged) shows no recap at all.
+func TestBuildBackupOutcomePromptNoIssueSummaryWhenClean(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	lg := logging.New(types.LogLevelInfo, false)
+	lg.SetOutput(io.Discard)
+	logging.SetDefaultLogger(lg)
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	res := backupModeResult{
+		exitCode:     types.ExitSuccess.Int(),
+		supportStats: &orchestrator.BackupStats{FilesCollected: 1, LocalStatus: "ok"},
+	}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+	if strings.Contains(out, "Warnings/errors during run") {
+		t.Fatalf("a clean run must not show the issue recap:\n%s", out)
+	}
+}
+
+// TestBuildBackupOutcomePromptFailure asserts a genuinely fatal exit code
+// (ExitConfigError) renders the red "Backup failed" banner and never reads as
+// completed.
+func TestBuildBackupOutcomePromptFailure(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	res := backupModeResult{
+		exitCode:     types.ExitConfigError.Int(),
+		supportStats: &orchestrator.BackupStats{FilesCollected: 1, LocalStatus: "error"},
+	}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+
+	if !strings.Contains(out, "Backup failed") {
+		t.Fatalf("missing failure banner:\n%s", out)
+	}
+	if strings.Contains(out, "Backup completed") {
+		t.Fatalf("a failed run must NOT read as completed:\n%s", out)
+	}
+	if strings.Contains(out, "Local:") {
+		t.Fatalf("the Local status line must be removed:\n%s", out)
+	}
+}
+
+// TestBuildBackupOutcomePromptInterrupted asserts an interrupted run (Ctrl+C,
+// exit 130) renders the magenta "Backup interrupted" banner.
+func TestBuildBackupOutcomePromptInterrupted(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	res := backupModeResult{exitCode: exitCodeInterrupted}
+	out := ansi.Strip(buildBackupOutcomePrompt(res))
+
+	if !strings.Contains(out, "Backup interrupted") {
+		t.Fatalf("missing interrupted banner:\n%s", out)
+	}
+	if strings.Contains(out, "Backup failed") || strings.Contains(out, "Backup completed") {
+		t.Fatalf("an interrupted run must read as interrupted, not failed/completed:\n%s", out)
+	}
+}
+
+// TestBuildBackupOutcomePromptNoStats asserts a missing BackupStats renders just the
+// banner without panicking.
+func TestBuildBackupOutcomePromptNoStats(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	out := ansi.Strip(buildBackupOutcomePrompt(backupModeResult{exitCode: types.ExitSuccess.Int()}))
+	if !strings.Contains(out, "Backup completed") {
+		t.Fatalf("missing banner:\n%s", out)
+	}
+	if strings.Contains(out, "Files:") {
+		t.Fatalf("no stats -> no stat lines:\n%s", out)
+	}
+}
+
+// TestRunBackupStreamedDriver drives runBackupStreamed on an observed altscreen
+// session the same way the dashboard handoff does: it stashes the session (so
+// runBackupStreamed adopts it), overrides backupStreamSteps with a stub that emits
+// [ts] LEVEL lines via logging.Info (captured -> streamed into the contained
+// viewport) and returns a canned result, then asserts the streamed lines + the
+// outcome + the Continue hint render, and that pressing Enter lets runBackupStreamed
+// close the session and return the result.
+func TestRunBackupStreamedDriver(t *testing.T) {
+	// Clean, Info-level default logger so the captured logging.Info lines emit.
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	prevSteps := backupStreamSteps
+	backupStreamSteps = func(opts backupModeOptions) backupModeResult {
+		logging.Info("collecting cluster configuration")
+		logging.Info("archive written to disk")
+		return backupModeResult{
+			exitCode: types.ExitSuccess.Int(),
+			supportStats: &orchestrator.BackupStats{
+				FilesCollected: 7,
+				ArchiveSize:    4096,
+				LocalStatus:    "ok",
+			},
+		}
+	}
+	t.Cleanup(func() { backupStreamSteps = prevSteps })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var buf shell.SyncBuffer
+	session := shell.StartForTestWithOutput(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Backup"}, &buf)
+
+	// Stash the observed session so runBackupStreamed adopts it (mirrors the
+	// dashboard "Backup" handoff). releaseDashboardLeftovers cleans up if the run
+	// never adopts (guards other tests against a dangling stash).
+	bootstrap := logging.NewBootstrapLogger()
+	stashDashboardSession(session, bootstrap)
+	t.Cleanup(releaseDashboardLeftovers)
+
+	resCh := make(chan backupModeResult, 1)
+	go func() {
+		resCh <- runBackupStreamed(backupModeOptions{ctx: ctx, bootstrap: bootstrap, cfg: &config.Config{}})
+	}()
+
+	waitFor(t, &buf, "collecting cluster configuration")
+	waitFor(t, &buf, "archive written to disk")
+	waitFor(t, &buf, "Backup completed")
+	waitFor(t, &buf, "Files: 7 collected")
+	waitFor(t, &buf, "enter continue")
+
+	res := pumpEnterBackup(t, session, resCh)
+	if res.exitCode != types.ExitSuccess.Int() {
+		t.Fatalf("expected success exit, got %d", res.exitCode)
+	}
+	if res.supportStats == nil || res.supportStats.FilesCollected != 7 {
+		t.Fatalf("expected the stub's canned result, got %+v", res.supportStats)
+	}
+}
+
+// TestRunBackupStreamedSupportEmailInStream asserts that in support mode the
+// maintainer-email step runs INSIDE the streamed viewport (its announcement is
+// captured -> streamed) and that runBackupStreamed marks it sent, so the deferred
+// CLI sender skips it (no double send). This is the whole point of the change: the
+// send's outcome must be visible in the stream, not lost to a closed screen.
+func TestRunBackupStreamedSupportEmailInStream(t *testing.T) {
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelInfo, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	prevSteps := backupStreamSteps
+	backupStreamSteps = func(opts backupModeOptions) backupModeResult {
+		logging.Info("archive written to disk")
+		return backupModeResult{
+			exitCode:     types.ExitSuccess.Int(),
+			supportStats: &orchestrator.BackupStats{FilesCollected: 3, LocalStatus: "ok"},
+		}
+	}
+	t.Cleanup(func() { backupStreamSteps = prevSteps })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var buf shell.SyncBuffer
+	session := shell.StartForTestWithOutput(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Backup"}, &buf)
+
+	bootstrap := logging.NewBootstrapLogger()
+	stashDashboardSession(session, bootstrap)
+	t.Cleanup(releaseDashboardLeftovers)
+
+	resCh := make(chan backupModeResult, 1)
+	go func() {
+		resCh <- runBackupStreamed(backupModeOptions{
+			ctx:         ctx,
+			bootstrap:   bootstrap,
+			cfg:         &config.Config{},
+			envInfo:     &environment.EnvironmentInfo{},
+			support:     true,
+			supportMeta: support.Meta{GitHubUser: "alice", IssueID: "#42"},
+		})
+	}()
+
+	waitFor(t, &buf, "archive written to disk")
+	// The support-email step runs after the backup steps but still inside the
+	// capture, so its announcement streams into the viewport.
+	waitFor(t, &buf, "sending support email")
+	waitFor(t, &buf, "enter continue")
+
+	res := pumpEnterBackup(t, session, resCh)
+	if !res.supportEmailSent {
+		t.Fatalf("streamed support run must mark the email as sent (so the deferred sender skips): %+v", res)
+	}
+}
+
+// TestRunBackupStreamedHandsOffInStream asserts the manual-backup daemon handoff
+// runs INSIDE the streamed capture, so its debug trace lands in the viewport
+// instead of printing to the plain scrollback after the session closes - the
+// regression the user saw in support mode, where the run forces DEBUG logging.
+func TestRunBackupStreamedHandsOffInStream(t *testing.T) {
+	// A supervised child would skip the handoff; make sure this run is standalone.
+	t.Setenv(health.EnvRunID, "")
+	// DEBUG level so the handoff's debug trace emits (support mode forces DEBUG).
+	prevLogger := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logging.New(types.LogLevelDebug, false))
+	t.Cleanup(func() { logging.SetDefaultLogger(prevLogger) })
+
+	prevSteps := backupStreamSteps
+	backupStreamSteps = func(opts backupModeOptions) backupModeResult {
+		return backupModeResult{
+			exitCode:     types.ExitGenericError.Int(),
+			supportStats: &orchestrator.BackupStats{FilesCollected: 1, LocalStatus: "ok"},
+		}
+	}
+	t.Cleanup(func() { backupStreamSteps = prevSteps })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var buf shell.SyncBuffer
+	session := shell.StartForTestWithOutput(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Backup"}, &buf)
+	bootstrap := logging.NewBootstrapLogger()
+	stashDashboardSession(session, bootstrap)
+	t.Cleanup(releaseDashboardLeftovers)
+
+	// Handoff enabled (healthchecks + backups) with a base dir that has no daemon
+	// pid file, so the handoff runs and traces its outcome INSIDE the capture.
+	cfg := &config.Config{HealthcheckEnabled: true, BackupEnabled: true, BaseDir: t.TempDir()}
+
+	resCh := make(chan backupModeResult, 1)
+	go func() {
+		resCh <- runBackupStreamed(backupModeOptions{ctx: ctx, bootstrap: bootstrap, cfg: cfg})
+	}()
+
+	// The handoff's debug trace appears in the viewport buffer (proving it ran
+	// inside the capture, not after the session closed).
+	waitFor(t, &buf, "manual backup handoff")
+	waitFor(t, &buf, "enter continue")
+	_ = pumpEnterBackup(t, session, resCh)
+}
+
+// pumpEnterBackup sends Enter until runBackupStreamed returns its result.
+func pumpEnterBackup(t *testing.T, s *shell.Session, done <-chan backupModeResult) backupModeResult {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(uitest.Deadline(5 * time.Second))
+	for {
+		select {
+		case res := <-done:
+			return res
+		case <-ticker.C:
+			s.Send(shell.KeyMsg("enter"))
+		case <-deadline:
+			t.Fatal("runBackupStreamed did not return")
+			return backupModeResult{}
+		}
+	}
+}

--- a/docs/CLOUD_STORAGE.md
+++ b/docs/CLOUD_STORAGE.md
@@ -82,6 +82,35 @@ Proxsave uses a **3-tier storage system**:
    └─> Cloud: MAX_CLOUD_BACKUPS or GFS
 ```
 
+### Cloud layout (bundle vs raw)
+
+By default (`BUNDLE_ASSOCIATED_FILES=true`) each backup is packed into a single
+`<archive>.bundle.tar` before upload, so the cloud remote receives **one file per
+backup**. The bundle contains the raw archive plus its `.metadata` and `.sha256`
+sidecars (and `.metadata.sha256` when present); the `.manifest.json` is **not** inside
+the bundle.
+
+Set `BUNDLE_ASSOCIATED_FILES=false` to upload the **raw** archive plus separate
+sidecars: `<archive>`, `<archive>.sha256`, `<archive>.manifest.json`,
+`<archive>.metadata`, and `<archive>.metadata.sha256` (missing ones are skipped). In
+this raw layout the `<archive>.manifest.json` is the **authoritative metadata** that
+keeps the backup discoverable and verifiable during restore/decrypt cloud scans, so do
+not delete it (PS-BH-002).
+
+### How ProxSave invokes rclone
+
+ProxSave never runs a free-form rclone command line. Every call is built from a fixed
+**subcommand allowlist**: `copyto`, `delete`, `deletefile`, `hashsum`, `ls`, `lsf`,
+`lsl`, `mkdir`, `touch` (anything else is rejected). Uploads use **`copyto`** (not
+`copy`), with `--progress --stats 10s` and, when set, `--bwlimit` and `--transfers`.
+Connectivity checks use `lsf` (plus `mkdir`, or `touch` + `deletefile` for the write
+test), and verification uses `lsl`/`ls` plus `hashsum sha256`. Timeouts are enforced
+with Go context deadlines rather than rclone flags, so ProxSave does not add
+`--config`, `--timeout`, or `--contimeout`. `RCLONE_FLAGS`, if set, is appended to
+every one of these commands (see the Configuration Reference). The manual `rclone`
+commands shown later in this guide are for you to run by hand and are not subject to
+this allowlist.
+
 ---
 
 ## Prerequisites
@@ -378,7 +407,7 @@ RETENTION_YEARLY=3
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CLOUD_ENABLED` | `false` | Enable cloud storage |
-| `CLOUD_REMOTE` | _(required)_ | rclone remote **name** from `rclone config` (legacy `remote:path` still supported) |
+| `CLOUD_REMOTE` | _(empty)_ | rclone remote **name** from `rclone config` (legacy `remote:path` still supported). Required only when cloud is enabled: if empty, cloud is **silently disabled** even with `CLOUD_ENABLED=true`. |
 | `CLOUD_REMOTE_PATH` | _(empty)_ | Folder path/prefix inside the remote (e.g., `/proxsave/backup`) |
 | `CLOUD_LOG_PATH` | _(empty)_ | Optional log folder (recommended: path-only on the same remote; use `otherremote:/path` only when using a different remote) |
 | `CLOUD_UPLOAD_MODE` | `parallel` | `parallel` or `sequential` |
@@ -388,7 +417,7 @@ RETENTION_YEARLY=3
 | `CLOUD_VERIFY_DOWNLOAD` | `false` | When the backend lacks native SHA256, download the object and hash it locally (uses bandwidth) |
 | `CLOUD_WRITE_HEALTHCHECK` | `false` | Use write test for connectivity check |
 | `RCLONE_TIMEOUT_CONNECTION` | `30` | Per-command timeout (seconds). Also used by restore/decrypt cloud scan (`rclone lsf` + per-backup manifest/metadata read). |
-| `RCLONE_TIMEOUT_OPERATION` | `300` | Operation timeout (seconds) |
+| `RCLONE_TIMEOUT_OPERATION` | `300` | Per-operation upload timeout (seconds). `0` means **unbounded** uploads (no per-op deadline). Management/query ops (list, delete, retention) are always bounded: they use this value when it is > 0, otherwise a built-in 300s floor. So raising it also raises the management ceiling, and a positive value below 300 also shortens management ops. |
 | `RCLONE_BANDWIDTH_LIMIT` | _(empty)_ | Upload rate limit (e.g., `5M` = 5 MB/s) |
 | `RCLONE_TRANSFERS` | `4` | Number of parallel transfers |
 | `RCLONE_RETRIES` | `3` | Retry attempts on failure |
@@ -396,12 +425,24 @@ RETENTION_YEARLY=3
 | `CLOUD_BATCH_SIZE` | `20` | Files per batch (deletion) |
 | `CLOUD_BATCH_PAUSE` | `1` | Seconds between batches |
 | `MAX_CLOUD_BACKUPS` | `30` | Simple retention (ignored if GFS enabled) |
+| `RCLONE_FLAGS` | _(empty)_ | Extra global rclone flags, split on whitespace and injected verbatim into **every** rclone command (right after the subcommand). No shell quoting or validation, so keep each flag a single token (e.g. `--fast-list --checkers 8`). |
+| `BUNDLE_ASSOCIATED_FILES` | `true` | Bundle the archive and its sidecars into one `.bundle.tar` before upload (the default cloud layout). Set `false` to upload the raw archive plus separate sidecars. See [Cloud layout](#cloud-layout-bundle-vs-raw). |
+
+**Legacy env-var aliases.** For backward compatibility ProxSave also accepts these
+older names (the value is read from whichever is set):
+
+- `CLOUD_ENABLED` accepts `ENABLE_CLOUD_BACKUP`
+- `CLOUD_REMOTE` accepts `RCLONE_REMOTE`
+- `MAX_CLOUD_BACKUPS` accepts `CLOUD_RETENTION_DAYS`
+- `RCLONE_TIMEOUT_CONNECTION` accepts `CLOUD_CONNECTIVITY_TIMEOUT`
+
+Prefer the canonical names on the left in new configs.
 
 For complete configuration reference, see: **[Configuration Guide](CONFIGURATION.md)**
 
 ### Recommended Remote Path Formats (Important)
 
-ProxSave supports both “new style” (path-only) and “legacy style” (`remote:path`) values, but using a consistent format avoids confusion.
+ProxSave supports both "new style" (path-only) and "legacy style" (`remote:path`) values, but using a consistent format avoids confusion.
 
 **Recommended:**
 - `CLOUD_REMOTE` should be just the **remote name** (no `:`), e.g. `nextcloud` or `GoogleDrive`.
@@ -440,10 +481,10 @@ In both cases ProxSave combines the base path and the optional prefix into a sin
 path inside the remote, and uses that consistently for:
 - **uploads** (cloud backend);
 - **cloud retention**;
-- **restore / decrypt menus** (entry “Cloud backups (rclone)”).
+- **restore / decrypt menus** (entry "Cloud backups (rclone)").
   - Restore/decrypt cloud scanning applies `RCLONE_TIMEOUT_CONNECTION` per rclone command (the timer resets on each `lsf`/manifest read).
 
-You can choose the style you prefer; they are equivalent from the tool’s point of view.
+You can choose the style you prefer; they are equivalent from the tool's point of view.
 
 **When to use CLOUD_REMOTE_PATH**:
 - Organizing multiple servers' backups: `server1/`, `server2/`
@@ -750,7 +791,7 @@ echo "Latest: $LATEST"
 rclone copy "gdrive:pbs-backups/$LATEST" /tmp/recovery/
 ```
 
-**Step 5: Extract Bundle** (if using bundle format)
+**Step 5: Extract Bundle** (the default layout ships one `.bundle.tar` per backup; skip this step only if you set `BUNDLE_ASSOCIATED_FILES=false`)
 
 ```bash
 cd /tmp/recovery

--- a/docs/COLLECTOR_ARCHITECTURE.md
+++ b/docs/COLLECTOR_ARCHITECTURE.md
@@ -43,15 +43,14 @@ not be reintroduced as hidden orchestration layers.
 
 ## Recipes
 
-The collector runtime is built from explicit recipes in
-`internal/backup/collector_bricks.go`.
+The collector runtime is built from explicit recipes. The recipe machinery and the
+brick IDs live in `internal/backup/collector_bricks.go`, but the per-role builders are
+split across files:
 
-The important builders are:
-
-- `newPVERecipe()`
-- `newPBSRecipe()`
-- `newDualRecipe()`
-- `newSystemRecipe()`
+- `newPVERecipe()` (`collector_bricks_pve.go`)
+- `newPBSRecipe()` (`collector_bricks_pbs.go`)
+- `newSystemRecipe()` (`collector_bricks_system.go`)
+- `newDualRecipe()` (`collector_bricks.go`)
 
 ### Composition Rules
 
@@ -118,6 +117,12 @@ PBS access control, notifications, remotes, jobs, tape, datastore state, and
 PXAR metadata are no longer handled by macro-wrappers. They are exposed as
 independent recipe bricks.
 
+`CollectPBSConfigs()` actually runs **two** recipes in sequence: `newPBSRecipe()`, then
+`newPBSUserConfigRecipe()`. The second is a follow-up that reads the PBS user IDs from
+the `user_list.json` snapshot captured by the first recipe and aggregates the per-user
+API token config, so token export runs as a distinct pass seeded by the earlier
+user-list.
+
 ## Dual Branch
 
 `CollectDualConfigs()` runs `newDualRecipe()` and collects both product roles in
@@ -171,20 +176,18 @@ Examples:
 
 ## Manifest and Metadata
 
-Two layers are important:
+Two layers are important, and they carry different fields:
 
-- collector manifest (`manifest.json`) written in the temp tree
-- backup metadata/sidecars written by the orchestrator/archive flow
-
-Current persisted role fields include:
-
-- `ProxmoxType`
-- `ProxmoxTargets`
-- `PVEVersion`
-- `PBSVersion`
-
-These fields are used later by restore for backup-type detection and category
-filtering.
+- The **collector manifest** (`manifest.json`, written in the temp tree) is the
+  pre-optimization collection inventory. Among role fields it carries only
+  `ProxmoxType` (`proxmox_type`) and `ProxmoxTargets` (`proxmox_targets`), plus per-file
+  entries. It is an ExportOnly diagnostic (category `proxsave_info`) and is **not read
+  back by restore**; the authoritative record of the shipped payload is the archive
+  sidecar (`<archive>.sha256` / `<archive>.manifest.json`) computed after archiving.
+- The **backup metadata sidecar**, written by the orchestrator, carries the role and
+  version fields restore actually uses: `BACKUP_TYPE`, `BACKUP_TARGETS`, and
+  `PVE_VERSION` / `PBS_VERSION` (from the orchestrator's `PVEVersion` / `PBSVersion`
+  stats). These drive backup-type detection and category filtering at restore time.
 
 ## Restore Relationship
 
@@ -216,9 +219,13 @@ real collector flow.
 ## Related Files
 
 - `internal/backup/collector.go`
-- `internal/backup/collector_bricks.go`
+- `internal/backup/collector_bricks.go` (recipe machinery, brick IDs, `newDualRecipe()`)
+- `internal/backup/collector_bricks_pve.go` (`newPVERecipe()`)
+- `internal/backup/collector_bricks_pbs.go` (`newPBSRecipe()`, `newPBSUserConfigRecipe()`)
+- `internal/backup/collector_bricks_system.go` (`newSystemRecipe()`)
+- `internal/backup/collector_pbs.go` (PBS branch: runs both PBS recipes)
 - `internal/backup/collector_dual.go`
 - `internal/backup/collector_manifest.go`
 - `internal/backup/collector_storage_stack_common.go`
 - `internal/environment/detect.go`
-- `internal/orchestrator/compatibility.go`
+- `internal/orchestrator/compatibility.go` (restore compatibility + metadata sidecar versions)

--- a/internal/backup/collector_bricks.go
+++ b/internal/backup/collector_bricks.go
@@ -44,6 +44,7 @@ const (
 	brickPVEAggregateReplicationStatus BrickID = "pve_aggregate_replication_status"
 	brickPVEVersionInfo                BrickID = "pve_version_info"
 	brickPVEManifestFinalize           BrickID = "pve_manifest_finalize"
+	brickPVEFinalizeSummary            BrickID = "pve_finalize_summary"
 
 	brickPBSValidate                            BrickID = "pbs_validate"
 	brickPBSConfigDirectoryCopy                 BrickID = "pbs_config_directory_copy"

--- a/internal/backup/collector_bricks_pve.go
+++ b/internal/backup/collector_bricks_pve.go
@@ -28,6 +28,7 @@ func newPVERecipe() recipe {
 	bricks = append(bricks, newPVEAggregateBricks()...)
 	bricks = append(bricks, newPVEVersionBricks()...)
 	bricks = append(bricks, newPVEManifestBricks()...)
+	bricks = append(bricks, newPVEFinalizeSummaryBricks()...)
 	return recipe{Name: "pve", Bricks: bricks}
 }
 

--- a/internal/backup/collector_bricks_pve_finalize.go
+++ b/internal/backup/collector_bricks_pve_finalize.go
@@ -145,6 +145,32 @@ func newPVEManifestBricks() []collectionBrick {
 	}
 }
 
+// newPVEFinalizeSummaryBricks logs the PVE collection summary as the final PVE
+// brick, mirroring newPBSFinalizeBricks exactly: Files collected / not found at
+// Info, a non-zero Files failed at Warning, and skipped / bytes at Debug. Keeping
+// the two summaries identical means a PVE run surfaces the same collection counts,
+// at the same log levels, that a PBS run already does.
+func newPVEFinalizeSummaryBricks() []collectionBrick {
+	return []collectionBrick{
+		{
+			ID:          brickPVEFinalizeSummary,
+			Description: "Finalize PVE collection state",
+			Run: func(_ context.Context, state *collectionState) error {
+				c := state.collector
+				c.logger.Info("PVE collection summary:")
+				c.logger.Info("  Files collected: %d", c.stats.FilesProcessed)
+				c.logger.Info("  Files not found: %d", c.stats.FilesNotFound)
+				if c.stats.FilesFailed > 0 {
+					c.logger.Warning("  Files failed: %d", c.stats.FilesFailed)
+				}
+				c.logger.Debug("  Files skipped: %d", c.stats.FilesSkipped)
+				c.logger.Debug("  Bytes collected: %d", c.stats.BytesCollected)
+				return nil
+			},
+		},
+	}
+}
+
 func (p *pveContext) runtimeNodes() []string {
 	if p == nil || p.runtimeInfo == nil {
 		return nil

--- a/internal/backup/collector_bricks_test.go
+++ b/internal/backup/collector_bricks_test.go
@@ -278,6 +278,7 @@ func TestNewPVERecipeOrder(t *testing.T) {
 		brickPVEAggregateReplicationStatus,
 		brickPVEVersionInfo,
 		brickPVEManifestFinalize,
+		brickPVEFinalizeSummary,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("PVE recipe IDs = %v, want %v", got, want)

--- a/internal/backup/collector_pve.go
+++ b/internal/backup/collector_pve.go
@@ -386,7 +386,7 @@ func (c *Collector) collectPVEClusterSnapshot(ctx context.Context, clustered boo
 	// sense of exclusion; the only way to drop them entirely is to also disable
 	// cluster backup.
 	if c.config.BackupClusterConfig && !c.config.BackupPVEACL {
-		c.logger.Warning("PVE access control: BACKUP_PVE_ACL=false excludes /etc/pve/priv/{shadow,token,tfa}.cfg, but the same secrets remain inside the cluster database config.db; set BACKUP_CLUSTER_CONFIG=false to exclude them entirely")
+		c.logger.Warning("PVE access control: BACKUP_PVE_ACL=false excludes /etc/pve/priv/{shadow,token,tfa}.cfg but the same secrets remain in the cluster database config.db. To exclude them entirely, set BACKUP_CLUSTER_CONFIG=false.")
 	}
 
 	if c.config.BackupClusterConfig {

--- a/internal/orchestrator/backup_candidate_display.go
+++ b/internal/orchestrator/backup_candidate_display.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/tis24dev/proxsave/internal/backup"
+	"github.com/tis24dev/proxsave/internal/ui/components"
 )
 
 const (
@@ -36,6 +37,18 @@ func describeBackupCandidate(cand *backupCandidate) backupCandidateDisplay {
 		Compression: formatBackupCandidateCompression(cand),
 		Base:        backupCandidateBaseName(cand),
 	}
+	// Sanitize manifest-derived fields here, the single choke point feeding
+	// both the CLI table (printed raw via fmt.Print*) and the Summary. The
+	// TUI double-sanitizes harmlessly via NewSelector. No-op on clean data,
+	// so column-width math on these fields stays consistent.
+	display.Created = components.SanitizeLine(display.Created)
+	display.Hostname = components.SanitizeLine(display.Hostname)
+	display.Mode = components.SanitizeLine(display.Mode)
+	display.Tool = components.SanitizeLine(display.Tool)
+	display.Target = components.SanitizeLine(display.Target)
+	display.Compression = components.SanitizeLine(display.Compression)
+	display.Base = components.SanitizeLine(display.Base)
+	// Build Summary from the already-sanitized fields so it is clean too.
 	display.Summary = formatBackupCandidateSummary(display)
 	return display
 }

--- a/internal/orchestrator/backup_candidate_display_test.go
+++ b/internal/orchestrator/backup_candidate_display_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bufio"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -115,5 +116,95 @@ func TestPromptCandidateSelection_PrintsHostname(t *testing.T) {
 
 	if !strings.Contains(stdout, "Host node1.example.com") {
 		t.Fatalf("expected hostname in CLI output, got %q", stdout)
+	}
+}
+
+// rawEscapeMarkers are substrings that must never survive sanitization into a
+// display field. They come from the manifest, which is fetched raw off a
+// remote (rclone cat), so an attacker controls Hostname/ScriptVersion/etc.
+var rawEscapeMarkers = []string{"\x1b]0;", "\x07", "\x9b", "\x1b[2J", "\x1b["}
+
+// TestDescribeBackupCandidate_SanitizesManifestFields proves the LEAK-1 choke
+// point: manifest-derived fields carrying terminal escapes are scrubbed inside
+// describeBackupCandidate, so both the CLI table and Summary are clean.
+func TestDescribeBackupCandidate_SanitizesManifestFields(t *testing.T) {
+	created := time.Date(2026, time.March, 22, 12, 21, 22, 0, time.UTC)
+	cand := &backupCandidate{
+		// filepath.Base(ArchivePath) style value with an OSC injection.
+		DisplayBase: "arch\x1b]0;pwned\x07ive.tar.xz",
+		Manifest: &backup.Manifest{
+			CreatedAt: created,
+			// OSC title-set + BEL, and a C1 CSI byte (0x9b).
+			Hostname:      "pve\x1b]0;pwned\x07host\x9b",
+			ScriptVersion: "1.2.3\x1b[2Jevil",
+			// Clear-screen CSI in a field that flows into Target.
+			ProxmoxTargets:  []string{"pve\x1b[2Jevil"},
+			ProxmoxVersion:  "8.0",
+			CompressionType: "xz\x1b[31m",
+		},
+	}
+
+	display := describeBackupCandidate(cand)
+
+	// Every string field, and the derived Summary, must be marker-free.
+	fields := map[string]string{
+		"Created":     display.Created,
+		"Hostname":    display.Hostname,
+		"Mode":        display.Mode,
+		"Tool":        display.Tool,
+		"Target":      display.Target,
+		"Compression": display.Compression,
+		"Base":        display.Base,
+		"Summary":     display.Summary,
+	}
+	for name, val := range fields {
+		for _, marker := range rawEscapeMarkers {
+			if strings.Contains(val, marker) {
+				t.Fatalf("%s field retained raw escape %q: %q", name, marker, val)
+			}
+		}
+	}
+
+	// Legitimate text must survive; only the escapes are stripped.
+	if !strings.Contains(display.Hostname, "pve") || !strings.Contains(display.Hostname, "host") {
+		t.Fatalf("Hostname lost legitimate text: %q", display.Hostname)
+	}
+	if !strings.Contains(display.Tool, "1.2.3") {
+		t.Fatalf("Tool lost legitimate text: %q", display.Tool)
+	}
+	if !strings.Contains(display.Base, "ive.tar.xz") {
+		t.Fatalf("Base lost legitimate text: %q", display.Base)
+	}
+	if !strings.Contains(display.Summary, "pve") {
+		t.Fatalf("Summary lost legitimate hostname text: %q", display.Summary)
+	}
+}
+
+// TestConfirmRestoreAction_SanitizesDisplayBase proves the LEAK-2 fix: the CLI
+// confirmation prints the remote-derived archive filename scrubbed. We drive
+// the prompt to cancel (input "0") after the line is printed.
+func TestConfirmRestoreAction_SanitizesDisplayBase(t *testing.T) {
+	cand := &backupCandidate{
+		DisplayBase: "arch\x1b]0;pwned\x07ive.tar.xz\x9b",
+		Manifest:    &backup.Manifest{CreatedAt: time.Date(2026, time.March, 22, 12, 21, 22, 0, time.UTC)},
+	}
+	reader := bufio.NewReader(strings.NewReader("0\n"))
+
+	var abortErr error
+	stdout := captureCLIStdout(t, func() {
+		abortErr = confirmRestoreAction(context.Background(), reader, cand, "/")
+	})
+
+	if !errors.Is(abortErr, ErrRestoreAborted) {
+		t.Fatalf("expected ErrRestoreAborted, got: %v", abortErr)
+	}
+	for _, marker := range rawEscapeMarkers {
+		if strings.Contains(stdout, marker) {
+			t.Fatalf("confirmRestoreAction output retained raw escape %q: %q", marker, stdout)
+		}
+	}
+	// The legitimate filename fragments must still print.
+	if !strings.Contains(stdout, "arch") || !strings.Contains(stdout, "ive.tar.xz") {
+		t.Fatalf("expected sanitized filename in output, got %q", stdout)
 	}
 }

--- a/internal/storage/backup_files.go
+++ b/internal/storage/backup_files.go
@@ -14,9 +14,24 @@ const bundleSuffix = ".bundle.tar"
 var errBackupSidecarDeleteOnly = errors.New("backup archive deleted; associated file(s) could not be removed")
 
 // isBackupSidecar reports whether a candidate path is an associated sidecar
-// (checksum/metadata) rather than the backup data archive itself.
+// (checksum, metadata, or manifest) rather than the backup data archive itself.
+//
+// Scope: this is the source of truth ONLY for CLASSIFICATION ("is this a standalone
+// backup?"), shared by every storage List filter (local/secondary/cloud) and by the
+// retention delete accounting. It is NOT the source of truth for the set of files a
+// backup enumerates to create or delete.
+//
+// Anti-drift: adding a new sidecar suffix means updating THREE places, not one:
+//  1. here (classification),
+//  2. buildBackupCandidatePaths below (the delete/retention enumeration),
+//  3. Orchestrator.removeAssociatedFiles in internal/orchestrator (raw-workspace cleanup).
+// PS-BH-002 was exactly this drift: .manifest.json was added to the cloud upload set
+// but omitted here, so retention could not delete it (orphan accumulation) and List
+// counted it as a phantom backup.
 func isBackupSidecar(path string) bool {
-	return strings.HasSuffix(path, ".sha256") || strings.HasSuffix(path, ".metadata")
+	return strings.HasSuffix(path, ".sha256") ||
+		strings.HasSuffix(path, ".metadata") ||
+		strings.HasSuffix(path, ".manifest.json")
 }
 
 // trimBundleSuffix removes the .bundle.tar suffix from a path if present.
@@ -61,18 +76,21 @@ func buildBackupCandidatePaths(base string, includeBundle bool) []string {
 		return true
 	}
 
-	files := make([]string, 0, 5)
+	candidates := []string{
+		base,
+		base + ".sha256",
+		base + ".manifest.json",
+		base + ".metadata",
+		base + ".metadata.sha256",
+	}
+	// Cap: every candidate plus at most one bundle path. Derived from len so it
+	// cannot re-diverge when a suffix is added to the list above.
+	files := make([]string, 0, len(candidates)+1)
 	if includeBundle {
 		bundlePath := bundlePathFor(base)
 		if add(bundlePath) {
 			files = append(files, bundlePath)
 		}
-	}
-	candidates := []string{
-		base,
-		base + ".sha256",
-		base + ".metadata",
-		base + ".metadata.sha256",
 	}
 	for _, c := range candidates {
 		if add(c) {

--- a/internal/storage/backup_files_test.go
+++ b/internal/storage/backup_files_test.go
@@ -28,6 +28,7 @@ func TestBuildBackupCandidatePathsNormalizesBundleInput(t *testing.T) {
 				"backup.tar.zst.bundle.tar",
 				"backup.tar.zst",
 				"backup.tar.zst.sha256",
+				"backup.tar.zst.manifest.json",
 				"backup.tar.zst.metadata",
 				"backup.tar.zst.metadata.sha256",
 			},
@@ -39,6 +40,7 @@ func TestBuildBackupCandidatePathsNormalizesBundleInput(t *testing.T) {
 			want: []string{
 				"backup.tar.zst",
 				"backup.tar.zst.sha256",
+				"backup.tar.zst.manifest.json",
 				"backup.tar.zst.metadata",
 				"backup.tar.zst.metadata.sha256",
 			},

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -1479,9 +1479,9 @@ func (c *CloudStorage) isBackupEntry(filename string, snapshot map[string]struct
 		return false
 	}
 
-	// Skip associated files
-	if strings.HasSuffix(filename, ".sha256") ||
-		strings.HasSuffix(filename, ".metadata") {
+	// Skip associated sidecars (checksum/metadata/manifest); shared with the
+	// local/secondary List filters and the delete accounting via isBackupSidecar.
+	if isBackupSidecar(filename) {
 		return false
 	}
 

--- a/internal/storage/cloud_test.go
+++ b/internal/storage/cloud_test.go
@@ -490,6 +490,92 @@ func TestCloudStorageListParsesBackups(t *testing.T) {
 	}
 }
 
+// TestCloudStorageListSkipsManifestSidecar proves the uploaded .manifest.json is
+// classified as a sidecar and never counted as a standalone backup (PS-BH-002:
+// isBackupEntry used to match it on `-backup-`+`.tar` and inflate the count).
+func TestCloudStorageListSkipsManifestSidecar(t *testing.T) {
+	cfg := &config.Config{CloudEnabled: true, CloudRemote: "remote"}
+	cs := newCloudStorageForTest(cfg)
+	queue := &commandQueue{
+		t: t,
+		queue: []queuedResponse{
+			{
+				name: "rclone",
+				args: []string{"lsl", "remote:"},
+				out: strings.TrimSpace(`
+99999 2024-11-12 12:00:00 host-backup-20241112.tar.zst
+120 2024-11-12 12:00:00 host-backup-20241112.tar.zst.sha256
+340 2024-11-12 12:00:00 host-backup-20241112.tar.zst.manifest.json
+88 2024-11-12 12:00:00 host-backup-20241112.tar.zst.metadata
+`),
+			},
+		},
+	}
+	cs.execCommand = queue.exec
+
+	backups, err := cs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("List() = %d backups, want 1 (sha256/manifest/metadata are sidecars)", len(backups))
+	}
+	if backups[0].BackupFile != "host-backup-20241112.tar.zst" {
+		t.Fatalf("unexpected backup file %q", backups[0].BackupFile)
+	}
+}
+
+// TestCloudStorageDeleteRemovesManifestSidecar proves retention/delete now issues a
+// deletefile for the .manifest.json so it cannot orphan on the remote after the
+// archive and its other sidecars are removed (PS-BH-002).
+func TestCloudStorageDeleteRemovesManifestSidecar(t *testing.T) {
+	cfg := &config.Config{CloudEnabled: true, CloudRemote: "remote", BundleAssociatedFiles: false}
+	cs := newCloudStorageForTest(cfg)
+	listOutput := strings.TrimSpace(`
+100 2025-01-01 01:00:00 host-backup-20250101-010101.tar.zst
+10 2025-01-01 01:00:00 host-backup-20250101-010101.tar.zst.sha256
+20 2025-01-01 01:00:00 host-backup-20250101-010101.tar.zst.manifest.json
+10 2025-01-01 01:00:00 host-backup-20250101-010101.tar.zst.metadata
+10 2025-01-01 01:00:00 host-backup-20250101-010101.tar.zst.metadata.sha256
+`)
+	queue := &commandQueue{
+		t: t,
+		queue: []queuedResponse{
+			{name: "rclone", args: []string{"lsl", "remote:"}, out: listOutput},
+			{name: "rclone", args: []string{"deletefile", "remote:host-backup-20250101-010101.tar.zst"}},
+			{name: "rclone", args: []string{"deletefile", "remote:host-backup-20250101-010101.tar.zst.sha256"}},
+			{name: "rclone", args: []string{"deletefile", "remote:host-backup-20250101-010101.tar.zst.manifest.json"}},
+			{name: "rclone", args: []string{"deletefile", "remote:host-backup-20250101-010101.tar.zst.metadata"}},
+			{name: "rclone", args: []string{"deletefile", "remote:host-backup-20250101-010101.tar.zst.metadata.sha256"}},
+		},
+	}
+	cs.execCommand = queue.exec
+
+	backups, err := cs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("expected 1 backup (manifest is a sidecar), got %d", len(backups))
+	}
+	if err := cs.Delete(context.Background(), backups[0].BackupFile); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	var deletedManifest bool
+	for _, call := range queue.calls {
+		if len(call.args) == 2 && call.args[0] == "deletefile" &&
+			strings.HasSuffix(call.args[1], ".manifest.json") {
+			deletedManifest = true
+		}
+	}
+	if !deletedManifest {
+		t.Fatalf("expected a deletefile for the .manifest.json sidecar, calls=%v", queue.calls)
+	}
+	if len(queue.calls) != 6 {
+		t.Fatalf("expected 6 rclone calls (list + 5 deletes incl. manifest), got %d: %v", len(queue.calls), queue.calls)
+	}
+}
+
 func TestCloudStorageDeleteSkipsMissingBundleCandidates(t *testing.T) {
 	cfg := &config.Config{
 		CloudEnabled:          true,

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -184,9 +184,8 @@ func (l *LocalStorage) List(ctx context.Context) (backups []*types.BackupMetadat
 
 	// Filter and parse backup files
 	for _, match := range matches {
-		// Skip associated files (.sha256, .metadata)
-		if strings.HasSuffix(match, ".sha256") ||
-			strings.HasSuffix(match, ".metadata") {
+		// Skip associated sidecars (checksum/metadata/manifest); shared predicate.
+		if isBackupSidecar(match) {
 			continue
 		}
 

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -480,6 +480,34 @@ func TestLocalStorage_GetStats(t *testing.T) {
 	}
 }
 
+// TestLocalStorage_List_SkipsSidecars proves local List skips the checksum,
+// metadata, and manifest sidecars (PS-BH-002: .manifest.json must not be counted
+// as a standalone backup).
+func TestLocalStorage_List_SkipsSidecars(t *testing.T) {
+	logger := newTestLogger()
+	base := t.TempDir()
+	cfg := &config.Config{BackupPath: base, BundleAssociatedFiles: false}
+	storage, _ := NewLocalStorage(cfg, logger)
+
+	backup := filepath.Join(base, "node-backup-20240102-030405.tar.zst")
+	for _, f := range []string{backup, backup + ".sha256", backup + ".manifest.json", backup + ".metadata", backup + ".metadata.sha256"} {
+		if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", f, err)
+		}
+	}
+
+	backups, err := storage.List(context.Background())
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("List returned %d backups want 1 (sha256/manifest/metadata are sidecars)", len(backups))
+	}
+	if backups[0].BackupFile != backup {
+		t.Fatalf("BackupFile=%q want %q", backups[0].BackupFile, backup)
+	}
+}
+
 func TestLocalStorage_GetStats_ListError(t *testing.T) {
 	logger := newTestLogger()
 	base := t.TempDir()

--- a/internal/storage/secondary.go
+++ b/internal/storage/secondary.go
@@ -390,9 +390,8 @@ func (s *SecondaryStorage) List(ctx context.Context) (backups []*types.BackupMet
 
 	// Filter and parse backup files
 	for _, match := range matches {
-		// Skip associated files
-		if strings.HasSuffix(match, ".sha256") ||
-			strings.HasSuffix(match, ".metadata") {
+		// Skip associated sidecars (checksum/metadata/manifest); shared predicate.
+		if isBackupSidecar(match) {
 			continue
 		}
 

--- a/internal/storage/secondary_test.go
+++ b/internal/storage/secondary_test.go
@@ -823,6 +823,10 @@ func TestSecondaryStorage_List_SkipsMetadataShaFiles(t *testing.T) {
 	if err := os.WriteFile(backup+".sha256", []byte("hash"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+	// The authoritative manifest sidecar must not be counted as a backup (PS-BH-002).
+	if err := os.WriteFile(backup+".manifest.json", []byte(`{"archive_path":"x"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	backups, err := storage.List(context.Background())
 	if err != nil {


### PR DESCRIPTION
Review-only slice, base is `review-base` (snapshot of main). **Do not merge.**

Vertical feature slice = backup engine (internal/backup, internal/storage), its orchestrator + cmd glue (backup_*), and its docs (CLOUD_STORAGE, COLLECTOR_ARCHITECTURE). Content matches `dev` for these paths. 27 files.

Trigger review manually with `@coderabbitai review`.

## Summary by Sourcery

Integrate healthcheck-aware backup orchestration, streamed TUI outcome reporting, and consistent sidecar handling across storage backends, while tightening safety around manifests, terminal output, and monitoring daemon handoff.

New Features:
- Add healthcheck notification section that validates configuration and daemon liveness before registering, and reports its effective state in the backup notification summary.
- Introduce a streamed backup mode that adopts the dashboard session, captures console output into a graphical viewport, and renders a themed outcome recap with stats, log path, storage status, and monitoring links.
- Implement manual-backup handoff to the monitoring daemon so standalone runs report their outcome via the daemon’s existing ping pipeline instead of pinging directly.

Bug Fixes:
- Sanitize manifest-derived backup metadata before display to prevent terminal escape injection in CLI and restore confirmation flows.
- Treat manifest sidecar files as non-backup sidecars across local, secondary, and cloud storage, ensuring they are not double-counted as backups and are removed alongside their archives during retention and deletion.
- Align compression statistics and exit-status glyphs across CLI and TUI so ratios and symbols render consistently and do not break framed panel layout.
- Prevent dry-run and daemon-supervised child backups from writing manual outcome handoffs, avoiding double-reporting or polluting monitoring with test runs.

Enhancements:
- Refine healthcheck daemon diagnosis by combining heartbeat status with systemd presence to produce accurate, user-facing reasons for disabled monitoring.
- Gate verbose backup statistics behind debug level and move human-friendly summaries into the graphical recap, while expanding PVE collection to log a structured summary like PBS.
- Unify notification configuration logging to show post-preflight effective channel states and include healthchecks alongside other channels.
- Improve PVE ACL warning text for clearer guidance on how to fully exclude sensitive cluster secrets.
- Extend collector and documentation around recipes, manifests, and metadata to clarify the relationship between collection manifests and orchestrator metadata sidecars.

Documentation:
- Expand cloud storage documentation with bundle vs raw layouts, sidecar roles, rclone subcommand allowlist, timeout semantics, extra rclone flags, legacy environment aliases, and the default bundle extraction workflow.
- Clarify collector architecture docs around recipe file locations, dual PBS recipes, and the distinct roles of collector manifests versus backup metadata sidecars in restore compatibility.

Tests:
- Add extensive tests for streamed backup UI behavior, healthcheck initialization and daemon diagnosis, monitoring daemon handoff gating, manifest sanitization, sidecar classification and deletion, local/secondary/cloud listing, PVE finalize summaries, backup statistics logging level, and exit-status glyph safety.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a backup engine and storage slice for ProxSave. The main changes are:

- Backup execution, streamed dashboard output, and outcome summaries.
- Healthcheck initialization and manual backup handoff to the daemon.
- Storage sidecar handling for manifests across local, secondary, and cloud storage.
- PVE collection summaries and backup candidate display sanitization.
- Backup and cloud storage documentation updates.

<h3>Confidence Score: 2/5</h3>

The command and orchestrator packages do not compile with the new backup slice.

- The streamed backup path references missing UI, serverbot, logging, and dashboard helpers.
- The healthcheck init path references missing channel and daemon probe symbols.
- The candidate display sanitizer import is unresolved.

cmd/proxsave/backup_stream.go, cmd/proxsave/backup_mode.go, cmd/proxsave/backup_notifications.go, internal/orchestrator/backup_candidate_display.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/proxsave/backup_stream.go | Adds streamed backup execution and outcome rendering, but depends on missing UI, serverbot, logging, and dashboard symbols. |
| cmd/proxsave/backup_mode.go | Routes dashboard-triggered backups into the streamed path, but calls a missing dashboard handoff function. |
| cmd/proxsave/backup_notifications.go | Adds healthcheck notification initialization, but references missing healthcheck channel and daemon presence symbols. |
| cmd/proxsave/backup_healthcheck.go | Adds best-effort manual backup handoff to the resident daemon with dry-run, supervised-child, config, and PID guards. |
| internal/storage/backup_files.go | Adds `.manifest.json` to sidecar classification and backup delete candidate enumeration. |
| internal/storage/cloud.go | Uses the shared sidecar predicate so cloud manifest sidecars are not listed as backups. |
| internal/storage/local.go | Uses the shared sidecar predicate for local backup listing. |
| internal/storage/secondary.go | Uses the shared sidecar predicate for secondary backup listing and delete accounting. |
| internal/backup/collector_bricks_pve_finalize.go | Adds a final PVE collection summary brick. |
| internal/orchestrator/backup_candidate_display.go | Adds display sanitization for backup candidates, but imports a missing sanitizer package. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[runBackupMode] --> B{Dashboard handoff pending?}
  B -->|yes| C[runBackupStreamed]
  B -->|no| D[runBackupModeSteps]
  D --> E[maybeHandoffManualBackup]
  C --> F[Run streamed task]
  F --> G[runBackupModeSteps]
  G --> H[runStreamedEndOfRunActions]
  H --> I[maybeHandoffManualBackup]
  G --> J[initializeBackupNotifications]
  J --> K[initializeHealthcheckSection]
  K --> L[Register healthcheck channel]
  E --> M[Write manual outcome and signal daemon]
  I --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[runBackupMode] --> B{Dashboard handoff pending?}
  B -->|yes| C[runBackupStreamed]
  B -->|no| D[runBackupModeSteps]
  D --> E[maybeHandoffManualBackup]
  C --> F[Run streamed task]
  F --> G[runBackupModeSteps]
  G --> H[runStreamedEndOfRunActions]
  H --> I[maybeHandoffManualBackup]
  G --> J[initializeBackupNotifications]
  J --> K[initializeHealthcheckSection]
  K --> L[Register healthcheck channel]
  E --> M[Write manual outcome and signal daemon]
  I --> M
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acmd%2Fproxsave%2Fbackup_stream.go%3A11-16%0A**Streamed%20Backup%20Dependencies%20Missing**%0A%0AThe%20new%20streamed%20backup%20path%20imports%20UI%2Fserverbot%20packages%20and%20calls%20helpers%20that%20are%20not%20present%20in%20the%20reviewed%20base%2C%20including%20%60adoptDashboardSession%60%2C%20%60emitSupportEmail%60%2C%20%60exitCodeSeverity%60%2C%20%60logging.NewLineWriterRaw%60%2C%20and%20%60logging.CaptureConsoleWithColor%60.%20Any%20build%20target%20that%20includes%20%60cmd%2Fproxsave%60%20fails%20before%20the%20backup%20command%20can%20run.%0A%0A%23%23%23%20Issue%202%20of%204%0Acmd%2Fproxsave%2Fbackup_mode.go%3A69-70%0A**Dashboard%20Handoff%20Symbol%20Missing**%0A%0AThis%20new%20branch%20calls%20%60dashboardHandoffPending%28%29%60%2C%20but%20that%20function%20is%20not%20defined%20in%20the%20package.%20The%20default%20command%20build%20now%20fails%20as%20soon%20as%20%60runBackupMode%60%20is%20compiled.%0A%0A%23%23%23%20Issue%203%20of%204%0Acmd%2Fproxsave%2Fbackup_notifications.go%3A121-146%0A**Healthcheck%20Init%20Symbols%20Missing**%0A%0AThe%20new%20healthcheck%20initialization%20path%20references%20%60orchestrator.NewHealthchecksChannel%60%20and%20%60daemonPresenceProbe%60%2C%20but%20neither%20symbol%20is%20defined%20in%20the%20reviewed%20code.%20Builds%20and%20the%20new%20healthcheck%20tests%20fail%20at%20compile%20time%20before%20this%20config%20path%20can%20run.%0A%0A%23%23%23%20Issue%204%20of%204%0Ainternal%2Forchestrator%2Fbackup_candidate_display.go%3A9%0A**Candidate%20Sanitizer%20Package%20Missing**%0A%0AThis%20new%20import%20points%20at%20%60internal%2Fui%2Fcomponents%60%2C%20and%20the%20changed%20display%20code%20calls%20%60components.SanitizeLine%60%2C%20but%20that%20package%2Ffunction%20is%20not%20available%20in%20the%20reviewed%20base.%20Any%20build%20or%20test%20that%20imports%20%60internal%2Forchestrator%60%20now%20fails%20during%20compilation.%0A%0A&repo=tis24dev%2Fproxsave&pr=257&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acmd%2Fproxsave%2Fbackup_stream.go%3A11-16%0A**Streamed%20Backup%20Dependencies%20Missing**%0A%0AThe%20new%20streamed%20backup%20path%20imports%20UI%2Fserverbot%20packages%20and%20calls%20helpers%20that%20are%20not%20present%20in%20the%20reviewed%20base%2C%20including%20%60adoptDashboardSession%60%2C%20%60emitSupportEmail%60%2C%20%60exitCodeSeverity%60%2C%20%60logging.NewLineWriterRaw%60%2C%20and%20%60logging.CaptureConsoleWithColor%60.%20Any%20build%20target%20that%20includes%20%60cmd%2Fproxsave%60%20fails%20before%20the%20backup%20command%20can%20run.%0A%0A%23%23%23%20Issue%202%20of%204%0Acmd%2Fproxsave%2Fbackup_mode.go%3A69-70%0A**Dashboard%20Handoff%20Symbol%20Missing**%0A%0AThis%20new%20branch%20calls%20%60dashboardHandoffPending%28%29%60%2C%20but%20that%20function%20is%20not%20defined%20in%20the%20package.%20The%20default%20command%20build%20now%20fails%20as%20soon%20as%20%60runBackupMode%60%20is%20compiled.%0A%0A%23%23%23%20Issue%203%20of%204%0Acmd%2Fproxsave%2Fbackup_notifications.go%3A121-146%0A**Healthcheck%20Init%20Symbols%20Missing**%0A%0AThe%20new%20healthcheck%20initialization%20path%20references%20%60orchestrator.NewHealthchecksChannel%60%20and%20%60daemonPresenceProbe%60%2C%20but%20neither%20symbol%20is%20defined%20in%20the%20reviewed%20code.%20Builds%20and%20the%20new%20healthcheck%20tests%20fail%20at%20compile%20time%20before%20this%20config%20path%20can%20run.%0A%0A%23%23%23%20Issue%204%20of%204%0Ainternal%2Forchestrator%2Fbackup_candidate_display.go%3A9%0A**Candidate%20Sanitizer%20Package%20Missing**%0A%0AThis%20new%20import%20points%20at%20%60internal%2Fui%2Fcomponents%60%2C%20and%20the%20changed%20display%20code%20calls%20%60components.SanitizeLine%60%2C%20but%20that%20package%2Ffunction%20is%20not%20available%20in%20the%20reviewed%20base.%20Any%20build%20or%20test%20that%20imports%20%60internal%2Forchestrator%60%20now%20fails%20during%20compilation.%0A%0A&pr=257&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Fproxsave%22%20on%20the%20existing%20branch%20%22review%2Fslice-1-backup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22review%2Fslice-1-backup%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acmd%2Fproxsave%2Fbackup_stream.go%3A11-16%0A**Streamed%20Backup%20Dependencies%20Missing**%0A%0AThe%20new%20streamed%20backup%20path%20imports%20UI%2Fserverbot%20packages%20and%20calls%20helpers%20that%20are%20not%20present%20in%20the%20reviewed%20base%2C%20including%20%60adoptDashboardSession%60%2C%20%60emitSupportEmail%60%2C%20%60exitCodeSeverity%60%2C%20%60logging.NewLineWriterRaw%60%2C%20and%20%60logging.CaptureConsoleWithColor%60.%20Any%20build%20target%20that%20includes%20%60cmd%2Fproxsave%60%20fails%20before%20the%20backup%20command%20can%20run.%0A%0A%23%23%23%20Issue%202%20of%204%0Acmd%2Fproxsave%2Fbackup_mode.go%3A69-70%0A**Dashboard%20Handoff%20Symbol%20Missing**%0A%0AThis%20new%20branch%20calls%20%60dashboardHandoffPending%28%29%60%2C%20but%20that%20function%20is%20not%20defined%20in%20the%20package.%20The%20default%20command%20build%20now%20fails%20as%20soon%20as%20%60runBackupMode%60%20is%20compiled.%0A%0A%23%23%23%20Issue%203%20of%204%0Acmd%2Fproxsave%2Fbackup_notifications.go%3A121-146%0A**Healthcheck%20Init%20Symbols%20Missing**%0A%0AThe%20new%20healthcheck%20initialization%20path%20references%20%60orchestrator.NewHealthchecksChannel%60%20and%20%60daemonPresenceProbe%60%2C%20but%20neither%20symbol%20is%20defined%20in%20the%20reviewed%20code.%20Builds%20and%20the%20new%20healthcheck%20tests%20fail%20at%20compile%20time%20before%20this%20config%20path%20can%20run.%0A%0A%23%23%23%20Issue%204%20of%204%0Ainternal%2Forchestrator%2Fbackup_candidate_display.go%3A9%0A**Candidate%20Sanitizer%20Package%20Missing**%0A%0AThis%20new%20import%20points%20at%20%60internal%2Fui%2Fcomponents%60%2C%20and%20the%20changed%20display%20code%20calls%20%60components.SanitizeLine%60%2C%20but%20that%20package%2Ffunction%20is%20not%20available%20in%20the%20reviewed%20base.%20Any%20build%20or%20test%20that%20imports%20%60internal%2Forchestrator%60%20now%20fails%20during%20compilation.%0A%0A&repo=tis24dev%2Fproxsave&pr=257&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["review slice 1 (backup): backup engine +..."](https://github.com/tis24dev/proxsave/commit/18ec0744319bf742457b311320fee8f25f398098) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44207121)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->