### PR TITLE
Slice 6/6: tests + docs + upgrade tooling + dependabot bumps

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: 'go.mod'
           cache: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,13 +30,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go (from go.mod)
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: 'go.mod'
           cache: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
         with:
           languages: go
 
@@ -45,6 +45,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
         with:
           category: "/language:go"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Go Lint
+
+run-name: Go lint - ${{ github.ref_name }}
+
+"on":
+  push:
+    branches:
+      - main
+      - dev
+  pull_request: {}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@db9de0fc1a667e1a49d2291a1a042dff081d78f6 # v9
+        with:
+          version: v2.12.2

--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       # SETUP GO
       ########################################
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: 'go.mod'
 
@@ -152,7 +152,7 @@ jobs:
       # GORELEASER
       ########################################
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           version: latest
           workdir: ${{ github.workspace }}
@@ -198,6 +198,6 @@ jobs:
       # BUILD PROVENANCE ATTESTATION
       ########################################
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
         with:
           subject-path: build/proxsave_*

--- a/.github/workflows/security-ultimate.yml
+++ b/.github/workflows/security-ultimate.yml
@@ -27,7 +27,7 @@ jobs:
       # GO 1.25 — MAIN TOOLCHAIN
       ########################################
       - name: Set up Go (from go.mod)
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: 'go.mod'
           cache: false
@@ -89,7 +89,7 @@ jobs:
       # UPLOAD SARIF
       ########################################
       - name: Upload GoSec SARIF
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
         with:
           sarif_file: gosec.sarif
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Local analyses, diagnostics & bug-hunt reports — not for version control
 /diagnostics/
+/.claude/
+/AGENTS.md
+/CLAUDE.md
 
 # Build artifacts — compiled binary (root build) and Makefile output dir
 /proxsave

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  default: standard
+
+issues:
+  new: true

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Proxmox PBS & PVE System Files Backup
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Go](https://img.shields.io/badge/Go-1.25+-success.svg?logo=go)](https://go.dev/)
 [![codecov](https://codecov.io/gh/tis24dev/proxsave/branch/dev/graph/badge.svg)](https://codecov.io/gh/tis24dev/proxsave)
-[![Go Report Card](https://goreportcard.com/badge/github.com/tis24dev/proxsave)](https://goreportcard.com/report/github.com/tis24dev/proxsave)
+[![Go Lint](https://github.com/tis24dev/proxsave/actions/workflows/lint.yml/badge.svg?branch=dev)](https://github.com/tis24dev/proxsave/actions/workflows/lint.yml)
 [![GoSec](https://img.shields.io/github/actions/workflow/status/tis24dev/proxsave/security-ultimate.yml?label=GoSec&logo=go)](https://github.com/tis24dev/proxsave/actions/workflows/security-ultimate.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/tis24dev/proxsave/codeql.yml?label=CodeQL&logo=github)](https://github.com/tis24dev/proxsave/actions/workflows/codeql.yml)
 [![Dependabot](https://img.shields.io/badge/Dependabot-enabled-success?logo=dependabot)](https://github.com/tis24dev/proxsave/network/updates)

--- a/cmd/proxsave/daemon_auto_migrate_characterization_test.go
+++ b/cmd/proxsave/daemon_auto_migrate_characterization_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+// Characterization for maybeAutoMigrateDaemon's decision gates (the --upgrade
+// daemon retrofit). These pin the three branches that MUST short-circuit BEFORE
+// the systemd migration (applyDaemonMode) is ever reached, so a later refactor
+// that moves this call into an extracted finalize phase cannot silently change
+// which installs get auto-migrated.
+//
+// The actual migration branch (cron + not opted out) is intentionally NOT
+// exercised here: it shells out to systemctl to install the unit, which needs
+// root + systemd and mutates the host, so it belongs to system/integration
+// coverage rather than a hermetic unit test. The stdout marker "Migrating to the
+// resident daemon" is printed immediately before applyDaemonMode, so its ABSENCE
+// proves the gate short-circuited without touching the scheduler.
+func TestMaybeAutoMigrateDaemon_Gates(t *testing.T) {
+	const migratingMarker = "Migrating to the resident daemon"
+	const optOutMarker = "leaving the cron scheduler in place"
+
+	run := func(t *testing.T, configPath, baseDir string) string {
+		t.Helper()
+		return captureStdout(t, func() {
+			maybeAutoMigrateDaemon(context.Background(), configPath, baseDir, "/usr/local/bin/proxsave", logging.NewBootstrapLogger())
+		})
+	}
+
+	t.Run("already on daemon: no migration", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "backup.env")
+		if err := os.WriteFile(cfgPath, []byte("SCHEDULER_MODE=daemon\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		out := run(t, cfgPath, dir)
+		if strings.Contains(out, migratingMarker) {
+			t.Errorf("already-daemon must not migrate; stdout:\n%s", out)
+		}
+		if strings.Contains(out, optOutMarker) {
+			t.Errorf("already-daemon must not print the opt-out notice; stdout:\n%s", out)
+		}
+	})
+
+	t.Run("opted out: honored, no migration", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "backup.env")
+		if err := os.WriteFile(cfgPath, []byte("SCHEDULER_MODE=cron\nDAEMON_OPT_OUT=true\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		out := run(t, cfgPath, dir)
+		if strings.Contains(out, migratingMarker) {
+			t.Errorf("opt-out must prevent migration; stdout:\n%s", out)
+		}
+		if !strings.Contains(out, optOutMarker) {
+			t.Errorf("opt-out must print the notice %q; stdout:\n%s", optOutMarker, out)
+		}
+	})
+
+	t.Run("unreadable config: silent no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		missing := filepath.Join(dir, "does-not-exist.env")
+		out := run(t, missing, dir)
+		if strings.Contains(out, migratingMarker) {
+			t.Errorf("unreadable config must not migrate; stdout:\n%s", out)
+		}
+		if strings.Contains(out, optOutMarker) {
+			t.Errorf("unreadable config must not print the opt-out notice; stdout:\n%s", out)
+		}
+	})
+}

--- a/cmd/proxsave/daemon_restart_verify_test.go
+++ b/cmd/proxsave/daemon_restart_verify_test.go
@@ -285,7 +285,7 @@ func TestUpgradeRestartDecisionGate(t *testing.T) {
 	}
 
 	upgradeRestartsDaemon = true
-	if !(upgradeRestartsDaemon && daemonIsActive(context.Background())) {
+	if !upgradeRestartsDaemon || !daemonIsActive(context.Background()) {
 		t.Fatal("CLI upgrade with an active daemon must restart")
 	}
 	upgradeRestartsDaemon = false

--- a/cmd/proxsave/daemon_restart_verify_test.go
+++ b/cmd/proxsave/daemon_restart_verify_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/health"
 	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/ui/components"
+	"github.com/tis24dev/proxsave/internal/ui/theme"
 )
 
 // shrinkRestartBudgets replaces the restart/backup-wait budgets with tiny values so the
@@ -348,10 +350,10 @@ func TestRestartVerifyStatus(t *testing.T) {
 	}
 }
 
-// TestBuildDaemonResultPrompt: the styled result prompt carries the "Status: " label and the
+// TestBuildStatusPrompt: the shared styled result prompt carries the "Status: " label and the
 // colored keyword (matching the daemon-status screen's Status block), plus the explanation.
-func TestBuildDaemonResultPrompt(t *testing.T) {
-	prompt := ansi.Strip(buildDaemonResultPrompt(orchestrator.HealthcheckSetupLevelOk, "restarted, aligned (v9.9.9)", "all good"))
+func TestBuildStatusPrompt(t *testing.T) {
+	prompt := ansi.Strip(orchestrator.BuildStatusPrompt(orchestrator.HealthcheckSetupLevelOk, "restarted, aligned (v9.9.9)", "all good"))
 	if !strings.Contains(prompt, "Status: ") {
 		t.Fatalf("prompt must carry the Status label: %q", prompt)
 	}
@@ -366,9 +368,23 @@ func TestBuildDaemonResultPrompt(t *testing.T) {
 		t.Fatalf("a blank line must separate Status from the suggestion: %q", prompt)
 	}
 	// A success outcome (empty explanation) is just the Status line, no trailing text.
-	okOnly := ansi.Strip(buildDaemonResultPrompt(orchestrator.HealthcheckSetupLevelOk, "restarted, aligned (v9.9.9)", ""))
+	okOnly := ansi.Strip(orchestrator.BuildStatusPrompt(orchestrator.HealthcheckSetupLevelOk, "restarted, aligned (v9.9.9)", ""))
 	if strings.Contains(okOnly, "\n") {
 		t.Fatalf("a success result must be a single Status line, got: %q", okOnly)
+	}
+}
+
+// TestBuildStatusPromptMatchesDashboardResultContract locks the exact pre-refactor
+// dashboard output, including SGR styling and the blank line before an explanation.
+func TestBuildStatusPromptMatchesDashboardResultContract(t *testing.T) {
+	level := orchestrator.HealthcheckSetupLevelWarn
+	keyword := "RESTARTED, NOT CONFIRMED"
+	explanation := "Open Daemon status to confirm it came back aligned."
+	want := theme.Text.Render("Status: ") +
+		orchestrator.RenderStatusLevel(level, components.SanitizeText(keyword)) + "\n\n" +
+		theme.Subtle.Render(components.SanitizeText(explanation))
+	if got := orchestrator.BuildStatusPrompt(level, keyword, explanation); got != want {
+		t.Fatalf("shared Status prompt changed dashboard output:\n got: %q\nwant: %q", got, want)
 	}
 }
 
@@ -385,13 +401,13 @@ func assertNoRawInjection(t *testing.T, out string) {
 	}
 }
 
-// TestBuildDaemonResultPromptSanitizesInjection: a keyword/explanation carrying raw escape bytes
+// TestBuildStatusPromptSanitizesInjection: a keyword/explanation carrying raw escape bytes
 // (OSC title-set + BEL, a CSI erase-screen) must NOT reach the verbatim WithSelectorPromptStyled
 // path as raw sequences, while the human-readable text survives. This closes the injection path
 // for daemon action outcomes (restart keyword embeds the daemon Version; error explanations embed
 // external tool / error strings).
-func TestBuildDaemonResultPromptSanitizesInjection(t *testing.T) {
-	prompt := buildDaemonResultPrompt(
+func TestBuildStatusPromptSanitizesInjection(t *testing.T) {
+	prompt := orchestrator.BuildStatusPrompt(
 		orchestrator.HealthcheckSetupLevelOk,
 		"restarted, aligned (v1.0\x1b]0;pwned\x07)",
 		"\x1b[2J\x07evil",
@@ -411,7 +427,7 @@ func TestBuildDaemonResultPromptSanitizesInjection(t *testing.T) {
 
 // TestRestartKeywordVersionInjectionSanitized: a hostile daemon Version (RAW from
 // .daemon_info.json) reaches the restart-result keyword as "restarted, aligned (v<version>)",
-// then flows restartVerifyStatus -> buildDaemonResultPrompt. Confirm the Version-carrying keyword
+// then flows restartVerifyStatus -> BuildStatusPrompt. Confirm the Version-carrying keyword
 // actually goes through the sanitized builder (no separate raw render), so the escape is scrubbed
 // end-to-end.
 func TestRestartKeywordVersionInjectionSanitized(t *testing.T) {
@@ -427,7 +443,7 @@ func TestRestartKeywordVersionInjectionSanitized(t *testing.T) {
 	if !strings.Contains(keyword, "\x1b]0;") {
 		t.Fatalf("expected the raw Version to ride in the keyword (sanitize happens in the builder): %q", keyword)
 	}
-	prompt := buildDaemonResultPrompt(level, keyword, explanation)
+	prompt := orchestrator.BuildStatusPrompt(level, keyword, explanation)
 	assertNoRawInjection(t, prompt)
 	if !strings.Contains(prompt, "RESTARTED, ALIGNED (v1.0)") || strings.Contains(prompt, "pwned") {
 		t.Fatalf("sanitized restart keyword should keep the plaintext version and drop the OSC payload: %q", prompt)

--- a/cmd/proxsave/daemon_restart_verify_test.go
+++ b/cmd/proxsave/daemon_restart_verify_test.go
@@ -323,27 +323,27 @@ func TestRestartVerifyStatus(t *testing.T) {
 	// Success: the version is in the keyword; the explanation is EMPTY (a what-to-do suggestion
 	// appears only on a problem outcome).
 	if level, keyword, msg := restartVerifyStatus(success); level != orchestrator.HealthcheckSetupLevelOk ||
-		keyword != "restarted, aligned (v4.5.6)" || msg != "" {
+		keyword != "RESTARTED, ALIGNED (v4.5.6)" || msg != "" {
 		t.Fatalf("success status wrong: level=%v keyword=%q msg=%q", level, keyword, msg)
 	}
 	deferred := RestartVerifyResult{BackupWaitTimedOut: true}
 	if level, keyword, _ := restartVerifyStatus(deferred); level != orchestrator.HealthcheckSetupLevelWarn ||
-		keyword != "deferred - backup running" {
+		keyword != "DEFERRED - BACKUP RUNNING" {
 		t.Fatalf("deferred status wrong: level=%v keyword=%q", level, keyword)
 	}
 	timedOut := RestartVerifyResult{Restarted: true, TimedOut: true}
 	if level, keyword, _ := restartVerifyStatus(timedOut); level != orchestrator.HealthcheckSetupLevelWarn ||
-		keyword != "restarted, not confirmed" {
+		keyword != "RESTARTED, NOT CONFIRMED" {
 		t.Fatalf("timed-out status wrong: level=%v keyword=%q", level, keyword)
 	}
 	ambiguous := RestartVerifyResult{Restarted: true} // restarted but not confirmed aligned (default arm)
 	if level, keyword, _ := restartVerifyStatus(ambiguous); level != orchestrator.HealthcheckSetupLevelWarn ||
-		keyword != "restarted, not confirmed" {
+		keyword != "RESTARTED, NOT CONFIRMED" {
 		t.Fatalf("ambiguous status wrong: level=%v keyword=%q", level, keyword)
 	}
 	failed := RestartVerifyResult{Err: errors.New("x")}
 	if level, keyword, msg := restartVerifyStatus(failed); level != orchestrator.HealthcheckSetupLevelError ||
-		keyword != "restart failed" || msg != "x" {
+		keyword != "RESTART FAILED" || msg != "x" {
 		t.Fatalf("failed status wrong: level=%v keyword=%q msg=%q", level, keyword, msg)
 	}
 }
@@ -429,7 +429,7 @@ func TestRestartKeywordVersionInjectionSanitized(t *testing.T) {
 	}
 	prompt := buildDaemonResultPrompt(level, keyword, explanation)
 	assertNoRawInjection(t, prompt)
-	if !strings.Contains(prompt, "restarted, aligned (v1.0)") || strings.Contains(prompt, "pwned") {
+	if !strings.Contains(prompt, "RESTARTED, ALIGNED (v1.0)") || strings.Contains(prompt, "pwned") {
 		t.Fatalf("sanitized restart keyword should keep the plaintext version and drop the OSC payload: %q", prompt)
 	}
 }

--- a/cmd/proxsave/daemon_setup.go
+++ b/cmd/proxsave/daemon_setup.go
@@ -106,13 +106,12 @@ func runDaemonStatus(rt *appRuntime) int {
 	}
 	if ds.HaveInfo || ds.AlignChecked {
 		align := "unknown"
-		switch {
-		case !ds.AlignChecked:
-			align = "unknown"
-		case ds.Aligned:
-			align = "aligned"
-		default:
-			align = "BEHIND (restart needed)"
+		if ds.AlignChecked {
+			if ds.Aligned {
+				align = "aligned"
+			} else {
+				align = "BEHIND (restart needed)"
+			}
 		}
 		logging.Info("Binary alignment: %s", align)
 	}

--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -324,23 +324,23 @@ func runDashboardDaemonRestart(ctx context.Context, session *shell.Session, conf
 func restartVerifyStatus(rv RestartVerifyResult) (orchestrator.HealthcheckSetupLevel, string, string) {
 	switch {
 	case rv.Err != nil:
-		return orchestrator.HealthcheckSetupLevelError, "restart failed", rv.Err.Error()
+		return orchestrator.HealthcheckSetupLevelError, "RESTART FAILED", rv.Err.Error()
 	case rv.BackupWaitTimedOut:
-		return orchestrator.HealthcheckSetupLevelWarn, "deferred - backup running",
+		return orchestrator.HealthcheckSetupLevelWarn, "DEFERRED - BACKUP RUNNING",
 			"Restart again once the backup finishes, or the daemon stays on the old binary."
 	case rv.TimedOut:
-		return orchestrator.HealthcheckSetupLevelWarn, "restarted, not confirmed",
+		return orchestrator.HealthcheckSetupLevelWarn, "RESTARTED, NOT CONFIRMED",
 			"Open Daemon status to confirm it came back aligned."
 	case rv.Restarted && rv.ProcessAlive && rv.Aligned && rv.FreshInfo:
-		// Success: the keyword ("restarted, aligned (vX)") already says everything, so no
+		// Success: the keyword ("RESTARTED, ALIGNED (vX)") already says everything, so no
 		// explanation line -- a what-to-do suggestion only appears on a problem outcome.
-		keyword := "restarted, aligned"
+		keyword := "RESTARTED, ALIGNED"
 		if v := strings.TrimSpace(rv.State.Version); v != "" {
 			keyword += " (v" + v + ")"
 		}
 		return orchestrator.HealthcheckSetupLevelOk, keyword, ""
 	default:
-		return orchestrator.HealthcheckSetupLevelWarn, "restarted, not confirmed",
+		return orchestrator.HealthcheckSetupLevelWarn, "RESTARTED, NOT CONFIRMED",
 			"Open Daemon status to confirm it came back aligned."
 	}
 }
@@ -409,7 +409,7 @@ func runDashboardDaemonAdmin(ctx context.Context, session *shell.Session, instal
 	cfg, err := daemonStatusLoadConfig(configPath, baseDir)
 	if err != nil || cfg == nil {
 		showDaemonResultScreen(ctx, session, "Daemon change failed", orchestrator.HealthcheckSetupLevelError,
-			"config unreadable", "Could not read the configuration to apply the scheduler change.")
+			"CONFIG UNREADABLE", "Could not read the configuration to apply the scheduler change.")
 		return
 	}
 
@@ -426,13 +426,13 @@ func runDashboardDaemonAdmin(ctx context.Context, session *shell.Session, instal
 	title := "Disabling daemon"
 	work := "Reverting to the cron scheduler..."
 	doneTitle := "Daemon disabled"
-	doneKeyword := "reverted to cron"
+	doneKeyword := "REVERTED TO CRON"
 	doneMsg := "Reverted to the cron scheduler and removed the daemon service. Future upgrades will not reinstall it."
 	if install {
 		title = "Installing daemon"
 		work = "Installing and enabling proxsave-daemon.service..."
 		doneTitle = "Daemon installed"
-		doneKeyword = "installed"
+		doneKeyword = "INSTALLED"
 		doneMsg = "The resident daemon (proxsave-daemon.service) is active. The cron entry was removed."
 	}
 	execToken := daemonSelfExecPath()
@@ -447,7 +447,7 @@ func runDashboardDaemonAdmin(ctx context.Context, session *shell.Session, instal
 	})
 
 	if opErr != nil {
-		showDaemonResultScreen(ctx, session, title+" failed", orchestrator.HealthcheckSetupLevelError, "failed", opErr.Error())
+		showDaemonResultScreen(ctx, session, title+" failed", orchestrator.HealthcheckSetupLevelError, "FAILED", opErr.Error())
 		return
 	}
 	showDaemonResultScreen(ctx, session, doneTitle, orchestrator.HealthcheckSetupLevelOk, doneKeyword, doneMsg)
@@ -528,7 +528,11 @@ func runDashboardDaemonStatus(ctx context.Context, session *shell.Session, confi
 			ProcStale:         procBinaryStaleProbe,
 		})
 		level, keyword, explanation := daemonStatusStyle(ds)
-		prompt := buildDaemonStatusPrompt(level, keyword, explanation, mode, unit, active, optOut, ds)
+		// Dashboard "Status:" keywords are ALL-CAPS (the house convention across every
+		// dashboard Status screen). daemonStatusStyle is shared with the plain-text
+		// --daemon-status CLI line, so uppercase HERE (the graphical consumer) rather than at
+		// the source, keeping the CLI/log readout in its natural case.
+		prompt := buildDaemonStatusPrompt(level, strings.ToUpper(keyword), explanation, mode, unit, active, optOut, ds)
 
 		items := []components.SelectorItem[daemonStatusAction]{
 			{Label: "Re-check", Description: "re-run the daemon state check", Value: daemonStatusActionCheck},

--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -587,13 +587,12 @@ func buildDaemonStatusPrompt(level orchestrator.HealthcheckSetupLevel, keyword, 
 	}
 	if ds.HaveInfo || ds.AlignChecked {
 		align := "unknown"
-		switch {
-		case !ds.AlignChecked:
-			align = "unknown"
-		case ds.Aligned:
-			align = "aligned"
-		default:
-			align = "BEHIND (restart needed)"
+		if ds.AlignChecked {
+			if ds.Aligned {
+				align = "aligned"
+			} else {
+				align = "BEHIND (restart needed)"
+			}
 		}
 		b.WriteString("\n")
 		b.WriteString(theme.Text.Render("Binary alignment: " + align))

--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -351,26 +351,6 @@ type daemonResultAction int
 
 const daemonResultActionBack daemonResultAction = iota
 
-// buildDaemonResultPrompt renders the styled "Status:" block for a daemon action-result screen,
-// mirroring buildDaemonStatusPrompt's Status block: a colored keyword line + a Subtle
-// explanation on the next line. This is the single styled renderer for the daemon action outcomes.
-func buildDaemonResultPrompt(level orchestrator.HealthcheckSetupLevel, keyword, explanation string) string {
-	var b strings.Builder
-	b.WriteString(theme.Text.Render("Status: "))
-	b.WriteString(renderDaemonStatusLevel(level, components.SanitizeText(keyword)))
-	// A what-to-do suggestion is shown only on a problem outcome (success passes ""), with a
-	// blank line separating it from the Status line. keyword and explanation are free-form (may
-	// embed external tool output, error strings, or the daemon Version), so both are
-	// SanitizeText-scrubbed before theme rendering to keep raw ANSI/OSC/C0/C1 escapes out of the
-	// verbatim WithSelectorPromptStyled path. The scrub-then-render shape is BYTE-IDENTICAL to
-	// buildWorkflowStatusPrompt; the exp != "" guard preserves the success-passes-"" behavior.
-	if exp := components.SanitizeText(explanation); exp != "" {
-		b.WriteString("\n\n")
-		b.WriteString(theme.Subtle.Render(exp))
-	}
-	return b.String()
-}
-
 // showDaemonResultScreen presents a daemon action outcome (restart / install / revert / error)
 // with the SAME look as the daemon-status screen: a styled "Status:" line (a colored keyword +
 // a Subtle explanation) above a single Back item. It loops to Back/esc and is non-blocking on
@@ -378,7 +358,7 @@ func buildDaemonResultPrompt(level orchestrator.HealthcheckSetupLevel, keyword, 
 // shared by every daemon action result, so they can never disagree visually with the status screen.
 func showDaemonResultScreen(ctx context.Context, session *shell.Session, title string, level orchestrator.HealthcheckSetupLevel, keyword, explanation string) {
 	errDaemonResultEsc := errors.New("daemon result: esc")
-	prompt := buildDaemonResultPrompt(level, keyword, explanation)
+	prompt := orchestrator.BuildStatusPrompt(level, keyword, explanation)
 	items := []components.SelectorItem[daemonResultAction]{
 		{Label: "Back", Description: "return to the dashboard menu", Value: daemonResultActionBack},
 	}

--- a/cmd/proxsave/dashboard_check_apply.go
+++ b/cmd/proxsave/dashboard_check_apply.go
@@ -84,7 +84,7 @@ const (
 // the primary was chosen. esc / secondary return false.
 func showDashboardCheckChoice(ctx context.Context, session *shell.Session, title string, level orchestrator.HealthcheckSetupLevel, keyword, explanation, primaryLabel, primaryDesc, secondaryLabel, secondaryDesc string) bool {
 	errEsc := errors.New("dashboard check: esc")
-	prompt := buildDaemonResultPrompt(level, keyword, explanation)
+	prompt := orchestrator.BuildStatusPrompt(level, keyword, explanation)
 	items := []components.SelectorItem[dashboardCheckChoice]{
 		{Label: primaryLabel, Description: primaryDesc, Value: dashboardCheckPrimary},
 		{Label: secondaryLabel, Description: secondaryDesc, Value: dashboardCheckSecondary},

--- a/cmd/proxsave/dashboard_cleanup_guards.go
+++ b/cmd/proxsave/dashboard_cleanup_guards.go
@@ -27,9 +27,9 @@ func runDashboardCleanupGuards(ctx context.Context, session *shell.Session) {
 				return dashboardCheckResult{}, err
 			}
 			if !report.HasGuards() {
-				return dashboardCheckResult{Found: false, Level: orchestrator.HealthcheckSetupLevelOk, Keyword: "Clean", Explanation: describeGuardCheck(report)}, nil
+				return dashboardCheckResult{Found: false, Level: orchestrator.HealthcheckSetupLevelOk, Keyword: "CLEAN", Explanation: describeGuardCheck(report)}, nil
 			}
-			return dashboardCheckResult{Found: true, Level: orchestrator.HealthcheckSetupLevelWarn, Keyword: "Found", Explanation: describeGuardCheck(report)}, nil
+			return dashboardCheckResult{Found: true, Level: orchestrator.HealthcheckSetupLevelWarn, Keyword: "FOUND", Explanation: describeGuardCheck(report)}, nil
 		},
 		func() (dashboardApplyResult, error) {
 			report, err := cleanupGuardsReport(ctx, discardLogger(), false) // run for real

--- a/cmd/proxsave/dashboard_update_config.go
+++ b/cmd/proxsave/dashboard_update_config.go
@@ -28,10 +28,10 @@ func runDashboardUpdateConfig(ctx context.Context, session *shell.Session, confi
 				return dashboardCheckResult{}, err
 			}
 			if result == nil || !result.Changed {
-				return dashboardCheckResult{Found: false, Level: orchestrator.HealthcheckSetupLevelOk, Keyword: "Up to date",
+				return dashboardCheckResult{Found: false, Level: orchestrator.HealthcheckSetupLevelOk, Keyword: "UP TO DATE",
 					Explanation: "The configuration already has every key from the template. Nothing to update."}, nil
 			}
-			return dashboardCheckResult{Found: true, Level: orchestrator.HealthcheckSetupLevelWarn, Keyword: "Update available",
+			return dashboardCheckResult{Found: true, Level: orchestrator.HealthcheckSetupLevelWarn, Keyword: "UPDATE AVAILABLE",
 				Explanation: describeConfigPlan(result)}, nil
 		},
 		func() (dashboardApplyResult, error) {
@@ -40,9 +40,9 @@ func runDashboardUpdateConfig(ctx context.Context, session *shell.Session, confi
 			if err != nil {
 				return dashboardApplyResult{}, err
 			}
-			keyword := "Updated"
+			keyword := "UPDATED"
 			if result == nil || !result.Changed {
-				keyword = "Up to date"
+				keyword = "UP TO DATE"
 			}
 			return dashboardApplyResult{Level: orchestrator.HealthcheckSetupLevelOk, Keyword: keyword, Explanation: describeConfigApply(result)}, nil
 		},

--- a/cmd/proxsave/dashboard_upgrade.go
+++ b/cmd/proxsave/dashboard_upgrade.go
@@ -158,7 +158,7 @@ func runDashboardUpgrade(ctx context.Context, session *shell.Session, configPath
 		} else {
 			kw, sty, sym = "FAILED", theme.ErrorText, symErr
 			showDaemonResultScreen(ctx, session, "Upgrade failed", orchestrator.HealthcheckSetupLevelError,
-				"failed", "Run 'proxsave --upgrade' from a shell for details.")
+				"FAILED", "Run 'proxsave --upgrade' from a shell for details.")
 		}
 	}
 }
@@ -288,7 +288,7 @@ func buildUpgradeOutcomePrompt(code int) string {
 func dashboardUpgradeRestartDaemon(ctx context.Context, session *shell.Session, configPath string) {
 	if !daemonIsActive(ctx) {
 		showDaemonResultScreen(ctx, session, "Upgrade complete", orchestrator.HealthcheckSetupLevelOk,
-			"new binary on disk", "New binary on disk. This process still runs the old version; relaunch proxsave.")
+			"NEW BINARY ON DISK", "New binary on disk. This process still runs the old version; relaunch proxsave.")
 		return
 	}
 	baseDir, _ := detectedBaseDirOrFallback()

--- a/cmd/proxsave/dashboard_upgrade_test.go
+++ b/cmd/proxsave/dashboard_upgrade_test.go
@@ -80,7 +80,8 @@ func TestRenderReleaseNotes(t *testing.T) {
 
 // TestDashboardUpgradeScreen drives the in-session upgrade screen directly: Check (shows
 // the available version, sanitized) -> Run upgrade (calls the real upgrade with
-// Upgrade+AutoYes+ConfigPath, shows the success notice) -> Back.
+// Upgrade+AutoYes+ConfigPath, keeps the binary-upgrade detail screen after each
+// result) -> Back. Both terminal result keywords stay ALL-CAPS.
 func TestDashboardUpgradeScreen(t *testing.T) {
 	origVer, origChk := dashboardUpgradeVersion, dashboardUpgradeCheck
 	origRun := dashboardUpgradeRun
@@ -101,9 +102,14 @@ func TestDashboardUpgradeScreen(t *testing.T) {
 		}
 	}
 	var gotArgs *cli.Args
+	runCalls := 0
 	dashboardUpgradeRun = func(ctx context.Context, args *cli.Args, bl *logging.BootstrapLogger) int {
+		runCalls++
 		gotArgs = args
-		return 0 // success
+		if runCalls == 1 {
+			return 0 // first run succeeds
+		}
+		return 1 // second run exercises the failure result
 	}
 
 	// Build an observed session eagerly (the shared seam creates it lazily via a flow).
@@ -160,17 +166,78 @@ func TestDashboardUpgradeScreen(t *testing.T) {
 	driver.waitOutput("enter continue")
 	driver.keys("enter")
 	driver.waitScreen("Upgrade complete")
+	_ = waitFor("NEW BINARY ON DISK") // inactive-daemon success uses the dashboard ALL-CAPS status convention
 	if gotArgs == nil || !gotArgs.Upgrade || !gotArgs.UpgradeAutoYes || gotArgs.ConfigPath != "/tmp/backup.env" {
 		t.Fatalf("run upgrade must pass Upgrade+AutoYes+ConfigPath, got %+v", gotArgs)
 	}
 
 	driver.keys("enter")         // dismiss the notice
 	driver.waitScreen("Upgrade") // back on the screen, now showing UPGRADED with a Re-check button
-	driver.keys("down enter")    // Back (2nd item) -> return
+	_ = waitFor("UPGRADED")
+	driver.keys("enter") // Re-check -> update remains available
+	driver.waitScreen("Upgrade")
+	driver.keys("enter") // Run upgrade again, this time failing
+	driver.waitScreen("Running upgrade")
+	driver.waitOutput("enter continue")
+	driver.keys("enter")
+	driver.waitScreen("Upgrade failed")
+	_ = waitFor("FAILED") // failure result uses the same ALL-CAPS convention
+	driver.keys("enter")
+	driver.waitScreen("Upgrade") // failure also returns to the binary-upgrade detail screen
+	if runCalls != 2 {
+		t.Fatalf("run upgrade calls = %d, want 2", runCalls)
+	}
+	driver.keys("down enter") // Back (2nd item) -> return
 	select {
 	case <-done:
 	case <-time.After(uitest.Deadline(60 * time.Second)):
 		t.Fatal("upgrade screen did not return")
+	}
+}
+
+// TestDashboardUpgradeExternalCheckFailureIsWarning preserves the deliberate
+// retryable-external-resource policy: GitHub being unavailable is yellow, not
+// a red local-operation failure, and the user can return without an action.
+func TestDashboardUpgradeExternalCheckFailureIsWarning(t *testing.T) {
+	origVer, origChk := dashboardUpgradeVersion, dashboardUpgradeCheck
+	t.Cleanup(func() { dashboardUpgradeVersion, dashboardUpgradeCheck = origVer, origChk })
+	dashboardUpgradeVersion = func() string { return "1.0.0" }
+	dashboardUpgradeCheck = func(context.Context, *logging.Logger, string) *UpdateInfo { return nil }
+
+	driver := &newkeyUIDriver{t: t, buf: &shell.SyncBuffer{}, pushes: make(chan string, 64)}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	driver.session = shell.StartObservedForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"},
+		driver.buf, func(title string) { driver.pushes <- title })
+
+	done := make(chan struct{})
+	go func() {
+		runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env")
+		close(done)
+	}()
+
+	driver.waitScreen("Upgrade")
+	deadline := time.After(uitest.Deadline(15 * time.Second))
+	for {
+		out := ansi.Strip(driver.buf.String())
+		if strings.Contains(out, "CHECK FAILED") {
+			if !strings.Contains(out, "⚠ CHECK FAILED") {
+				t.Fatalf("external check failure must retain the warning symbol, got %q", tailStr(out))
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for CHECK FAILED, tail:\n%s", tailStr(out))
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	driver.keys("down enter") // Back, not Re-check
+	select {
+	case <-done:
+	case <-time.After(uitest.Deadline(60 * time.Second)):
+		t.Fatal("upgrade screen did not return after external check failure")
 	}
 }
 

--- a/cmd/proxsave/install_docs_characterization_test.go
+++ b/cmd/proxsave/install_docs_characterization_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	rootdocs "github.com/tis24dev/proxsave"
+)
+
+// Characterization for installSupportDocs, part of the --upgrade finalize block
+// (refresh embedded docs). Pins that every embedded doc is written under the base
+// dir at its own Name (creating nested directories), byte-for-byte, at mode 0600,
+// so an upcoming finalize-phase extraction can be proven behaviour-preserving.
+func TestInstallSupportDocs_WritesEmbeddedDocs(t *testing.T) {
+	docs := rootdocs.InstallableDocs()
+	if len(docs) == 0 {
+		t.Fatal("expected embedded docs (at least README.md); got none")
+	}
+
+	dir := t.TempDir()
+	if err := installSupportDocs(dir, nil); err != nil {
+		t.Fatalf("installSupportDocs: %v", err)
+	}
+
+	sawNested := false
+	for _, doc := range docs {
+		target := filepath.Join(dir, doc.Name)
+		got, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatalf("doc %q not written: %v", doc.Name, err)
+		}
+		if !bytes.Equal(got, doc.Data) {
+			t.Errorf("doc %q content mismatch (%d bytes on disk vs %d embedded)", doc.Name, len(got), len(doc.Data))
+		}
+		if runtime.GOOS != "windows" {
+			info, err := os.Stat(target)
+			if err != nil {
+				t.Fatalf("stat %q: %v", target, err)
+			}
+			if info.Mode().Perm() != 0o600 {
+				t.Errorf("doc %q mode = %o, want 0600", doc.Name, info.Mode().Perm())
+			}
+		}
+		if strings.Contains(doc.Name, "/") {
+			sawNested = true
+		}
+	}
+	if !sawNested {
+		t.Log("note: no embedded doc had a nested path; the MkdirAll subdir branch was not exercised")
+	}
+}
+
+// installSupportDocs surfaces a directory-creation failure as an error (it is
+// best-effort at the call site, only warned, but the function itself must still
+// report the failure). Pointing the base dir at a regular file makes the first
+// MkdirAll fail, which characterizes the error path without needing root.
+func TestInstallSupportDocs_ErrorsWhenBaseDirIsRegularFile(t *testing.T) {
+	if len(rootdocs.InstallableDocs()) == 0 {
+		t.Fatal("expected embedded docs (at least README.md); got none")
+	}
+
+	dir := t.TempDir()
+	fileAsBase := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(fileAsBase, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if err := installSupportDocs(fileAsBase, nil); err == nil {
+		t.Fatal("expected an error when the base dir is a regular file, got nil")
+	}
+}

--- a/cmd/proxsave/main_modes.go
+++ b/cmd/proxsave/main_modes.go
@@ -75,6 +75,9 @@ func validateUpgradeCompatibility(args *cli.Args) []string {
 	if args.Upgrade && (args.Install || args.NewInstall) {
 		return []string{"Cannot use --upgrade together with --install or --new-install."}
 	}
+	if args.LocalFile && !args.Upgrade {
+		return []string{"The --localfile flag only applies to --upgrade (use: --upgrade --localfile)."}
+	}
 	return nil
 }
 

--- a/cmd/proxsave/main_modes_test.go
+++ b/cmd/proxsave/main_modes_test.go
@@ -53,6 +53,15 @@ func TestValidateModeCompatibility(t *testing.T) {
 			want: []string{"Cannot use --upgrade together with --install or --new-install."},
 		},
 		{
+			name: "upgrade localfile allowed",
+			args: &cli.Args{Upgrade: true, LocalFile: true},
+		},
+		{
+			name: "localfile without upgrade rejected",
+			args: &cli.Args{LocalFile: true},
+			want: []string{"The --localfile flag only applies to --upgrade (use: --upgrade --localfile)."},
+		},
+		{
 			name: "accumulates all compatibility violations",
 			args: &cli.Args{CleanupGuards: true, Support: true, Decrypt: true, Install: true, NewInstall: true, Upgrade: true},
 			want: []string{

--- a/cmd/proxsave/upgrade.go
+++ b/cmd/proxsave/upgrade.go
@@ -105,10 +105,15 @@ func logUpgradeDaemonRestart(bootstrap *logging.BootstrapLogger, rv *RestartVeri
 	}
 }
 
-// runUpgrade orchestrates the upgrade flow:
-//   - downloads and installs the latest binary release
-//   - upgrades backup.env by adding missing keys from the new template (preserving existing values)
-//   - refreshes symlinks/cron/docs and normalizes permissions/ownership
+// runUpgrade orchestrates the upgrade flow in two phases:
+//   - acquire the binary (upgradeAcquireBinary): download+install the latest
+//     release, or -- with --localfile -- use the binary already on disk
+//   - finalize (upgradeFinalizePhase): upgrade backup.env by adding missing keys
+//     from the new template, refresh symlinks/docs, migrate/restart the daemon,
+//     and normalize permissions/ownership
+//
+// The shared setup (logger, banner, config load) runs before either phase so the
+// --localfile path prints the same header and honours the same guards.
 func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.BootstrapLogger) int {
 	baseDir, _ := detectedBaseDirOrFallback()
 	_ = os.Setenv("BASE_DIR", baseDir)
@@ -132,7 +137,7 @@ func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.Bootstra
 	}
 
 	var workflowErr error
-	done := logging.DebugStartBootstrap(bootstrap, "upgrade workflow", "config=%s base=%s", args.ConfigPath, baseDir)
+	done := logging.DebugStartBootstrap(bootstrap, "upgrade workflow", "config=%s base=%s localfile=%t", args.ConfigPath, baseDir, args.LocalFile)
 	defer func() { done(workflowErr) }()
 
 	if err := ensureConfigExists(args.ConfigPath, bootstrap); err != nil {
@@ -155,11 +160,46 @@ func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.Bootstra
 	bootstrap.Printf("Base directory: %s", baseDir)
 	bootstrap.Println("")
 
-	_, err := config.LoadConfigWithBaseDir(args.ConfigPath, baseDir)
-	if err != nil {
+	if _, err := config.LoadConfigWithBaseDir(args.ConfigPath, baseDir); err != nil {
 		bootstrap.Error("ERROR: Failed to load configuration: %v", err)
 		workflowErr = err
 		return types.ExitConfigError.Int()
+	}
+
+	// Phase 1: resolve the binary to finalize against. terminal=true means a
+	// pre-finalize gate fired (already latest / newer / fetch failure / declined)
+	// and we must return without touching the install.
+	execPath, versionInstalled, exitCode, terminal, upgradeErr := upgradeAcquireBinary(ctx, args, bootstrap, baseDir, currentVersion)
+	if terminal {
+		workflowErr = upgradeErr
+		return exitCode
+	}
+
+	// Phase 2: local finalize, shared by the download and --localfile paths.
+	code, finalizeErr := upgradeFinalizePhase(ctx, args, bootstrap, sessionLogger, baseDir, execPath, versionInstalled, upgradeErr)
+	workflowErr = finalizeErr
+	return code
+}
+
+// upgradeAcquireBinary resolves the binary that upgradeFinalizePhase will act on.
+// Default: fetch the latest GitHub release, confirm, download and install it.
+// With --localfile: skip the release check and download entirely and use the
+// binary already on disk (the upgrade-beta.sh path, which has already swapped in
+// and verified a binary the flow must not re-fetch -- fetching would resolve the
+// latest STABLE release and could pull a beta tester back off their build).
+//
+// terminal=true tells runUpgrade to return exitCode WITHOUT finalizing (the
+// pre-download gates: already-latest, installed-newer, fetch failure, decline).
+// When terminal=false the returned execPath/versionInstalled/upgradeErr feed the
+// finalize phase; upgradeErr!=nil there means the download failed but the footer
+// still runs.
+func upgradeAcquireBinary(ctx context.Context, args *cli.Args, bootstrap *logging.BootstrapLogger, baseDir, currentVersion string) (execPath, versionInstalled string, exitCode int, terminal bool, upgradeErr error) {
+	if args.LocalFile {
+		execPath = getExecInfo().ExecPath
+		versionInstalled = strings.TrimPrefix(currentVersion, "v")
+		bootstrap.Println("Local-file upgrade: finalizing with the binary already on disk (no release check, no download).")
+		logging.DebugStepBootstrap(bootstrap, "upgrade workflow", "localfile mode: on-disk binary %s (version %s)", execPath, versionInstalled)
+		return execPath, versionInstalled, 0, false, nil
 	}
 
 	// Discover the latest available release on GitHub and compare with the
@@ -168,20 +208,17 @@ func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.Bootstra
 	tag, latestVersion, _, err := fetchLatestRelease(ctx)
 	if err != nil {
 		bootstrap.Error("ERROR: Failed to check latest release: %v", err)
-		workflowErr = err
-		return types.ExitConfigError.Int()
+		return "", "", types.ExitConfigError.Int(), true, err
 	}
 
 	logging.DebugStepBootstrap(bootstrap, "upgrade workflow", "current=%s latest=%s", currentVersion, latestVersion)
 	switch compareVersions(currentVersion, latestVersion) {
 	case 0:
 		bootstrap.Printf("You are already running the latest version: %s", currentVersion)
-		workflowErr = nil
-		return types.ExitSuccess.Int()
+		return "", "", types.ExitSuccess.Int(), true, nil
 	case 1:
 		bootstrap.Printf("Installed version (%s) is newer than latest release (%s); aborting upgrade.", currentVersion, latestVersion)
-		workflowErr = fmt.Errorf("current version newer than latest")
-		return types.ExitConfigError.Int()
+		return "", "", types.ExitConfigError.Int(), true, fmt.Errorf("current version newer than latest")
 	}
 
 	bootstrap.Printf("Latest available version: %s (current: %s)", latestVersion, currentVersion)
@@ -191,35 +228,42 @@ func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.Bootstra
 		logging.DebugStepBootstrap(bootstrap, "upgrade workflow", "auto-confirm enabled (--upgrade y)")
 	} else {
 		reader := bufio.NewReader(os.Stdin)
-		var err error
-		confirm, err = promptYesNo(ctx, reader, "Do you want to download and install this version now? (backup.env will be updated with any missing keys; a backup will be created) [y/N]: ", false)
-		if err != nil {
-			bootstrap.Error("ERROR: %v", err)
-			workflowErr = err
-			return types.ExitConfigError.Int()
+		confirmed, promptErr := promptYesNo(ctx, reader, "Do you want to download and install this version now? (backup.env will be updated with any missing keys; a backup will be created) [y/N]: ", false)
+		if promptErr != nil {
+			bootstrap.Error("ERROR: %v", promptErr)
+			return "", "", types.ExitConfigError.Int(), true, promptErr
 		}
+		confirm = confirmed
 	}
 	if !confirm {
 		bootstrap.Println("Upgrade cancelled by user; no changes were made.")
-		workflowErr = nil
-		return types.ExitSuccess.Int()
+		return "", "", types.ExitSuccess.Int(), true, nil
 	}
 
 	// Download + install latest binary (confirmed)
-	execInfo := getExecInfo()
-	execPath := execInfo.ExecPath
+	execPath = getExecInfo().ExecPath
 	logging.DebugStepBootstrap(bootstrap, "upgrade workflow", "executing upgrade for %s", execPath)
-	versionInstalled, upgradeErr := downloadAndInstallLatest(ctx, execPath, bootstrap, tag, latestVersion)
+	versionInstalled, upgradeErr = downloadAndInstallLatest(ctx, execPath, bootstrap, tag, latestVersion)
 	if upgradeErr != nil {
 		bootstrap.Error("ERROR: Upgrade failed: %v", upgradeErr)
-		// Continue to footer to show guidance and permission status, but exit with error.
-		workflowErr = upgradeErr
+		// Continue to the footer to show guidance and permission status, but exit
+		// with error (upgradeErr flows through finalize).
 	}
+	return execPath, versionInstalled, 0, false, upgradeErr
+}
 
+// upgradeFinalizePhase runs the local, post-binary steps of an upgrade against
+// the binary now on disk: upgrade backup.env with any new template keys, refresh
+// docs/symlinks, auto-migrate/restart the daemon, normalize permissions, and
+// print the footer. It is shared by the download path and the --localfile path,
+// which both reach it with the target binary already in place. Returns the
+// process exit code and the error to attribute to the workflow span (nil on full
+// success, the config-upgrade error, or the binary-install error).
+func upgradeFinalizePhase(ctx context.Context, args *cli.Args, bootstrap *logging.BootstrapLogger, sessionLogger *logging.Logger, baseDir, execPath, versionInstalled string, upgradeErr error) (int, error) {
 	var cfgUpgradeResult *config.UpgradeResult
 	var cfgUpgradeErr error
 	if upgradeErr == nil {
-		logging.DebugStepBootstrap(bootstrap, "upgrade workflow", "upgrading configuration with newly installed binary")
+		logging.DebugStepBootstrap(bootstrap, "upgrade workflow", "upgrading configuration with the installed binary")
 		cfgUpgradeResult, cfgUpgradeErr = upgradeConfigWithBinary(ctx, execPath, args.ConfigPath)
 		if cfgUpgradeErr != nil {
 			bootstrap.Warning("Upgrade: configuration upgrade failed: %v", cfgUpgradeErr)
@@ -277,13 +321,17 @@ func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.Bootstra
 
 	printUpgradeFooter(upgradeErr, versionInstalled, args.ConfigPath, baseDir, telegramCode, permStatus, permMessage, cfgUpgradeResult, cfgUpgradeErr, daemonRestart)
 
-	// A configuration-upgrade failure after a successful binary install must also be
-	// reflected in the exit code (the footer already shows "Configuration: ERROR"),
-	// so automation does not treat the run as fully successful.
-	if upgradeErr == nil && cfgUpgradeErr != nil {
+	// The workflow span error mirrors the exit code's reasoning: a binary-install
+	// failure, or a config-upgrade failure after a good install (the footer already
+	// shows "Configuration: ERROR"), so automation and the trace agree.
+	var workflowErr error
+	switch {
+	case upgradeErr != nil:
+		workflowErr = upgradeErr
+	case cfgUpgradeErr != nil:
 		workflowErr = cfgUpgradeErr
 	}
-	return upgradeExitCode(upgradeErr, cfgUpgradeErr)
+	return upgradeExitCode(upgradeErr, cfgUpgradeErr), workflowErr
 }
 
 // upgradeExitCode maps the binary-install and config-upgrade outcomes to a process

--- a/cmd/proxsave/upgrade_localfile_test.go
+++ b/cmd/proxsave/upgrade_localfile_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/cli"
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+// upgradeAcquireBinary in --localfile mode must NOT touch the network: it returns
+// the binary already on disk so upgradeFinalizePhase acts on it, and never signals
+// terminal (the finalize has to run). This is the seam upgrade-beta.sh relies on --
+// a fetch here would resolve the latest STABLE release and could pull a beta tester
+// off their build. The running version is reported as the installed version,
+// stripped of a leading "v" to match the download path's format.
+func TestUpgradeAcquireBinary_LocalFile(t *testing.T) {
+	cases := []struct {
+		name           string
+		currentVersion string
+		wantVersion    string
+	}{
+		{"plain semver", "1.2.3", "1.2.3"},
+		{"leading v trimmed", "v9.9.9", "9.9.9"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			args := &cli.Args{LocalFile: true}
+			var execPath, versionInstalled string
+			var upgradeErr error
+			var exitCode int
+			var terminal bool
+			out := captureStdout(t, func() {
+				execPath, versionInstalled, exitCode, terminal, upgradeErr = upgradeAcquireBinary(
+					context.Background(), args, logging.NewBootstrapLogger(), t.TempDir(), c.currentVersion)
+			})
+
+			if terminal {
+				t.Errorf("localfile must not be terminal (finalize has to run); exitCode=%d", exitCode)
+			}
+			if upgradeErr != nil {
+				t.Errorf("localfile must not error: %v", upgradeErr)
+			}
+			if exitCode != 0 {
+				t.Errorf("localfile exitCode = %d, want 0", exitCode)
+			}
+			if execPath == "" {
+				t.Error("localfile must return the on-disk exec path, got empty")
+			}
+			if versionInstalled != c.wantVersion {
+				t.Errorf("versionInstalled = %q, want %q", versionInstalled, c.wantVersion)
+			}
+			if !strings.Contains(out, "no download") {
+				t.Errorf("localfile must announce it skips the download; stdout:\n%s", out)
+			}
+		})
+	}
+}

--- a/docs/CLOUD_STORAGE.md
+++ b/docs/CLOUD_STORAGE.md
@@ -82,6 +82,35 @@ Proxsave uses a **3-tier storage system**:
    └─> Cloud: MAX_CLOUD_BACKUPS or GFS
 ```
 
+### Cloud layout (bundle vs raw)
+
+By default (`BUNDLE_ASSOCIATED_FILES=true`) each backup is packed into a single
+`<archive>.bundle.tar` before upload, so the cloud remote receives **one file per
+backup**. The bundle contains the raw archive plus its `.metadata` and `.sha256`
+sidecars (and `.metadata.sha256` when present); the `.manifest.json` is **not** inside
+the bundle.
+
+Set `BUNDLE_ASSOCIATED_FILES=false` to upload the **raw** archive plus separate
+sidecars: `<archive>`, `<archive>.sha256`, `<archive>.manifest.json`,
+`<archive>.metadata`, and `<archive>.metadata.sha256` (missing ones are skipped). In
+this raw layout the `<archive>.manifest.json` is the **authoritative metadata** that
+keeps the backup discoverable and verifiable during restore/decrypt cloud scans, so do
+not delete it (PS-BH-002).
+
+### How ProxSave invokes rclone
+
+ProxSave never runs a free-form rclone command line. Every call is built from a fixed
+**subcommand allowlist**: `copyto`, `delete`, `deletefile`, `hashsum`, `ls`, `lsf`,
+`lsl`, `mkdir`, `touch` (anything else is rejected). Uploads use **`copyto`** (not
+`copy`), with `--progress --stats 10s` and, when set, `--bwlimit` and `--transfers`.
+Connectivity checks use `lsf` (plus `mkdir`, or `touch` + `deletefile` for the write
+test), and verification uses `lsl`/`ls` plus `hashsum sha256`. Timeouts are enforced
+with Go context deadlines rather than rclone flags, so ProxSave does not add
+`--config`, `--timeout`, or `--contimeout`. `RCLONE_FLAGS`, if set, is appended to
+every one of these commands (see the Configuration Reference). The manual `rclone`
+commands shown later in this guide are for you to run by hand and are not subject to
+this allowlist.
+
 ---
 
 ## Prerequisites
@@ -378,7 +407,7 @@ RETENTION_YEARLY=3
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CLOUD_ENABLED` | `false` | Enable cloud storage |
-| `CLOUD_REMOTE` | _(required)_ | rclone remote **name** from `rclone config` (legacy `remote:path` still supported) |
+| `CLOUD_REMOTE` | _(empty)_ | rclone remote **name** from `rclone config` (legacy `remote:path` still supported). Required only when cloud is enabled: if empty, cloud is **silently disabled** even with `CLOUD_ENABLED=true`. |
 | `CLOUD_REMOTE_PATH` | _(empty)_ | Folder path/prefix inside the remote (e.g., `/proxsave/backup`) |
 | `CLOUD_LOG_PATH` | _(empty)_ | Optional log folder (recommended: path-only on the same remote; use `otherremote:/path` only when using a different remote) |
 | `CLOUD_UPLOAD_MODE` | `parallel` | `parallel` or `sequential` |
@@ -388,7 +417,7 @@ RETENTION_YEARLY=3
 | `CLOUD_VERIFY_DOWNLOAD` | `false` | When the backend lacks native SHA256, download the object and hash it locally (uses bandwidth) |
 | `CLOUD_WRITE_HEALTHCHECK` | `false` | Use write test for connectivity check |
 | `RCLONE_TIMEOUT_CONNECTION` | `30` | Per-command timeout (seconds). Also used by restore/decrypt cloud scan (`rclone lsf` + per-backup manifest/metadata read). |
-| `RCLONE_TIMEOUT_OPERATION` | `300` | Operation timeout (seconds) |
+| `RCLONE_TIMEOUT_OPERATION` | `300` | Per-operation upload timeout (seconds). `0` means **unbounded** uploads (no per-op deadline). Management/query ops (list, delete, retention) are always bounded: they use this value when it is > 0, otherwise a built-in 300s floor. So raising it also raises the management ceiling, and a positive value below 300 also shortens management ops. |
 | `RCLONE_BANDWIDTH_LIMIT` | _(empty)_ | Upload rate limit (e.g., `5M` = 5 MB/s) |
 | `RCLONE_TRANSFERS` | `4` | Number of parallel transfers |
 | `RCLONE_RETRIES` | `3` | Retry attempts on failure |
@@ -396,12 +425,24 @@ RETENTION_YEARLY=3
 | `CLOUD_BATCH_SIZE` | `20` | Files per batch (deletion) |
 | `CLOUD_BATCH_PAUSE` | `1` | Seconds between batches |
 | `MAX_CLOUD_BACKUPS` | `30` | Simple retention (ignored if GFS enabled) |
+| `RCLONE_FLAGS` | _(empty)_ | Extra global rclone flags, split on whitespace and injected verbatim into **every** rclone command (right after the subcommand). No shell quoting or validation, so keep each flag a single token (e.g. `--fast-list --checkers 8`). |
+| `BUNDLE_ASSOCIATED_FILES` | `true` | Bundle the archive and its sidecars into one `.bundle.tar` before upload (the default cloud layout). Set `false` to upload the raw archive plus separate sidecars. See [Cloud layout](#cloud-layout-bundle-vs-raw). |
+
+**Legacy env-var aliases.** For backward compatibility ProxSave also accepts these
+older names (the value is read from whichever is set):
+
+- `CLOUD_ENABLED` accepts `ENABLE_CLOUD_BACKUP`
+- `CLOUD_REMOTE` accepts `RCLONE_REMOTE`
+- `MAX_CLOUD_BACKUPS` accepts `CLOUD_RETENTION_DAYS`
+- `RCLONE_TIMEOUT_CONNECTION` accepts `CLOUD_CONNECTIVITY_TIMEOUT`
+
+Prefer the canonical names on the left in new configs.
 
 For complete configuration reference, see: **[Configuration Guide](CONFIGURATION.md)**
 
 ### Recommended Remote Path Formats (Important)
 
-ProxSave supports both “new style” (path-only) and “legacy style” (`remote:path`) values, but using a consistent format avoids confusion.
+ProxSave supports both "new style" (path-only) and "legacy style" (`remote:path`) values, but using a consistent format avoids confusion.
 
 **Recommended:**
 - `CLOUD_REMOTE` should be just the **remote name** (no `:`), e.g. `nextcloud` or `GoogleDrive`.
@@ -440,10 +481,10 @@ In both cases ProxSave combines the base path and the optional prefix into a sin
 path inside the remote, and uses that consistently for:
 - **uploads** (cloud backend);
 - **cloud retention**;
-- **restore / decrypt menus** (entry “Cloud backups (rclone)”).
+- **restore / decrypt menus** (entry "Cloud backups (rclone)").
   - Restore/decrypt cloud scanning applies `RCLONE_TIMEOUT_CONNECTION` per rclone command (the timer resets on each `lsf`/manifest read).
 
-You can choose the style you prefer; they are equivalent from the tool’s point of view.
+You can choose the style you prefer; they are equivalent from the tool's point of view.
 
 **When to use CLOUD_REMOTE_PATH**:
 - Organizing multiple servers' backups: `server1/`, `server2/`
@@ -750,7 +791,7 @@ echo "Latest: $LATEST"
 rclone copy "gdrive:pbs-backups/$LATEST" /tmp/recovery/
 ```
 
-**Step 5: Extract Bundle** (if using bundle format)
+**Step 5: Extract Bundle** (the default layout ships one `.bundle.tar` per backup; skip this step only if you set `BUNDLE_ASSOCIATED_FILES=false`)
 
 ```bash
 cd /tmp/recovery

--- a/docs/CLUSTER_RECOVERY.md
+++ b/docs/CLUSTER_RECOVERY.md
@@ -6,6 +6,7 @@ Advanced disaster recovery procedures for Proxmox VE cluster database restoratio
 
 - [Overview](#overview)
 - [Understanding PVE Cluster Architecture](#understanding-pve-cluster-architecture)
+- [Cluster restore modes: SAFE vs RECOVERY](#cluster-restore-modes-safe-vs-recovery)
 - [Recovery Scenarios](#recovery-scenarios)
 - [Pre-Recovery Checklist](#pre-recovery-checklist)
 - [Scenario 1: Single-Node Recovery](#scenario-1-single-node-recovery)
@@ -104,32 +105,101 @@ Communication Layer:
 **/etc/pve**:
 - **NOT** a real directory (it's a FUSE mount)
 - View into config.db
-- **Cannot be restored directly** (that's why export-only)
-- Automatically populated when pmxcfs starts with restored config.db
+- You cannot write files into it directly (writes go to the FUSE layer). ProxSave either applies the exported files through the API (SAFE) or restores config.db while pmxcfs is stopped (RECOVERY). See [Cluster restore modes](#cluster-restore-modes-safe-vs-recovery).
+- Repopulated from config.db when pmxcfs restarts (the RECOVERY path)
 
 **Corosync**:
 - Synchronizes config.db changes across nodes
 - Manages quorum (who can make changes)
 - Configuration in `/etc/pve/corosync.conf`
 
-### Why Special Handling Is Required
+### Why /etc/pve needs special handling
 
-**Problem**: You cannot simply copy files to `/etc/pve`:
+You cannot simply copy files into `/etc/pve`. It is a FUSE view of config.db, so a `cp` into it writes to the FUSE layer and is lost when pmxcfs restarts:
+
 ```bash
-# ✗ This will NOT work:
+# This does NOT persist:
 cp backup/etc/pve/storage.cfg /etc/pve/storage.cfg
-# Writes go to FUSE, not permanent storage
-# Lost on pmxcfs restart
 ```
 
-**Solution**: Restore `/var/lib/pve-cluster/config.db`:
-```bash
-# ✓ This works (with services stopped):
-# 1. Stop pmxcfs and related services
-# 2. Restore config.db from backup
-# 3. Restart pmxcfs
-# 4. /etc/pve automatically repopulated from restored config.db
+ProxSave handles this in one of two ways, and it makes you choose which at restore time: it either applies the exported configuration to a running cluster through the Proxmox API (SAFE), or it restores the whole config.db while pmxcfs is stopped (RECOVERY). The next section is the one that matters most.
+
+---
+
+## Cluster restore modes: SAFE vs RECOVERY
+
+This is the single most important decision in a cluster restore, and ProxSave forces you to make it explicitly.
+
+### When the prompt appears
+
+Whenever a PVE restore includes the `pve_cluster` category and the backup actually contains cluster data, ProxSave shows a second, mandatory prompt right after you pick the restore scope. FULL and STORAGE both include `pve_cluster`, so they always reach it; CUSTOM reaches it only if you select `PVE Cluster Configuration`. SYSTEM BASE does not include `pve_cluster`, so it never shows this prompt. In the CLI it reads:
+
 ```
+Cluster backup detected. Choose how to restore the cluster database:
+  [1] SAFE: Do NOT write /var/lib/pve-cluster/config.db. Export cluster files only (manual/apply via API).
+  [2] RECOVERY: Restore full cluster database (/var/lib/pve-cluster). Use only when cluster is offline/isolated.
+  [0] Exit
+Choice:
+```
+
+In the TUI it is a selector titled `Cluster restore mode` with `SAFE`, `RECOVERY`, and `Exit` items carrying the same text. `Exit` (or Esc) aborts the whole restore.
+
+### SAFE (the non-destructive choice)
+
+SAFE never writes config.db, never stops `pve-cluster`/`pvedaemon`/`pveproxy`/`pvestatd`, and never unmounts `/etc/pve`. It extracts the cluster files to an export directory and re-applies them to the RUNNING cluster through `pvesh`/`pveum`:
+
+- storage definitions (`pvesh create /storage` from storage.cfg), unless the `storage_pve` category already restores them;
+- datacenter options (`pvesh set /cluster/config`);
+- resource pools (`pveum pool add/modify` for definitions, then membership, with an optional allow-move guard when a pool lists guests);
+- PCI, USB, and directory resource mappings;
+- VM and CT configs, re-created on the CURRENT node via `pvesh create` then `pvesh set` under `/nodes/<node>/qemu|lxc/<vmid>/config`.
+
+Use SAFE when the node or cluster is up and you want to merge the backed-up configuration back in without touching the live database. SAFE needs `pvesh` on PATH; without it, it logs a skip and applies nothing.
+
+If the backup's VM/CT configs are stored under a node name that does not match the current host (a hostname change), SAFE handles it for you: it warns, and either auto-selects the single exported node or asks which exported node to import the guest configs from. The chosen configs are applied to the current node. You do not need to copy `/etc/pve/nodes/...` by hand.
+
+### RECOVERY (the destructive, offline choice)
+
+RECOVERY restores the entire cluster database by overwriting `/var/lib/pve-cluster/`. To do that safely it:
+
+1. stops `pve-cluster`, `pvedaemon`, `pveproxy`, `pvestatd` in that order (escalating to SIGKILL if a service will not stop);
+2. unmounts `/etc/pve` (a failure here is a warning, not fatal);
+3. extracts `./var/lib/pve-cluster/` (config.db) directly to disk while pmxcfs is down;
+4. restarts the four services during cleanup.
+
+While pmxcfs is down, ProxSave does not write individual `/etc/pve` files. The config areas that live under `/etc/pve` (storage, jobs, firewall, HA, SDN, access control, notifications) each skip their own apply step during a cluster RECOVERY, because config.db now owns them; a shadow-guard strips any `/etc/pve` path from the direct-extraction set as a backstop. Everything under `/etc/pve` comes back from the restored config.db once `/etc/pve` is remounted.
+
+Use RECOVERY only on an OFFLINE or ISOLATED node. Restoring config.db on a node that is still talking to other cluster members can corrupt the cluster. ProxSave logs a warning when you pick it: `Selected RECOVERY cluster restore: full cluster database will be restored; ensure other nodes are isolated`.
+
+### Which one an earlier version of this guide described
+
+Older versions of this guide showed the "stopping PVE services / unmounting /etc/pve / restart" sequence as the automatic result of choosing "STORAGE only". That sequence is RECOVERY only. Choosing STORAGE (or FULL) just brings you to the SAFE/RECOVERY prompt; SAFE does none of it.
+
+### Offline storage: mount guards
+
+If a datastore or storage mountpoint is offline during a restore (its device is not mounted, so the path resolves to the root filesystem), ProxSave bind-mounts a read-only guard over it under `/var/lib/proxsave/guards`, so the restore cannot write onto the root disk and be shadowed later when the real storage mounts. The guard is a runtime bind mount: it disappears when the real storage mounts on top, and it is gone after a reboot. Current versions no longer set a persistent `chattr +i` flag. To clear leftover guards once storage is back online:
+
+```bash
+proxsave --cleanup-guards            # remove leftover guards
+proxsave --cleanup-guards --dry-run  # preview only
+```
+
+`--cleanup-guards` also clears any legacy `chattr +i` immutable flags left by older versions.
+
+### Network changes are applied with an auto-rollback
+
+If your restore scope includes the network category (FULL, SYSTEM BASE, or a CUSTOM selection, not STORAGE), ProxSave remaps interface names by hardware identity and applies the config with an armed auto-rollback: it arms a 180-second timer, reloads networking, and reverts automatically unless you confirm with `COMMIT` in time. Run that step from the local console or IPMI, not over SSH, since it can change the active IP. The firewall, HA, and access-control applies use the same armed 180-second rollback.
+
+### The safety backup
+
+Before overwriting anything, ProxSave writes a safety backup of the current configuration to `/tmp/proxsave/restore_backup_<YYYYMMDD_HHMMSS>.tar.gz` and keeps it. At the end it prints where it is and how to remove it:
+
+```
+Safety backup preserved at: /tmp/proxsave/restore_backup_20251120_143052.tar.gz
+Remove it manually if restore was successful: rm /tmp/proxsave/restore_backup_20251120_143052.tar.gz
+```
+
+If any staged step fails, the run ends with `Restore completed with warnings.` rather than aborting, and this safety backup is your rollback.
 
 ---
 
@@ -291,10 +361,7 @@ pvecm status
 #### Step 2: Run Restore Workflow
 
 ```bash
-# Navigate to proxsave directory
-cd /opt/proxsave
-
-# Run restore
+# Run restore (works from any directory)
 proxsave --restore
 ```
 
@@ -303,60 +370,70 @@ proxsave --restore
 ```
 Select backup source:
   [1] Primary backup path
-→ Select: 1
+Select: 1
 
 Available backups:
   [1] backup-pve01-20251120-143052.bundle.tar
-→ Select: 1
+Select: 1
 
 Backup is encrypted with AGE.
 Enter AGE passphrase: ********
-→ Enter your passphrase
 
 Select restore mode:
-  [1] FULL restore
-  [2] STORAGE only    ← Recommended for cluster recovery
-  [3] SYSTEM BASE only
-  [4] CUSTOM selection
-→ Select: 2 (STORAGE only)
+  [1] FULL restore - Restore everything from backup
+  [2] STORAGE only - PVE cluster + storage + jobs + mounts
+  [3] SYSTEM BASE only - Network + SSL + SSH + services + filesystem
+  [4] CUSTOM selection - Choose specific categories
+  [0] Cancel
+Select: 2 (STORAGE only)
+```
 
+Because the backup contains cluster data, ProxSave now asks how to restore the cluster database (see [Cluster restore modes](#cluster-restore-modes-safe-vs-recovery)):
+
+```
+Cluster backup detected. Choose how to restore the cluster database:
+  [1] SAFE: Do NOT write /var/lib/pve-cluster/config.db. Export cluster files only (manual/apply via API).
+  [2] RECOVERY: Restore full cluster database (/var/lib/pve-cluster). Use only when cluster is offline/isolated.
+  [0] Exit
+Choice: 2 (RECOVERY)
+```
+
+For a standalone node you are rebuilding from backup, RECOVERY is the right choice: the node is offline and you want its exact database back. On a node that is already up and running, choose SAFE instead. The STORAGE-mode restore plan on a PVE host is:
+
+```
 RESTORE PLAN:
-  • PVE Cluster Configuration
-  • PVE Storage Configuration
-  • PVE Backup Jobs
-  • ZFS Configuration
+  - PVE Cluster Configuration
+  - PVE Storage Configuration
+  - PVE Backup Jobs
+  - ZFS Configuration
+  - Filesystem Configuration
+  - Storage Stack (Mounts/Targets)
 
-Type "RESTORE" to proceed: RESTORE
-→ Type: RESTORE
+Type RESTORE to proceed or 0 to cancel: RESTORE
 ```
 
-#### Step 4: Automated Process
+#### Step 4: Automated Process (RECOVERY)
+
+Because you chose RECOVERY, ProxSave restores config.db with the cluster services stopped. The real log is terse; the sequence is:
 
 ```
-Creating safety backup...
-✓ Safety backup: /tmp/proxsave/restore_backup_20251120_143052.tar.gz
+Selected RECOVERY cluster restore: full cluster database will be restored; ensure other nodes are isolated
 
-Preparing system for cluster database restore:
-  Stopping pve-cluster... ✓
-  Stopping pvedaemon... ✓
-  Stopping pveproxy... ✓
-  Stopping pvestatd... ✓
-  Unmounting /etc/pve... ✓
+Creating Safety backup of current configuration...
+Safety backup location: /tmp/proxsave/restore_backup_20251120_143052.tar.gz
 
-Extracting selected categories...
-✓ Restored 47 files/directories
+Preparing system for cluster database restore: stopping PVE services and unmounting /etc/pve
 
-Recreating storage directories...
-✓ Storage directories recreated
-
-Restarting services...
-✓ pve-cluster started
-✓ pvedaemon started
-✓ pveproxy started
-✓ pvestatd started
+... extraction of the selected categories ...
 
 Restore completed successfully.
+Safety backup preserved at: /tmp/proxsave/restore_backup_20251120_143052.tar.gz
+Remove it manually if restore was successful: rm /tmp/proxsave/restore_backup_20251120_143052.tar.gz
 ```
+
+ProxSave stops `pve-cluster`, `pvedaemon`, `pveproxy`, `pvestatd`, unmounts `/etc/pve`, extracts `/var/lib/pve-cluster/` (config.db), then restarts the four services. It does not print a per-service checkmark line for each one. No `/etc/pve` files are written directly: config.db owns them, so `/etc/pve` is repopulated from the restored database a moment after pmxcfs remounts, not by the file-extraction phase.
+
+Had you chosen SAFE, this step would instead apply the exported storage, datacenter, pool, and VM/CT configs through `pvesh` on the running cluster, with no service stop and no config.db write.
 
 #### Step 5: Verification
 
@@ -450,10 +527,11 @@ hostname
 # reboot
 
 # 2. Run restore (STORAGE or FULL mode)
-cd /opt/proxsave
 proxsave --restore
 # Select: [2] STORAGE only
-# This restores cluster config, storage, ZFS
+# At the cluster prompt choose RECOVERY: the primary is offline, so this
+# restores the full config.db. SAFE would apply configs via the API without
+# writing config.db, so the cluster/corosync state would not come back.
 
 # 3. Verify primary node working
 pvecm status
@@ -730,7 +808,6 @@ pvesm status
 
 ```bash
 # Use CUSTOM mode to restore only specific categories
-cd /opt/proxsave
 proxsave --restore
 
 # Select: [4] CUSTOM selection
@@ -744,7 +821,7 @@ proxsave --restore
 # Type "RESTORE" to proceed
 ```
 
-**Important**: Do NOT restore `pve_cluster` category - node is already in working cluster!
+**Important**: Never run a RECOVERY cluster restore on a node that is still in the cluster; it overwrites config.db and can corrupt the cluster. The conservative choice is to leave `PVE Cluster Configuration` unselected here. If you do select it, ProxSave prompts SAFE vs RECOVERY, and on a live member SAFE is the only correct answer (it applies configs via the API and never writes config.db).
 
 #### Step 6: Migrate VMs/CTs to Replacement Node
 
@@ -814,8 +891,7 @@ pvecm add <working-node-ip>
 
 ```bash
 # 1. Create fresh backup
-cd /opt/proxsave
-proxsave
+proxsave --backup
 
 # 2. Document configuration
 pvecm status > /root/old-cluster-status.txt
@@ -857,10 +933,11 @@ mkdir -p /opt/proxsave/backup
 mv /root/*.bundle.tar /opt/proxsave/backup/
 
 # 3. Run restore
-cd /opt/proxsave
 proxsave --restore
 
 # Select: [2] STORAGE only (or FULL)
+# At the cluster prompt choose RECOVERY: the old hardware is shut down, so
+# this node is offline/isolated and RECOVERY restores the full config.db.
 # Type "RESTORE" to confirm
 ```
 
@@ -983,7 +1060,6 @@ vi /etc/hosts
 reboot
 
 # 4. Run restore normally
-cd /opt/proxsave
 proxsave --restore
 ```
 
@@ -994,12 +1070,15 @@ proxsave --restore
 #### Step 1: Restore with Mismatched Hostname
 
 ```bash
-# Run restore (will work despite hostname mismatch)
-cd /opt/proxsave
+# Run restore (works despite the hostname mismatch)
 proxsave --restore
 
 # Select: [2] STORAGE only
-# Continue even though hostname differs
+# At the cluster prompt choose RECOVERY: this restores the backup's config.db,
+# which still references the OLD hostname. You fix those references in the
+# steps below. (If the node is already up and you would rather keep it running,
+# SAFE applies the configs via the API and auto-handles the VM/CT node-name
+# mismatch, which makes most of the manual fixes below unnecessary.)
 ```
 
 #### Step 2: Fix Corosync Configuration
@@ -1040,10 +1119,12 @@ systemctl restart pve-cluster pvedaemon pveproxy
 ls -la /etc/pve/nodes/
 # Will show old hostname directory
 
-# 2. The cluster filesystem should auto-create new hostname directory
-# But you may need to migrate configs:
+# 2. The cluster filesystem auto-creates the new hostname directory, but a
+# RECOVERY restore put the guest configs under the OLD node name.
 
-# 3. Copy node-specific configs (if needed)
+# 3. Copy the node-specific configs to the new node directory.
+# (Had you used SAFE instead, ProxSave would have re-created the VM/CT configs
+# on the current node automatically and this copy would not be needed.)
 cp -r /etc/pve/nodes/pve01/* /etc/pve/nodes/pve02/
 
 # 4. Verify new directory
@@ -1394,6 +1475,9 @@ systemctl restart pve-cluster
 ```
 
 **3. Permissions wrong**:
+
+ProxSave preserves each restored file's owner and mode from the backup archive, so it does not hardcode these. The following is manual Proxmox advice for the case where the ownership on `/var/lib/pve-cluster` is wrong for some other reason:
+
 ```bash
 chown -R root:www-data /var/lib/pve-cluster
 chmod 0640 /var/lib/pve-cluster/config.db
@@ -1774,6 +1858,4 @@ journalctl -u corosync              # Corosync logs
 2. Create additional backups
 3. Test procedure on non-production system
 4. Ask for help on Proxmox forums
-5. Better to be slow and safe than fast and corrupted
-
-Good luck with your recovery! 🍀
+5. Better to be slow and safe than fast and corrupted.

--- a/docs/COLLECTOR_ARCHITECTURE.md
+++ b/docs/COLLECTOR_ARCHITECTURE.md
@@ -43,15 +43,14 @@ not be reintroduced as hidden orchestration layers.
 
 ## Recipes
 
-The collector runtime is built from explicit recipes in
-`internal/backup/collector_bricks.go`.
+The collector runtime is built from explicit recipes. The recipe machinery and the
+brick IDs live in `internal/backup/collector_bricks.go`, but the per-role builders are
+split across files:
 
-The important builders are:
-
-- `newPVERecipe()`
-- `newPBSRecipe()`
-- `newDualRecipe()`
-- `newSystemRecipe()`
+- `newPVERecipe()` (`collector_bricks_pve.go`)
+- `newPBSRecipe()` (`collector_bricks_pbs.go`)
+- `newSystemRecipe()` (`collector_bricks_system.go`)
+- `newDualRecipe()` (`collector_bricks.go`)
 
 ### Composition Rules
 
@@ -118,6 +117,12 @@ PBS access control, notifications, remotes, jobs, tape, datastore state, and
 PXAR metadata are no longer handled by macro-wrappers. They are exposed as
 independent recipe bricks.
 
+`CollectPBSConfigs()` actually runs **two** recipes in sequence: `newPBSRecipe()`, then
+`newPBSUserConfigRecipe()`. The second is a follow-up that reads the PBS user IDs from
+the `user_list.json` snapshot captured by the first recipe and aggregates the per-user
+API token config, so token export runs as a distinct pass seeded by the earlier
+user-list.
+
 ## Dual Branch
 
 `CollectDualConfigs()` runs `newDualRecipe()` and collects both product roles in
@@ -171,20 +176,18 @@ Examples:
 
 ## Manifest and Metadata
 
-Two layers are important:
+Two layers are important, and they carry different fields:
 
-- collector manifest (`manifest.json`) written in the temp tree
-- backup metadata/sidecars written by the orchestrator/archive flow
-
-Current persisted role fields include:
-
-- `ProxmoxType`
-- `ProxmoxTargets`
-- `PVEVersion`
-- `PBSVersion`
-
-These fields are used later by restore for backup-type detection and category
-filtering.
+- The **collector manifest** (`manifest.json`, written in the temp tree) is the
+  pre-optimization collection inventory. Among role fields it carries only
+  `ProxmoxType` (`proxmox_type`) and `ProxmoxTargets` (`proxmox_targets`), plus per-file
+  entries. It is an ExportOnly diagnostic (category `proxsave_info`) and is **not read
+  back by restore**; the authoritative record of the shipped payload is the archive
+  sidecar (`<archive>.sha256` / `<archive>.manifest.json`) computed after archiving.
+- The **backup metadata sidecar**, written by the orchestrator, carries the role and
+  version fields restore actually uses: `BACKUP_TYPE`, `BACKUP_TARGETS`, and
+  `PVE_VERSION` / `PBS_VERSION` (from the orchestrator's `PVEVersion` / `PBSVersion`
+  stats). These drive backup-type detection and category filtering at restore time.
 
 ## Restore Relationship
 
@@ -216,9 +219,13 @@ real collector flow.
 ## Related Files
 
 - `internal/backup/collector.go`
-- `internal/backup/collector_bricks.go`
+- `internal/backup/collector_bricks.go` (recipe machinery, brick IDs, `newDualRecipe()`)
+- `internal/backup/collector_bricks_pve.go` (`newPVERecipe()`)
+- `internal/backup/collector_bricks_pbs.go` (`newPBSRecipe()`, `newPBSUserConfigRecipe()`)
+- `internal/backup/collector_bricks_system.go` (`newSystemRecipe()`)
+- `internal/backup/collector_pbs.go` (PBS branch: runs both PBS recipes)
 - `internal/backup/collector_dual.go`
 - `internal/backup/collector_manifest.go`
 - `internal/backup/collector_storage_stack_common.go`
 - `internal/environment/detect.go`
-- `internal/orchestrator/compatibility.go`
+- `internal/orchestrator/compatibility.go` (restore compatibility + metadata sidecar versions)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,6 +6,8 @@ Complete reference for all 200+ configuration variables in `configs/backup.env`.
 
 - [Configuration File Location](#configuration-file-location)
 - [General Settings](#general-settings)
+- [Scheduler engine](#scheduler-engine)
+- [Healthchecks connector (daemon)](#healthchecks-connector-daemon)
 - [Restore Behavior & Dual-Role Hosts](#restore-behavior--dual-role-hosts)
 - [Security Settings](#security-settings)
 - [Disk Space](#disk-space)
@@ -30,8 +32,8 @@ Complete reference for all 200+ configuration variables in `configs/backup.env`.
 
 ## Configuration File Location
 
-**Default**: `/opt/proxsave/configs/backup.env`
-**Custom**: Specify with `--config` flag
+**Default**: `configs/backup.env`, resolved under the detected install directory (`BASE_DIR`), so typically `/opt/proxsave/configs/backup.env`.
+**Custom**: specify with `--config`. An absolute path is used as-is; a relative path is joined onto the install directory, not the current working directory.
 
 ```bash
 # Use custom config file
@@ -69,6 +71,59 @@ PROFILING_ENABLED=true             # true | false (profiles written under /tmp/p
 | `standard` | Basic operation logging |
 | `advanced` | Detailed command execution, file operations |
 | `extreme` | Full verbose output including rclone/compression internals |
+
+At the config layer `standard` resolves to the `info` log level and both `advanced` and `extreme` resolve to `debug`. `--log-level` overrides `DEBUG_LEVEL` for a run (see [CLI_REFERENCE.md](CLI_REFERENCE.md)).
+
+---
+
+## Scheduler engine
+
+ProxSave runs the backup either from a cron entry or from a resident systemd daemon. The behavior is documented in [DAEMON.md](DAEMON.md); the keys are:
+
+```bash
+SCHEDULER_MODE=cron            # cron | daemon (any unrecognized value normalizes to cron)
+SCHEDULER_TIME=02:00           # daily HH:MM "Run at" time
+MAX_RUN_DURATION=6h            # daemon watchdog: hard timeout for one backup
+DAEMON_OPT_OUT=false           # set true by --daemon-remove; --upgrade won't re-migrate to the daemon
+```
+
+The compiled default for `SCHEDULER_MODE` is `cron`, but a fresh install defaults to the daemon and writes `SCHEDULER_MODE=daemon`.
+
+---
+
+## Healthchecks connector (daemon)
+
+The daemon can push to an external [healthchecks](https://healthchecks.io/) monitor. The four checks and the centralized-vs-self behavior are documented in [DAEMON.md](DAEMON.md); the keys are:
+
+```bash
+HEALTHCHECK_ENABLED=false      # forced true by --daemon-setup / --upgrade auto-migration
+HEALTHCHECK_MODE=centralized   # centralized (fetch URLs from the server) | self
+HEALTHCHECK_HEARTBEAT_INTERVAL=5m
+HEALTHCHECK_UPDATE_INTERVAL=5m
+HEALTHCHECK_SEND_LOG=true
+
+# Centralized cache (auto-filled from the server; do not edit)
+HEALTHCHECK_ALIVE_URL=
+HEALTHCHECK_BACKUP_URL=
+
+# Self mode
+HEALTHCHECK_PING_ENDPOINT=https://hc-ping.com
+HEALTHCHECK_PING_KEY=
+HEALTHCHECK_ALIVE_ID=
+HEALTHCHECK_BACKUP_ID=
+HEALTHCHECK_UPDATES_URL=
+HEALTHCHECK_UPDATES_ID=
+HEALTHCHECK_NOTIFY_EMAIL_URL=
+HEALTHCHECK_NOTIFY_EMAIL_ID=
+HEALTHCHECK_NOTIFY_TELEGRAM_URL=
+HEALTHCHECK_NOTIFY_TELEGRAM_ID=
+HEALTHCHECK_NOTIFY_GOTIFY_URL=
+HEALTHCHECK_NOTIFY_GOTIFY_ID=
+HEALTHCHECK_NOTIFY_WEBHOOK_URL=
+HEALTHCHECK_NOTIFY_WEBHOOK_ID=
+```
+
+`HEALTHCHECK_ENABLED` parses as `false` by default, but `--daemon-setup` and the `--upgrade` auto-migration force it to `true` when enabling the daemon.
 
 ---
 
@@ -280,6 +335,8 @@ MIN_DISK_SPACE_CLOUD_GB=1          # Cloud storage (not enforced for remote)
 
 **Behavior**: Backup aborts if available space < minimum threshold.
 
+**Defaults**: when a key is absent the compiled fallback is `10` GB, and any value `<= 0` is coerced to `10`. `MIN_DISK_SPACE_SECONDARY_GB` and `MIN_DISK_SPACE_CLOUD_GB` fall back to whatever `MIN_DISK_SPACE_PRIMARY_GB` resolves to. The `1` shown above is an example, not the fallback.
+
 ---
 
 ## Storage Paths
@@ -311,7 +368,7 @@ LOG_PATH=${BASE_DIR}/log
 
 ```bash
 # Compression algorithm
-COMPRESSION_TYPE=xz                # none | gzip | pigz | bzip2 | xz | lzma | zstd
+COMPRESSION_TYPE=xz                # none | gz | pigz | bz2 | xz | lzma | zst (gzip/bzip2/zstd accepted as aliases)
 
 # Compression level
 COMPRESSION_LEVEL=9                # Range depends on algorithm (see table below)
@@ -323,17 +380,19 @@ COMPRESSION_THREADS=0              # 0 = auto, >0 = fixed thread count
 COMPRESSION_MODE=ultra             # fast | standard | maximum | ultra
 ```
 
+The canonical algorithm values are the short forms `gz`, `pigz`, `bz2`, `xz`, `lzma`, `zst` (plus `none`); `gzip`, `bzip2`, and `zstd` are accepted as aliases. Compiled fallbacks when a key is absent are `COMPRESSION_TYPE=xz`, `COMPRESSION_LEVEL=6`, `COMPRESSION_MODE=standard`. The shipped template sets `9` / `ultra` (the values above), so a copied template compresses harder than the bare defaults.
+
 ### Compression Algorithm Details
 
 | Algorithm | Level Range | Notes |
 |-----------|-------------|-------|
 | `none` | 0 | No compression |
-| `gzip` | 1-9 | Single-threaded, widely compatible |
+| `gz` (alias `gzip`) | 1-9 | Single-threaded, widely compatible |
 | `pigz` | 1-9 | Parallel gzip, faster on multi-core |
-| `bzip2` | 1-9 | Higher compression, slower |
+| `bz2` (alias `bzip2`) | 1-9 | Higher compression, slower |
 | `xz` | 0-9 | Excellent compression, supports `--extreme` |
 | `lzma` | 0-9 | Similar to xz |
-| `zstd` | 1-22 | Fast, good compression (>19 uses `--ultra`) |
+| `zst` (alias `zstd`) | 1-22 | Fast, good compression (>19 uses `--ultra`) |
 
 ### Compression Modes
 
@@ -341,8 +400,8 @@ COMPRESSION_MODE=ultra             # fast | standard | maximum | ultra
 |------|-------------|
 | `fast` | Lower levels, faster execution |
 | `standard` | Balanced |
-| `maximum` | Level 9 for gzip/bzip2/xz, level 19 for zstd |
-| `ultra` | Adds `--extreme` for xz/lzma, level 22 for zstd |
+| `maximum` | Level 9 for gz/bz2/xz, level 19 for zst |
+| `ultra` | Adds `--extreme` for xz/lzma, level 22 for zst |
 
 ### Examples
 
@@ -386,7 +445,7 @@ PREFILTER_MAX_FILE_SIZE_MB=8       # Skip prefilter for files >8MB
 - **Deduplication**: Detects duplicate data blocks (reduces storage)
 - **Prefilter**: Applies safe, semantic-preserving normalization to small text/JSON files to improve compression (e.g. removes CR from CRLF line endings and minifies JSON). It does **not** reorder, de-indent, or strip structured configuration files, and it avoids touching Proxmox/PBS structured config paths (e.g. `etc/pve/**`, `etc/proxmox-backup/**`).
 
-### Prefilter (`ENABLE_PREFILTER`) — details and risks
+### Prefilter (`ENABLE_PREFILTER`): details and risks
 
 **What it does** (on the *staged* backup tree, before compression):
 - Removes `\r` from CRLF text files (`.txt`, `.log`, `.md`, `.conf`, `.cfg`, `.ini`) to normalize line endings
@@ -406,7 +465,7 @@ PREFILTER_MAX_FILE_SIZE_MB=8       # Skip prefilter for files >8MB
 - If you need maximum fidelity (bit-for-bit) of text/JSON formatting as originally collected (CRLF preservation, JSON pretty-printing, etc.)
 - If you prefer the most conservative pipeline possible (forensics/compliance)
 
-**Important**: Prefilter never edits files on the host system — it only operates on the temporary staging directory that will be archived.
+**Important**: Prefilter never edits files on the host system; it only operates on the temporary staging directory that will be archived.
 
 ---
 
@@ -658,10 +717,10 @@ RCLONE_TIMEOUT_CONNECTION=30       # Remote accessibility check (also used as pe
 RCLONE_TIMEOUT_OPERATION=300       # Upload/download operations (5 minutes default)
 
 # Bandwidth limit
-RCLONE_BANDWIDTH_LIMIT=            # Empty = unlimited, "10M" = 10 MB/s
+RCLONE_BANDWIDTH_LIMIT=            # empty = unlimited (compiled default); the template ships "10M"
 
 # Parallel transfers inside rclone
-RCLONE_TRANSFERS=16                # Number of simultaneous file transfers
+RCLONE_TRANSFERS=16                # simultaneous transfers (compiled fallback 4; the template ships 16)
 
 # Retry attempts
 RCLONE_RETRIES=3                   # Retry count for failed operations
@@ -751,6 +810,8 @@ MAX_CLOUD_BACKUPS=15               # Cloud storage
 
 **Example**: With `MAX_LOCAL_BACKUPS=30` and daily backups, keeps last 30 days.
 
+**Compiled fallbacks** (when a key is absent): `MAX_LOCAL_BACKUPS=7`, `MAX_SECONDARY_BACKUPS=14`, `MAX_CLOUD_BACKUPS=30`. The shipped template sets all three to `15` (the values above).
+
 ### 2. GFS Retention (Grandfather-Father-Son)
 
 ```bash
@@ -763,6 +824,8 @@ RETENTION_WEEKLY=4                 # Keep 4 weekly backups (1 per ISO week)
 RETENTION_MONTHLY=12               # Keep 12 monthly backups (1 per month)
 RETENTION_YEARLY=3                 # Keep 3 yearly backups (1 per year)
 ```
+
+**Compiled fallbacks** are all `0`: GFS keeps nothing until you set `RETENTION_POLICY=gfs` and at least one tier. The `7/4/12/3` above are example/template values, not the defaults. `RETENTION_DAILY` is forced to at least `1` (0 is treated as 1).
 
 ### GFS Algorithm
 
@@ -845,6 +908,11 @@ BOT_TELEGRAM_TYPE=centralized      # centralized | personal
 # Personal mode settings
 TELEGRAM_BOT_TOKEN=                # Bot token (from @BotFather)
 TELEGRAM_CHAT_ID=                  # Chat ID (your user ID or group ID)
+
+# Two-response delivery confirmation
+TELEGRAM_CONFIRM_DELIVERY=true     # poll the relay to confirm delivery after sending
+TELEGRAM_CONFIRM_TIMEOUT_SECONDS=10
+TELEGRAM_CONFIRM_INTERVAL_SECONDS=1
 ```
 
 **Bot types**:
@@ -906,7 +974,7 @@ The value `pmf` may also be written as `proxmox`, `proxmox-notifications`, or `p
 **Notes**:
 - Allowed values for `EMAIL_DELIVERY_METHOD` are: `pmf`, `relay`, `sendmail` (invalid values will skip Email with a warning).
 - `EMAIL_FALLBACK_SENDMAIL=true` controls local `/usr/sbin/sendmail` failover. `EMAIL_FALLBACK_PMF` is accepted only as a transitional alias from older templates.
-- `relay` requires a real mailbox recipient and blocks `root@…` recipients; set `EMAIL_RECIPIENT` to a non-root mailbox if needed.
+- `relay` requires a real mailbox recipient and blocks `root@` recipients; set `EMAIL_RECIPIENT` to a non-root mailbox if needed.
 - Default install behavior is `relay -> sendmail`.
 - If you manually set `EMAIL_DELIVERY_METHOD=pmf`, fallback order is `pmf -> relay -> sendmail` when `EMAIL_FALLBACK_SENDMAIL=true`.
 - When logs say the relay "accepted request", it means the worker and upstream email API accepted the submission. It does **not** guarantee final inbox delivery (the message may still bounce, be deferred, or land in spam later).
@@ -1057,7 +1125,7 @@ CEPH_CONFIG_PATH=/etc/ceph         # Ceph config directory
 BACKUP_VM_CONFIGS=true             # VM/CT config files
 ```
 
-**Note (PVE snapshot behavior)**: ProxSave snapshots `PVE_CONFIG_PATH` for completeness. When a PVE feature is disabled, proxsave also excludes its well-known files from that snapshot to avoid “still included via full directory copy” surprises (e.g. `qemu-server/` + `lxc/` for `BACKUP_VM_CONFIGS=false`, `firewall/` + `host.fw` for `BACKUP_PVE_FIREWALL=false`, `user.cfg`/`domains.cfg` plus the credential files `priv/shadow.cfg`/`priv/token.cfg`/`priv/tfa.cfg` for `BACKUP_PVE_ACL=false` (ACLs are stored in `user.cfg` on PVE), `jobs.cfg` + `vzdump.cron` for `BACKUP_PVE_JOBS=false`, `corosync.conf` (and `config.db` capture) for `BACKUP_CLUSTER_CONFIG=false`).
+**Note (PVE snapshot behavior)**: ProxSave snapshots `PVE_CONFIG_PATH` for completeness. When a PVE feature is disabled, proxsave also excludes its well-known files from that snapshot to avoid "still included via full directory copy" surprises (e.g. `qemu-server/` + `lxc/` for `BACKUP_VM_CONFIGS=false`, `firewall/` + `host.fw` for `BACKUP_PVE_FIREWALL=false`, `user.cfg`/`domains.cfg` plus the credential files `priv/shadow.cfg`/`priv/token.cfg`/`priv/tfa.cfg` for `BACKUP_PVE_ACL=false` (ACLs are stored in `user.cfg` on PVE), `jobs.cfg` + `vzdump.cron` for `BACKUP_PVE_JOBS=false`, `corosync.conf` (and `config.db` capture) for `BACKUP_CLUSTER_CONFIG=false`).
 
 > **Security note**: `/etc/pve` is a pmxcfs mount backed by the cluster database `config.db`. Setting `BACKUP_PVE_ACL=false` removes the flat `priv/*` credential files from the snapshot, but the same secrets remain inside `config.db` (captured when `BACKUP_CLUSTER_CONFIG=true`). To exclude PVE access-control secrets from the backup entirely, set both `BACKUP_PVE_ACL=false` and `BACKUP_CLUSTER_CONFIG=false`. ProxSave logs a WARNING during backup when this combination leaves secrets in `config.db`.
 
@@ -1138,7 +1206,7 @@ SYSTEM_ROOT_PREFIX=                # Optional alternate root for system collecti
 # Use this to point the collector at a chroot/test fixture without touching the host FS.
 ```
 
-**Note**: `${PVE_CONFIG_PATH}` (and other `${VAR}` references) are resolved from the same `backup.env` file too — you don’t need to `export` them.
+**Note**: `${PVE_CONFIG_PATH}` (and other `${VAR}` references) are resolved from the same `backup.env` file too, so you do not need to `export` them.
 
 **Use case**: Working with mounted snapshots or mirrors at non-standard paths.
 
@@ -1196,7 +1264,7 @@ BACKUP_SCRIPT_REPOSITORY=false     # Snapshot the ProxSave install dir (excludes
 BACKUP_CONFIG_FILE=true            # Include this backup.env configuration file in the backup
 ```
 
-**Note (SSH keys)**: `BACKUP_SSH_KEYS=false` also suppresses `.ssh/` directories when collecting home directories (root and users), so keys aren’t included indirectly via `BACKUP_ROOT_HOME`/home collection.
+**Note (SSH keys)**: `BACKUP_SSH_KEYS=false` also suppresses `.ssh/` directories when collecting home directories (root and users), so keys are not included indirectly via `BACKUP_ROOT_HOME`/home collection.
 
 **Note**: `BACKUP_CONFIG_FILE=true` automatically includes the `configs/backup.env` file in the backup archive. This is highly recommended for disaster recovery, as it allows you to restore your exact backup configuration along with the system files. If you have sensitive credentials in `backup.env`, ensure your backups are encrypted (`ENCRYPT_ARCHIVE=true`).
 

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -1,97 +1,171 @@
 # Resident daemon + healthchecks monitoring
 
-ProxSave can run as a **resident daemon** instead of a one-shot `cron` job. The
-daemon schedules and supervises each backup, adds a hang watchdog, and reports two
-signals to a [healthchecks](https://healthchecks.io/) monitor so silent failures
-(a crash before notifying, a run that hangs, a host that is simply down) are
-caught by an external dead-man switch.
+ProxSave can run as a **resident daemon** instead of a one-shot `cron` job. The daemon schedules and supervises each backup, adds a hang watchdog, and reports to an external [healthchecks](https://healthchecks.io/) monitor so silent failures (a crash before notifying, a run that hangs, a host that is simply down) are caught by an external dead-man switch.
 
 ## Why
 
-A pure "notify only on failure" model is blind to the worst failures: the process
-cannot speak when it panics, is OOM-killed, hangs, or never starts. The daemon
-solves this by pushing to an **external** monitor that alarms on *silence*.
+A pure "notify only on failure" model is blind to the worst failures: the process cannot speak when it panics, is OOM-killed, hangs, or never starts. The daemon pushes to an **external** monitor that alarms on *silence*, so those cases are still caught.
 
 ## What it does
 
-- **Schedules** the daily backup itself (replacing the crontab entry) at the
-  `SCHEDULER_TIME` ("Run at") time.
-- **Supervises** each run as a child process under a `MAX_RUN_DURATION` timeout. A
-  run that overruns is sent `SIGTERM`, then `SIGKILL`, and reported as a **hang**.
-- **Reports** two independent checks:
-  - `proxsave-alive` - a heartbeat every `HEALTHCHECK_HEARTBEAT_INTERVAL`; if the
-    daemon dies or the host goes down, this check goes down.
-  - `proxsave-backup` - per run: `/start`, then the exit status (`/0` success,
-    `/1` warning **alerts**, `/<code>` on error with a log tail), or `/fail` on a
-    hang.
+- **Schedules** the daily backup itself (replacing the crontab entry) at the `SCHEDULER_TIME` ("Run at") time.
+- **Supervises** each run as a child process (`proxsave --backup`) under a `MAX_RUN_DURATION` timeout. A run that overruns gets `SIGTERM`, then `SIGKILL` after a 30-second grace, and is reported as a **hang**.
+- **Reports** four kinds of monitored checks (see below). systemd (`proxsave-daemon.service`, `Restart=always`) is only the keep-alive supervisor; the daemon schedules internally.
 
-systemd (`proxsave-daemon.service`, `Restart=always`) is only the keep-alive
-supervisor; the daemon schedules internally.
+## The monitored checks
+
+The daemon reports **four** check families to the monitor, each shown as a `proxsave-*` check:
+
+| Check | When it pings | Meaning |
+|-------|---------------|---------|
+| `proxsave-alive` | a heartbeat every `HEALTHCHECK_HEARTBEAT_INTERVAL` (and once at startup) | if the daemon dies or the host goes down, this check stops pinging and the monitor alarms on the silence |
+| `proxsave-backup` | per run: `/start` at launch, then the child's exit code, or `/fail` on a hang | `/0` is success (green); any non-zero exit code makes the check go DOWN (red); `/fail` is the hang case |
+| `proxsave-updates` | every `HEALTHCHECK_UPDATE_INTERVAL` (and once at startup) | `/0` when up to date, `/1` when a newer release exists (the check goes DOWN so you get alerted to upgrade) |
+| `proxsave-notify-<channel>` | after each run, one per channel the backup child attempted | `/0` when that channel delivered cleanly, `/1` on a warning or error (the check goes DOWN) |
+
+Notes on the exact semantics:
+
+- The `proxsave-backup` finish ping is always `/` plus the run's exit status (clamped to 0..255). There is no separate "warning" suffix: exit `1` simply pings `/1`, and a start failure or an external kill is reported as a non-zero code too. When `HEALTHCHECK_SEND_LOG` is on, a bounded log tail (up to about 8 KiB) rides along as the request body on a **supervised** run's non-zero exit or hang. A standalone (manual or dashboard) backup hands off only its exit code, so its finish ping carries no log tail.
+- The `proxsave-updates` check only flips to `/0` on a definite up-to-date answer. An inconclusive check (GitHub unreachable or rate-limited) re-affirms the last verdict rather than flapping a real `/1` back to `/0`.
+- The `proxsave-notify-<channel>` checks are driven by what the backup child actually attempted (recorded per run), not by cached config, so a channel toggled off does not leave a stale DOWN.
+- One notify check exists per enabled channel among email, telegram, gotify, and webhook. In centralized mode the daemon tells the server which channels are enabled so it provisions exactly those checks.
+
+### BACKUP_ENABLED=false
+
+When `BACKUP_ENABLED=false`, the daemon skips the scheduled run entirely: no child process, no backup-outcome ping, so `proxsave-backup` honestly goes down (no false green). The `proxsave-alive` heartbeat keeps signalling, so you can still tell the daemon is up.
+
+## Standalone backups: the SIGUSR1 handoff
+
+A backup run outside the daemon (by hand, or the dashboard "run now") does not ping the monitor itself. The resident daemon is the sole pinger. Instead, a standalone run drops a handoff file (`.manual_backup_outcome.json`) and wakes the daemon with `SIGUSR1`; the daemon then pings `proxsave-backup` with that run's outcome. A handoff older than 15 minutes is dropped without pinging (so a long-past run never flips the check), and if no live daemon is found nothing pings.
 
 ## Two modes
 
-- **centralized** (default): the daemon fetches its two ping URLs from the
-  ProxSave server (`GET /api/healthcheck/config`), reusing the SAME identity it
-  already uses for Telegram notifications (`server_id` + relay secret). No manual
-  setup, no API key on the client. Requires the client to have been paired on
-  Telegram (that is where the relay secret comes from). The portal login link is
-  delivered separately on the notification responses.
-- **self**: point the daemon at your own healthchecks (self-hosted or SaaS) by
-  setting `HEALTHCHECK_PING_ENDPOINT` (+ optional `HEALTHCHECK_PING_KEY`) and the
-  two check IDs `HEALTHCHECK_ALIVE_ID` / `HEALTHCHECK_BACKUP_ID`.
+- **centralized** (default): the daemon fetches its ping URLs from the ProxSave server (`GET /api/healthcheck/config`), reusing the SAME identity it already uses for Telegram notifications (`server_id` + relay secret). No manual setup, no API key on the client. It requires the client to have been paired on Telegram (that is where the relay secret comes from). If the fetch fails, the daemon falls back to the cached `HEALTHCHECK_ALIVE_URL` / `HEALTHCHECK_BACKUP_URL`.
+- **self**: point the daemon at your own healthchecks (self-hosted or SaaS). Set `HEALTHCHECK_PING_ENDPOINT` (plus optional `HEALTHCHECK_PING_KEY`) and the per-check IDs, or give full per-check URLs. Self mode covers all four check families: `*_ALIVE_*`, `*_BACKUP_*`, `*_UPDATES_*`, and the `*_NOTIFY_<CHANNEL>_*` keys (a URL and an ID per channel). A full `*_URL` takes precedence over the matching `*_ID`.
 
-A client without a relay secret still gets the daemon (scheduling + hang
-watchdog); the healthcheck reporting stays off until `self` mode is configured.
+A client without a relay secret still gets the daemon (scheduling + hang watchdog); the healthcheck reporting stays off until `self` mode is configured.
 
-## Install
+## Binary alignment after an upgrade
 
-New installs default to the daemon. The install wizard (TUI and `--cli`) asks for
-the **Scheduler engine** (daemon or cron) just before the **Run at** time, in the
-same screen as the storage/notification settings. Choosing the daemon installs
-`proxsave-daemon.service`, removes the cron entry, and enables centralized
-healthchecks.
+An in-place `--upgrade` replaces the on-disk binary without restarting the resident daemon, so the daemon can keep running the **old** code (systemd keeps the old process alive). ProxSave detects this hash-free: Linux blocks overwriting a running executable, so an upgrade unlinks it and `/proc/<pid>/exe` ends in `" (deleted)"`, which alone proves the daemon is behind.
 
-## Retrofit existing installs
-
-- `--upgrade` **auto-migrates** a cron install to the daemon after updating the
-  binary and config (unless you opted out - see below). Idempotent; a migration
-  failure leaves you on cron.
-- `--daemon-setup` switches to the daemon at any time.
-- `--daemon-remove` reverts to cron, disables the service, and sets
-  `DAEMON_OPT_OUT=true` so later upgrades will **not** reinstall the daemon.
-
-## Configuration keys (`backup.env`)
-
-```
-SCHEDULER_MODE=cron            # cron | daemon
-SCHEDULER_TIME=02:00           # daily HH:MM ("Run at"), daemon mode
-MAX_RUN_DURATION=6h            # watchdog hard timeout for one backup
-DAEMON_OPT_OUT=false           # set true by --daemon-remove; upgrade won't re-migrate
-
-HEALTHCHECK_ENABLED=false
-HEALTHCHECK_MODE=centralized   # centralized (fetch from server) | self
-HEALTHCHECK_HEARTBEAT_INTERVAL=5m
-HEALTHCHECK_SEND_LOG=true
-HEALTHCHECK_ALIVE_URL=         # centralized cache (auto-filled; do not edit)
-HEALTHCHECK_BACKUP_URL=        # centralized cache (auto-filled; do not edit)
-HEALTHCHECK_PING_ENDPOINT=https://hc-ping.com   # self mode
-HEALTHCHECK_PING_KEY=          # self mode
-HEALTHCHECK_ALIVE_ID=          # self mode
-HEALTHCHECK_BACKUP_ID=         # self mode
-```
+`--upgrade`, `--daemon-setup`, and the dashboard reconcile this with a restart-and-verify: they wait (bounded, up to 4 minutes) for any in-progress daemon-supervised backup to finish (deferring the restart, never killing the backup), restart the service, then poll until the daemon is back, aligned, and freshly started. `--daemon-status` reports the same `behind - restart needed` verdict.
 
 ## Operating
 
 ```bash
-systemctl status proxsave-daemon.service      # is it running?
-journalctl -u proxsave-daemon.service -f      # follow its log
-proxsave --daemon-remove                       # back to cron
-proxsave --daemon-setup                        # back to the daemon
+proxsave --daemon-status                       # read-only status + exit code (see below)
+systemctl status proxsave-daemon.service       # is it running?
+journalctl -u proxsave-daemon.service -f       # follow its log
+proxsave --daemon-setup                        # switch to the daemon
+proxsave --daemon-remove                       # revert to cron
 ```
+
+`proxsave --daemon-status` prints a combined verdict and is meant for scripts:
+
+```
+Daemon status: <keyword>
+Scheduler mode: <cron|daemon>
+Daemon service (proxsave-daemon.service): installed | not installed
+Service state (systemctl is-active): <active|inactive|...>
+Opted out of auto-migration (--daemon-remove): yes | no
+Running version: <version> (<commit>)
+Binary alignment: aligned | BEHIND (restart needed) | unknown
+```
+
+The last two lines (`Running version:` and `Binary alignment:`) appear only when a running daemon and its identity record are available; they are omitted when the daemon is not installed or not running. It exits `0` **only** when the daemon is running, beating, and aligned; every gap (not installed, not running, stale, running but not reporting, or behind) exits non-zero, so `proxsave --daemon-status` can gate a script. It cannot be combined with `--daemon`, `--daemon-setup`, or `--daemon-remove`.
+
+## Install
+
+New installs default to the daemon. The install wizard (TUI and `--cli`) asks for the **Scheduler engine** (daemon or cron) just before the **Run at** time. Choosing the daemon installs `proxsave-daemon.service`, removes the cron entry, and turns on centralized healthchecks.
+
+## Retrofit existing installs
+
+- `--upgrade` **auto-migrates** a cron install to the daemon after updating the binary and config, unless you opted out (see `--daemon-remove`). It is idempotent; a migration failure leaves you on cron.
+- `--daemon-setup` switches to the daemon at any time. It installs the service, removes the cron entry, writes `SCHEDULER_MODE=daemon`, `DAEMON_OPT_OUT=false`, and `HEALTHCHECK_ENABLED=true`, then restarts and verifies the daemon.
+- `--daemon-remove` reverts to cron, disables the service, and sets `DAEMON_OPT_OUT=true` so later upgrades will **not** reinstall the daemon.
+
+Enabling the daemon forces `HEALTHCHECK_ENABLED=true` even though its raw config default is `false`, so a retrofitted host gets the dead-man switch.
+
+## systemd unit
+
+`proxsave-daemon.service` at `/etc/systemd/system/proxsave-daemon.service`:
+
+```ini
+[Unit]
+Description=ProxSave backup daemon
+Documentation=https://github.com/tis24dev/proxsave
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/proxsave --daemon --config <backup.env path>
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ExecStart` pins the same `backup.env` the install resolved (via `--config`), so the exact path in the generated unit is your install's config path.
+
+## On-disk state files
+
+The daemon coordinates through five small files under `<BASE_DIR>/identity/`, all written atomically (temp file then rename, mode `0600`) and deliberately not made immutable so they can be rewritten:
+
+| File | Purpose |
+|------|---------|
+| `.daemon.pid` | the daemon's PID; the contract a standalone backup reads to send `SIGUSR1` |
+| `.daemon_info.json` | the running daemon's identity (pid, exec path, version, commit, start time), for display and the restart-verify freshness check |
+| `.healthcheck_status.json` | the last ping outcome per check, read back by the run phase to report real transmission; a corrupt file is quarantined to `.corrupt` and reset |
+| `.notify_results.json` | the backup child's per-channel notification severities, handed to the daemon to drive the `proxsave-notify-*` pings |
+| `.manual_backup_outcome.json` | a standalone run's outcome, handed off for the daemon to ping |
+
+`.daemon.pid` and `.daemon_info.json` are written at startup and removed on shutdown.
+
+## Configuration keys (`backup.env`)
+
+```
+# Scheduler engine
+SCHEDULER_MODE=cron            # cron | daemon
+SCHEDULER_TIME=02:00           # daily HH:MM ("Run at")
+MAX_RUN_DURATION=6h            # watchdog hard timeout for one backup
+DAEMON_OPT_OUT=false           # set true by --daemon-remove; upgrade won't re-migrate
+BACKUP_ENABLED=true            # false: daemon skips the scheduled run (backup check goes down)
+
+# Healthchecks
+HEALTHCHECK_ENABLED=false      # forced true by --daemon-setup / auto-migration
+HEALTHCHECK_MODE=centralized   # centralized (fetch from server) | self
+HEALTHCHECK_HEARTBEAT_INTERVAL=5m
+HEALTHCHECK_UPDATE_INTERVAL=5m
+HEALTHCHECK_SEND_LOG=true      # attach a log tail on a failed/hung run
+
+# Centralized cache (auto-filled from the server; do not edit)
+HEALTHCHECK_ALIVE_URL=
+HEALTHCHECK_BACKUP_URL=
+
+# Self mode
+HEALTHCHECK_PING_ENDPOINT=https://hc-ping.com
+HEALTHCHECK_PING_KEY=
+HEALTHCHECK_ALIVE_ID=
+HEALTHCHECK_BACKUP_ID=
+HEALTHCHECK_UPDATES_URL=
+HEALTHCHECK_UPDATES_ID=
+HEALTHCHECK_NOTIFY_EMAIL_URL=
+HEALTHCHECK_NOTIFY_EMAIL_ID=
+HEALTHCHECK_NOTIFY_TELEGRAM_URL=
+HEALTHCHECK_NOTIFY_TELEGRAM_ID=
+HEALTHCHECK_NOTIFY_GOTIFY_URL=
+HEALTHCHECK_NOTIFY_GOTIFY_ID=
+HEALTHCHECK_NOTIFY_WEBHOOK_URL=
+HEALTHCHECK_NOTIFY_WEBHOOK_ID=
+```
+
+In self mode you only need the checks you actually want: set the endpoint plus the alive and backup IDs to get the two core checks, and add the updates and per-channel notify IDs (or full URLs) to report those too. In centralized mode the server resolves all of these for you.
+
+See [CONFIGURATION.md](CONFIGURATION.md) for the full variable reference and [CLI_REFERENCE.md](CLI_REFERENCE.md) for the `--daemon-*` flags.
 
 ## Caveat: uninterruptible sleep (D state)
 
-A backup child wedged in uninterruptible sleep on a dead mount cannot be killed
-even with `SIGKILL` (a kernel limit). The daemon still **reports the hang and
-moves on**, and the monitor's server-side `/start` + grace catches it too; the
-`FS_IO_TIMEOUT` / `safefs` defenses are the layer below this watchdog.
+A backup child wedged in uninterruptible sleep on a dead mount cannot be killed even with `SIGKILL` (a kernel limit). The daemon still **reports the hang and moves on**, and the monitor's server-side `/start` plus grace catches it too; the `FS_IO_TIMEOUT` / `safefs` defenses are the layer below this watchdog.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -30,7 +30,7 @@ Proxsave is built with modern Go practices, emphasizing:
 - **Language**: Go 1.25+
 - **Dependencies**: See `go.mod` for complete list
 - **Build system**: Makefile + Go modules
-- **Compression**: xz, zstd, gzip, bzip2, lz4
+- **Compression**: gzip, bzip2, xz, lzma, zstd
 - **Encryption**: AGE (age-encryption.org)
 - **Cloud storage**: rclone integration
 
@@ -98,33 +98,50 @@ go test ./...
 ```
 proxsave/
 ├── cmd/
-│   └── proxsave/              # Main entry point
+│   └── proxsave/              # Main entry point, CLI commands, and the resident daemon (daemon*.go)
 ├── internal/                  # Private application code
-│   ├── backup/                # Archiving, manifests, checksums
-│   ├── checks/                # Dependency/system checks
-│   ├── cli/                   # CLI argument parsing
-│   ├── config/                # Configuration management + templates
-│   ├── environment/           # Environment detection
-│   ├── identity/              # Identity helpers
-│   ├── logging/               # Logging
+│   ├── backup/                # Collector recipes/bricks, archiving, compression, manifests, checksums
+│   ├── checks/                # Dependency and system checks
+│   ├── cli/                   # CLI argument parsing (stdlib flag)
+│   ├── closeerr/              # Deferred-close error helpers
+│   ├── config/                # Configuration management and embedded template
+│   ├── cron/                  # Cron scheduler integration
+│   ├── environment/           # PVE/PBS environment detection
+│   ├── health/                # Healthchecks monitoring and daemon reporting
+│   ├── identity/              # Server identity and relay-secret provisioning
+│   ├── input/                 # Interactive input helpers
+│   ├── installer/             # Install and upgrade flows
+│   ├── lint/                  # Internal static-analysis helpers
+│   ├── logging/               # Logging and secret redaction
 │   ├── metrics/               # Prometheus metrics export
 │   ├── notify/                # Notification channels (Telegram/Email/Gotify/Webhook)
-│   ├── orchestrator/          # Backup/restore workflows
+│   ├── orchestrator/          # Backup and restore workflows (the restore engine lives here)
 │   ├── pbs/                   # PBS helpers
-│   ├── security/              # Security checks, permissions
+│   ├── safeexec/              # Guarded external-command execution
+│   ├── safefs/                # Filesystem-safety guards (I/O timeouts, mount checks)
+│   ├── security/              # Security checks and permissions
+│   ├── serverbot/             # Leaf transport to the centralized bot-server
 │   ├── storage/               # Storage backends (local/secondary/cloud)
-│   ├── tui/                   # TUI wizards
+│   ├── support/               # Support-bundle helpers
+│   ├── testutil/              # Shared test utilities
 │   ├── types/                 # Shared types
+│   ├── ui/                    # Charm (bubbletea) TUI: dashboard, wizards, forms
+│   ├── uitest/                # Race-aware UI test helpers
 │   └── version/               # Version info
-├── pkg/                       # Shared helper packages for Proxsave (not an implicit stable external API)
+├── pkg/                       # Shared helper packages (bech32, utils); not an implicit stable external API
 ├── build/                     # Build artifacts (binary output)
-├── configs/                   # Configuration files
 ├── docs/                      # Documentation
 ├── go.mod                     # Go module definition
 ├── go.sum                     # Dependency checksums
 ├── Makefile                   # Build automation
-└── README.md                  # Main documentation
+└── README.md                  # Minimal root readme (see docs/ for the full set)
 ```
+
+The live `backup.env` is not in the source tree. The configuration template is
+embedded in the binary (`internal/config`) and the working config is created under
+the install base dir at install time (see [INSTALL.md](INSTALL.md)). The UI stack is
+Charm (`charm.land/bubbletea/v2` and friends); the legacy `tview`/`tcell` stack was
+removed and a `make lint` guard (`check-no-tview`) keeps it out.
 
 ### Key Modules
 
@@ -133,8 +150,11 @@ proxsave/
 | **orchestrator** | Core backup/restore orchestration and capability-based restore decisions | `internal/orchestrator/*.go` |
 | **config** | Configuration management | `internal/config/config.go` |
 | **storage** | Local/secondary/cloud storage | `internal/storage/*.go` |
-| **backup** | Collector recipes/bricks, archiving, manifest/checksum helpers | `internal/backup/*.go` |
-| **notify** | Notification channels | `internal/notify/*.go` |
+| **backup** | Collector recipes/bricks, archiving, compression, manifest/checksum helpers | `internal/backup/*.go` |
+| **notify** | Notification channels (see [NOTIFICATIONS.md](NOTIFICATIONS.md)) | `internal/notify/*.go` |
+| **serverbot** | Leaf transport to the centralized bot-server (see [NOTIFICATIONS.md](NOTIFICATIONS.md)) | `internal/serverbot/*.go` |
+| **health** | Healthchecks monitoring; the resident daemon lives in `cmd/proxsave/daemon*.go` (see [DAEMON.md](DAEMON.md)) | `internal/health/*.go` |
+| **ui** | Charm (bubbletea) TUI: dashboard, wizards, forms (see [DASHBOARD_TUI.md](DASHBOARD_TUI.md)) | `internal/ui/*.go` |
 | **security** | Security checks, permissions | `internal/security/*.go` |
 
 ---
@@ -255,6 +275,20 @@ go tool cover -func=coverage.out
 go tool cover -html=coverage.out -o coverage.html
 ```
 
+The Makefile wraps these with a pinned toolchain:
+
+```bash
+# Coverage profile + HTML (opens coverage.out)
+make test-coverage
+
+# Full coverage report across all packages (prints the total)
+make coverage
+
+# Enforce a minimum total coverage (default 50%, override COVERAGE_THRESHOLD)
+make coverage-check
+make coverage-check COVERAGE_THRESHOLD=60.0
+```
+
 ### Benchmark Tests
 
 ```bash
@@ -264,22 +298,27 @@ go test -bench=. ./...
 # Benchmark with memory stats
 go test -bench=. -benchmem ./...
 
-# Benchmark specific function
-go test -bench=BenchmarkCompression ./internal/compression
+# Benchmark a specific package (compression lives in internal/backup)
+go test -bench=. ./internal/backup
 ```
 
 ---
 
 ## Dependency Management
 
+The CLI is built on the standard library `flag` package, not a third-party
+framework. The real direct dependencies are the Charm TUI stack
+(`charm.land/bubbletea/v2`, `charm.land/bubbles/v2`, `charm.land/lipgloss/v2`) and
+`filippo.io/age` for encryption; see `go.mod` for the full list.
+
 ### Add Dependency
 
 ```bash
-# Add new dependency
-go get github.com/spf13/cobra@latest
+# Add a new dependency (example)
+go get filippo.io/age@latest
 
-# Add specific version
-go get github.com/spf13/cobra@v1.8.0
+# Add a specific version
+go get filippo.io/age@v1.3.1
 
 # Tidy up (remove unused, add missing)
 go mod tidy
@@ -292,7 +331,7 @@ go mod tidy
 go get -u ./...
 
 # Update specific dependency
-go get -u github.com/spf13/cobra
+go get -u filippo.io/age
 
 # Tidy after updates
 go mod tidy
@@ -328,11 +367,24 @@ go build -mod=vendor -o build/proxsave ./cmd/proxsave
 ### Go Best Practices
 
 - **Follow [Effective Go](https://golang.org/doc/effective_go.html)**
-- **Use `gofmt`** for formatting (automatic with `go fmt`)
-- **Run `golangci-lint`** before committing
+- **Use `gofmt`** for formatting (automatic with `go fmt` or `make fmt`)
+- **Run `make lint`** before committing (see the structural guards below)
 - **Write godoc comments** for exported functions
 - **Handle errors explicitly** (no silent failures)
 - **Use `context.Context`** for cancellation
+
+### Lint and structural guards
+
+`make lint` runs `go vet ./...`, `golint` if installed, and two repo-specific
+guards that fail the build on an architectural regression:
+
+- `check-no-tview`: fails if any `cmd`, `internal`, or `pkg` code imports the legacy
+  `rivo/tview` or `gdamore/tcell` stack. The Charm rebuild removed them and they must
+  not come back.
+- `check-serverbot-leaf`: fails if `internal/serverbot` imports
+  `internal/health`, `internal/notify`, `internal/orchestrator`, `internal/config`, or
+  `internal/identity`. The transport must stay a leaf (logging, version, and the
+  standard library only); see [NOTIFICATIONS.md](NOTIFICATIONS.md).
 
 ### Code Style
 
@@ -438,11 +490,10 @@ We welcome contributions! Here's how you can help:
 
 ### Ways to Contribute
 
-- 🐛 **Report bugs**: Open an issue with detailed reproduction steps
-- 💡 **Suggest features**: Share your ideas for improvements
-- 📖 **Improve documentation**: Fix typos, add examples, clarify instructions
-- 💻 **Submit code**: Fork, create a branch, and submit a pull request
-- ⭐ **Star the repo**: Show your support!
+- **Report bugs**: open an issue with detailed reproduction steps
+- **Suggest features**: share your ideas for improvements
+- **Improve documentation**: fix typos, add examples, clarify instructions
+- **Submit code**: fork, create a branch, and submit a pull request
 
 ### Contribution Workflow
 
@@ -471,8 +522,8 @@ go fmt ./...
 # Run tests
 go test ./...
 
-# Run linter (if installed)
-golangci-lint run
+# Run vet and the structural guards
+make lint
 ```
 
 **4. Commit changes**:
@@ -575,15 +626,15 @@ go test -v ./...
 # Benchmarks
 go test -bench=. ./...
 
-# Lint (requires golangci-lint)
-golangci-lint run
+# Lint (go vet + structural guards: check-no-tview, check-serverbot-leaf)
+make lint
 ```
 
 ### Dependencies
 
 ```bash
 # Add dependency
-go get github.com/spf13/cobra@latest
+go get filippo.io/age@latest
 
 # Update all dependencies
 go get -u ./...
@@ -695,8 +746,8 @@ Testing:
 □ Write unit tests for new functions
 □ Add integration tests for workflows
 □ Run all tests (go test ./...)
-□ Check coverage (make test-coverage)
-□ Run linter (golangci-lint run)
+□ Check coverage (make coverage-check)
+□ Run vet and guards (make lint)
 
 Documentation:
 □ Update relevant docs/*.md files
@@ -714,8 +765,6 @@ Before Submitting PR:
 After PR Submission:
 □ Address review comments
 □ Push updates to same branch
-□ Thank reviewers
-□ Celebrate when merged! 🎉
 ```
 
 ---
@@ -723,20 +772,18 @@ After PR Submission:
 ## Code Review Guidelines
 
 **For reviewers**:
-- ✅ Verify tests pass
-- ✅ Check code follows Go best practices
-- ✅ Ensure documentation is updated
-- ✅ Look for potential security issues
-- ✅ Verify error handling is robust
-- ✅ Check for race conditions (use `-race`)
-- ✅ Ensure commit messages are clear
+- Verify tests pass
+- Check code follows Go best practices
+- Ensure documentation is updated
+- Look for potential security issues
+- Verify error handling is robust
+- Check for race conditions (use `-race`)
+- Ensure commit messages are clear
 
 **For contributors**:
-- ⏰ Be patient - reviews take time
-- 📝 Respond to all comments
-- 🙏 Thank reviewers for their time
-- 🔄 Push updates to same branch (no force push after review starts)
-- ✅ Mark resolved comments
+- Respond to all comments
+- Push updates to the same branch (no force push after review starts)
+- Mark resolved comments
 
 ---
 
@@ -752,8 +799,4 @@ This project is licensed under the **MIT License** - see the [LICENSE](../LICENS
 - **Pull Requests**: https://github.com/tis24dev/proxsave/pulls
 - **Discussions**: Use GitHub Discussions for questions and ideas
 
-**For security vulnerabilities**: Please email privately instead of opening a public issue.
-
----
-
-Thank you for contributing to Proxsave! 🎉
+**For security vulnerabilities**: please email privately instead of opening a public issue.

--- a/docs/ENCRYPTION.md
+++ b/docs/ENCRYPTION.md
@@ -108,7 +108,7 @@ Recipients are public keys or passphrases that can decrypt backups. A backup enc
 
 ### Static Configuration
 
-**File** (default): `${BASE_DIR}/identity/age/recipient.txt`
+**File**: set by `AGE_RECIPIENT_FILE`, which is **empty by default**; when unset ProxSave resolves it to `${BASE_DIR}/identity/age/recipient.txt`.
 
 ```plaintext
 # AGE recipients (one per line)
@@ -147,9 +147,15 @@ If `ENCRYPT_ARCHIVE=true` and no recipients are configured, proxsave will start 
 - Enter a passphrase to derive a deterministic AGE key (passphrase is **not stored**)
 - Paste an AGE private key (`AGE-SECRET-KEY-...`) to derive its public recipient (key is **not stored**)
 
+**Passphrase strength.** When you derive a recipient from a passphrase, ProxSave
+enforces a minimum strength or rejects it with an error: at least **12 characters**, and
+characters from at least **3 of 4 classes** (lowercase, uppercase, digit, symbol). A
+short list of well-known weak passphrases (for example `password`, `123456`, `qwerty`)
+is also rejected outright.
+
 **Notes**:
 - Proxsave stores **only recipients** (public keys) in `${BASE_DIR}/identity/age/recipient.txt`. Keep private keys and passphrases offline.
-- `AGE_RECIPIENT` and `AGE_RECIPIENT_FILE` are **merged and de-duplicated**.
+- `AGE_RECIPIENT` (inline) and `AGE_RECIPIENT_FILE` are **merged and de-duplicated**. `AGE_RECIPIENTS` (plural) is accepted as a fallback alias for `AGE_RECIPIENT`, used only when `AGE_RECIPIENT` is empty.
 - Both TUI and CLI setup flows support multiple recipients and de-duplicate repeated entries before saving.
 
 ---
@@ -160,7 +166,7 @@ If `ENCRYPT_ARCHIVE=true` and no recipients are configured, proxsave will start 
 
 1. `ENCRYPT_ARCHIVE=true` in `configs/backup.env`
 2. At least one recipient configured via `AGE_RECIPIENT` and/or `AGE_RECIPIENT_FILE`
-3. File permissions checked automatically (0700 directory, 0600 recipient file)
+3. File permissions and ownership checked automatically (0700 directory, 0600 recipient file, owned root:root; auto-fixed when `AUTO_FIX_PERMISSIONS=true`, otherwise a warning)
 
 ### Backup Execution
 
@@ -218,7 +224,7 @@ backup/
 {
   "archive_path": "/opt/proxsave/backup/pve-node1-backup-20240115-023000.tar.xz.age",
   "archive_size": 1234567890,
-  "sha256": "…",
+  "sha256": "...",
   "created_at": "2024-01-15T02:30:00Z",
   "compression_type": "xz",
   "hostname": "pve-node1",
@@ -256,7 +262,7 @@ age --decrypt -i /path/to/age-keys.txt host-backup-YYYYMMDD-HHMMSS.tar.xz.age > 
 > **Passphrase recipients are not native age passphrases.** A passphrase recipient
 > is an X25519 key *derived* from the passphrase, so the raw `age --decrypt` (which
 > only understands age's own scrypt passphrase stanza) cannot decrypt it from the
-> passphrase alone — use `proxsave --decrypt`. proxsave re-derives the identity from
+> passphrase alone, use `proxsave --decrypt`. proxsave re-derives the identity from
 > the passphrase plus the **per-installation random salt** generated at setup, which
 > is stored next to the recipient (`identity/age/passphrase.salt`) and embedded in
 > every backup manifest (`passphrase_salt`) so recovery works on any host.
@@ -381,7 +387,7 @@ age --decrypt -i /path/to/age-keys.txt host-backup-YYYYMMDD-HHMMSS.tar.xz.age | 
 ### Encryption Implementation
 
 - **Algorithm**: ChaCha20-Poly1305 (AEAD) with X25519 ECDH
-- **Key derivation**: scrypt (N=2^15, r=8, p=1) for passphrases, with a per-installation random salt (stored in `identity/age/passphrase.salt` and embedded in each manifest as `passphrase_salt`; legacy archives used a fixed salt and remain decryptable)
+- **Key derivation**: scrypt (N=2^15, r=8, p=1) for passphrases. The current scheme uses a **per-installation random salt** (v2), generated once, stored `0600` at `identity/age/passphrase.salt`, and embedded in each manifest as `passphrase_salt` so the passphrase alone can re-derive the recipient on any host. At decrypt ProxSave tries salts in order: the manifest's per-install salt first, then two fixed legacy namespaces (`proxsave/age-passphrase/v1`, then the pre-rebrand `proxmox-backup-go/age-passphrase/v1`), so archives from older versions and from before the rename stay decryptable.
 - **Random nonces**: Unique per encryption operation
 - **Authentication**: Poly1305 MAC prevents tampering
 
@@ -392,7 +398,7 @@ age --decrypt -i /path/to/age-keys.txt host-backup-YYYYMMDD-HHMMSS.tar.xz.age | 
 | **Passphrase handling** | Read with `term.ReadPassword` (no echo) |
 | **Memory security** | Buffers zeroed immediately after use |
 | **Streaming encryption** | No plaintext on disk during backup |
-| **File permissions** | Enforced 0700/0600 on recipient/identity files |
+| **File permissions & ownership** | Enforced 0700/0600 and root:root on recipient/identity files (auto-fixed with `AUTO_FIX_PERMISSIONS`, otherwise warned) |
 | **Private key storage** | **Keep offline** (password manager, hardware token, printed backup) |
 | **Backup separation** | Store keys separately from backup media |
 | **Access control** | Limit who has decryption keys |
@@ -492,9 +498,11 @@ AGE encryption meets requirements for:
 ENCRYPT_ARCHIVE=true                       # Master switch
 
 # Recipient configuration
+# AGE_RECIPIENT_FILE is empty by default; when unset it resolves to ${BASE_DIR}/identity/age/recipient.txt
 AGE_RECIPIENT_FILE=${BASE_DIR}/identity/age/recipient.txt   # Public recipients (recommended)
 
 # Optional: inline recipients (merged with file; supports comma/semicolon/pipe/newline)
+# AGE_RECIPIENTS (plural) is accepted as a fallback alias, used only when AGE_RECIPIENT is empty
 AGE_RECIPIENT=age1abc123...,age1def456...
 ```
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -15,6 +15,7 @@ Real-world configuration examples for Proxsave covering common deployment scenar
 - [Example 8: Complete Production Setup](#example-8-complete-production-setup)
 - [Example 9: Test in a Chroot/Fixture](#example-9-test-in-a-chrootfixture)
 - [Example 10: Dual PVE+PBS Host](#example-10-dual-pvepbs-host)
+- [Example 11: Resident daemon and healthchecks monitoring](#example-11-resident-daemon-and-healthchecks-monitoring)
 - [Related Documentation](#related-documentation)
 
 ---
@@ -280,11 +281,10 @@ rclone ls gdrive:/pbs-logs/
 ```bash
 proxsave --newkey
 
-# Wizard:
-# [2] Generate from personal passphrase
-# Enter passphrase: **************** (min 12 chars, strong)
-# Confirm: ****************
-# ✓ AGE recipient generated and saved
+# In the wizard (a Charm TUI by default; add --cli for text prompts):
+# - choose the passphrase option to derive a recipient from a passphrase
+# - enter a strong passphrase (min 12 chars, at least 3 character classes)
+# - confirm it; the AGE recipient is generated and saved (the passphrase is not stored)
 ```
 
 #### Step 2: Configure backup.env
@@ -319,10 +319,11 @@ proxsave
 ```bash
 proxsave --decrypt
 
-# Select backup: [1]
-# Destination: /tmp/decrypt
-# Enter passphrase: ****************
-# ✓ Decryption successful
+# In the wizard (a Charm TUI by default; add --cli for text prompts):
+# - select the backup to decrypt
+# - enter the AGE key or passphrase in the single secret field
+# - enter the destination directory (defaults to the decrypt/ folder under BASE_DIR)
+# The decrypted archive is written there as <name>.decrypted.bundle.tar
 ```
 
 ### Expected Results
@@ -571,7 +572,7 @@ proxsave
 ```bash
 # Option A: Cloud relay (default, outbound HTTPS)
 # - Set EMAIL_DELIVERY_METHOD=relay and configure EMAIL_RECIPIENT (or leave empty for root@pam auto-detect)
-# - Relay blocks root@… recipients; use a real non-root mailbox for EMAIL_RECIPIENT
+# - Relay blocks root@... recipients; use a real non-root mailbox for EMAIL_RECIPIENT
 # - No local SMTP/MTA setup required on the node
 # - Optional/default: set EMAIL_FALLBACK_SENDMAIL=true to fall back to local sendmail when the relay fails
 
@@ -964,6 +965,41 @@ PXAR_SCAN_ENABLE=true
 
 The restore workflow filters categories automatically when the current host does
 not support all backup targets.
+
+---
+
+## Example 11: Resident daemon and healthchecks monitoring
+
+**Scenario**: You want the backup scheduled and supervised by a resident service with a
+hang watchdog and an external dead-man switch, instead of a bare cron entry. Fresh
+installs default to this engine; use these commands to switch an existing install or to
+inspect it.
+
+### Switch to the daemon
+
+```bash
+# Install the systemd service, remove the cron entry, turn on centralized healthchecks
+proxsave --daemon-setup
+
+# Check status (exit 0 only when running, beating, and binary-aligned)
+proxsave --daemon-status
+```
+
+`--daemon-setup` writes `SCHEDULER_MODE=daemon` and `HEALTHCHECK_ENABLED=true` and starts
+`proxsave-daemon.service`. The daemon runs the backup daily at `SCHEDULER_TIME`, under a
+`MAX_RUN_DURATION` watchdog, and reports four checks (alive, backup, updates, and one per
+notification channel) to an external healthchecks monitor.
+
+### Inspect and revert
+
+```bash
+systemctl status proxsave-daemon.service      # is it running?
+journalctl -u proxsave-daemon.service -f      # follow its log
+proxsave --daemon-remove                       # revert to a cron entry
+```
+
+See [DAEMON.md](DAEMON.md) for the healthchecks modes (centralized vs self) and the full
+configuration keys.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,18 +1,19 @@
 # ProxSave Installation Guide
 
-## 📑 Table of Contents
+## Table of Contents
 
-- [🚀 Fast Install](#fast-install)
+- [Fast Install](#fast-install)
   - [Direct Install](#direct-install)
   - [First Backup Workflow](#first-backup-workflow)
-- [⬆️ Upgrading ProxSave Binary](#upgrading-proxsave-binary)
+- [Upgrading ProxSave Binary](#upgrading-proxsave-binary)
   - [Quick Upgrade](#quick-upgrade)
   - [What Gets Updated](#what-gets-updated)
   - [Full Upgrade Workflow](#full-upgrade-workflow)
-- [💾 Manual Installation](#manual-installation)
+- [Manual Installation](#manual-installation)
   - [Prerequisites](#prerequisites)
   - [Building from Source](#building-from-source)
   - [Interactive Installation Wizard](#interactive-installation-wizard)
+  - [Scheduling and the daemon](#scheduling-and-the-daemon)
 
 ## Fast Install
 
@@ -30,6 +31,8 @@
    bash -c "$(curl -fsSL https://raw.githubusercontent.com/tis24dev/proxsave/main/install.sh)" _ --new-install
    ```
 
+   Append `--cli` to run the text-mode installer instead of the TUI (for example `... install.sh)" _ --cli`).
+
 2. Run your first backup
 
    ```bash
@@ -40,7 +43,7 @@
 > verify every release before installing it: `SHA256SUMS` is checked against the
 > project's pinned **ECDSA P-256** signature (`SHA256SUMS.sig`), then the archive
 > is checked against `SHA256SUMS`. A missing or invalid signature aborts the
-> install/upgrade — there is no fallback to checksum-only. `install.sh` requires
+> install/upgrade, with no fallback to checksum-only. `install.sh` requires
 > `openssl` for this (preinstalled on Proxmox); the Go upgrade verifies it
 > natively. To verify a download yourself, see
 > [PROVENANCE_VERIFICATION.md](PROVENANCE_VERIFICATION.md#release-signature-sha256sumssig).
@@ -87,13 +90,11 @@ proxsave --dry-run
 
 The `--upgrade` command:
 
-- ✅ Downloads latest binary from GitHub releases
-- ✅ Verifies integrity with SHA256 checksums
-- ✅ Atomically replaces current binary
-- ✅ Updates the `/usr/local/bin/proxsave` symlink (and removes the legacy `proxmox-backup` symlink if present)
-- ✅ Fixes file permissions
-- ✅ Merges any new template keys into your `backup.env` (your existing and custom values are preserved, and the previous file is backed up first)
-- ❌ **Does NOT touch** your cron schedule (re-run `--install` to change it)
+- Downloads the latest binary from GitHub releases and verifies its signature and checksum before installing.
+- Atomically replaces the current binary and updates the `/usr/local/bin/proxsave` symlink (removing the legacy `proxmox-backup` symlink if present).
+- Fixes file permissions.
+- Merges any new template keys into your `backup.env` (your existing and custom values are preserved, and the previous file is backed up first).
+- Reconciles the scheduler: a cron install is migrated to the resident daemon unless you opted out with `--daemon-remove`; a daemon install stays on the daemon. Re-run `--install` to change the run time or engine.
 
 ### Full Upgrade Workflow
 
@@ -107,8 +108,8 @@ proxsave --upgrade-config
 # 3. Test configuration
 proxsave --dry-run
 
-# 4. Verify cron schedule
-crontab -l
+# 4. Check the scheduler
+proxsave --daemon-status   # daemon installs; use crontab -l if you opted out of the daemon
 
 # 5. Run a real backup to confirm
 proxsave
@@ -207,20 +208,22 @@ In **Keep existing & continue** mode, config-dependent post-steps are skipped:
 
 Final install steps still run:
 - Support docs installation
-- Symlink and cron finalization
+- Symlink and scheduler finalization (installs the daemon service or the cron entry for the chosen engine)
 - Permission normalization
 
 **Wizard prompts:**
 
-1. **Configuration file path**: Default `configs/backup.env` (accepts absolute or relative paths within repo)
+1. **Configuration file path** (taken from `--config`, not asked in the wizard): default `configs/backup.env`, shown in the install banner. An absolute path is used as-is; a relative path resolves against the detected install directory (`BASE_DIR`), not the current directory.
 2. **Secondary storage**: Optional path for backup/log copies; disabling it clears both saved secondary paths from `backup.env`
 3. **Cloud storage (rclone)**: Optional rclone configuration (supports `CLOUD_REMOTE` as a remote name (recommended) or legacy `remote:path`; `CLOUD_LOG_PATH` supports path-only (recommended) or `otherremote:/path`)
 4. **Firewall rules**: Optional firewall rules collection toggle (`BACKUP_FIREWALL_RULES=false` by default; supports iptables/nftables)
 5. **Notifications**: Enable Telegram (centralized) and Email notifications; Email asks for a delivery method and defaults to `relay` with `sendmail` failover. Use `pmf` only when you want Proxmox Notifications via `proxmox-mail-forward`.
 6. **Encryption**: AGE encryption setup (runs sub-wizard immediately if enabled)
-7. **Cron schedule**: Choose cron time (HH:MM, default `02:00`) for the `proxsave` cron entry in both CLI and TUI install modes
-8. **Post-install check (optional)**: Runs `proxsave --dry-run` and shows actionable warnings like `set BACKUP_*=false to disable`, allowing you to disable unused collectors and reduce WARNING noise
-9. **Telegram pairing (optional)**: If Telegram centralized mode is enabled and the installer can load a valid config plus a Server ID, it shows your Server ID and lets you verify pairing with the bot (retry/skip supported). Otherwise installation continues and logs why pairing was skipped.
+7. **Scheduler engine**: choose the ProxSave local daemon or system cron. Fresh installs and Overwrite default to the daemon (a resident systemd service with a hang watchdog and healthchecks); editing an existing config keeps its current engine. See [DAEMON.md](DAEMON.md).
+8. **Healthchecks** (daemon only): with the daemon engine, choose the monitoring mode: `Off`, `ProxSave HC Server` (centralized, zero setup, the default), or `Your own server` (self). Self mode opens a follow-up screen to paste your ping URLs, then a verification screen. With the cron engine this choice is dimmed and forced off.
+9. **Run at (HH:MM)**: the daily backup time (default `02:00`), used by whichever engine you chose (the daemon's daily run, or the cron entry).
+10. **Post-install check (optional)**: Runs `proxsave --dry-run` and shows actionable warnings like `set BACKUP_*=false to disable`, allowing you to disable unused collectors and reduce WARNING noise
+11. **Telegram pairing (optional)**: If Telegram centralized mode is enabled and the installer can load a valid config plus a Server ID, it shows your Server ID and lets you verify pairing with the bot (retry/skip supported). Otherwise installation continues and logs why pairing was skipped.
 
 #### Telegram pairing wizard (TUI)
 
@@ -268,5 +271,9 @@ When shown, it does **not** modify your `backup.env`. It only:
 - Install session log under `/tmp/proxsave/install-*.log` (includes audit results and Telegram pairing outcome)
 
 After completion, edit `configs/backup.env` manually for advanced options.
+
+### Scheduling and the daemon
+
+ProxSave runs the backup from the resident daemon or from cron, chosen in the wizard above. Switch or inspect the scheduler at any time with `proxsave --daemon-setup`, `proxsave --daemon-remove`, and `proxsave --daemon-status`. See [DAEMON.md](DAEMON.md).
 
 `BASE_DIR` is detected from the installed `proxsave` executable. Do not add an active `BASE_DIR=...` line to `backup.env`; upgrades remove it and runtime ignores it if present.

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -1,0 +1,442 @@
+# Notifications and the centralized bot relay
+
+ProxSave reports the outcome of every backup run over a small set of channels:
+**Email**, **Telegram**, **Gotify**, and **Webhooks**. On top of those it runs a
+separate monitoring layer that turns each channel's outcome into an external
+dead-man sensor. This document explains how the channels work, the centralized
+Telegram relay (where the bot token stays on the host), the two-response delivery
+model, the portal magic-link, and the log-redaction rules that keep secrets out of
+the logs.
+
+For the full list of `backup.env` keys see [CONFIGURATION.md](CONFIGURATION.md).
+For the per-channel healthchecks sensors and the resident daemon that pings them see
+[DAEMON.md](DAEMON.md).
+
+## The one invariant: notifications never abort the backup
+
+A notification is always best-effort. No channel can fail, delay, or block a backup:
+
+- Every notifier reports `IsCritical() == false`. The interface comment is explicit:
+  "notifications never abort backup" (`internal/notify/notify.go`).
+- The orchestrator adapter swallows every `Send` error: it logs the failure, records
+  an `error` outcome for that channel, and returns `nil` to the caller
+  (`internal/orchestrator/notification_adapter.go`). The dispatcher ignores the return
+  value too.
+- The run's exit code is **frozen before any channel sends**. `applyIssueExitCode`
+  promotes the exit code from the collected errors and warnings first, then the
+  notification phase runs. A warning raised while sending a notification is still a
+  warning, never an error, and never changes the exit code
+  (`internal/orchestrator/extensions.go`).
+
+So a red channel in the logs tells you a message did not go out. It never means the
+backup failed.
+
+## Two tiers
+
+There are two independent layers, and it helps to keep them apart:
+
+- **Tier 1, delivery.** During the run's notification phase each enabled channel
+  (Email, Telegram, Gotify, Webhook) formats the report and sends it. This is the
+  user-facing "did I get a message" layer.
+- **Tier 2, monitoring.** Each channel's outcome (`ok` / `warning` / `error` /
+  `disabled`) is handed to the resident daemon, which turns it into a per-channel
+  `proxsave-notify-<channel>` healthchecks sensor (`/0` up, `/1` down). Alongside it,
+  an always-visible **Healthchecks** section prints the current transmission status.
+  This is the "is my monitoring actually working" layer. See [DAEMON.md](DAEMON.md).
+
+The two tiers are decoupled on purpose. A Telegram message the relay accepted but
+Telegram did not deliver keeps the run green (Tier 1 success), yet drives the
+`notify-telegram` sensor DOWN (Tier 2), so an undelivered message never reports "ok".
+
+### Dispatch order
+
+Channels are wired and dispatched in a fixed order:
+
+```
+Email, Telegram, Gotify, Webhook, Healthchecks
+```
+
+Healthchecks is deliberately **last**. The Telegram relay may piggyback a fresh
+portal magic-link on its response; dispatching Healthchecks last means that link has
+already been captured onto the run's stats before the Healthchecks section renders.
+Each channel is gated independently on its own `*_ENABLED` flag, so the ordering is
+about link capture, not about one channel depending on another.
+
+### The per-channel handoff file
+
+The backup child writes its per-channel outcomes to
+`<BASE_DIR>/identity/.notify_results.json` (atomic write, mode `0600`), and the
+resident daemon (the only process that pings the monitor) reads it after the child
+exits. Two guards keep it honest:
+
+- The write is **gated on `PROXSAVE_RUN_ID`**, which only the daemon sets on its
+  child. A bare `proxsave --backup` by hand writes no file and leaves nothing stale.
+- The daemon **rejects any file whose run id is not the run it supervised**, and an
+  empty result set is written as an empty object so the daemon can tell "child ran,
+  nothing to report" from "child crashed" (missing file).
+
+The pings are driven by the channel set **in the file**, not by the daemon's cached
+config, so a channel toggled off between runs never flaps a stale DOWN. The
+Healthchecks section is a reporting surface, not a delivery channel, so it never
+gets a `notify-*` result of its own.
+
+## Telegram: personal vs centralized
+
+Telegram has two modes, chosen by `BOT_TELEGRAM_TYPE` (`personal` or `centralized`,
+default `centralized`). Any other value makes the Telegram notifier skip itself (a
+warning is logged and Telegram is not registered); the backup is unaffected.
+
+### Personal mode (the bot token leaves the host)
+
+Personal mode talks straight to Telegram. It requires `TELEGRAM_BOT_TOKEN` and
+`TELEGRAM_CHAT_ID` (validated against `^[0-9]+:[A-Za-z0-9_-]{35,}$` and `^-?[0-9]+$`)
+and POSTs to `https://api.telegram.org/bot<token>/sendMessage`. The raw bot token is
+in the request URL, so in personal mode the token leaves the host on every send. Use
+this only if you run your own bot.
+
+### Centralized mode (the bot token stays on the host)
+
+Centralized mode routes through the shared ProxSave bot-server at
+`https://bot.proxsave.dev` (the hardcoded `ServerAPIHost`). It requires a `SERVER_ID`.
+Once a per-server relay secret has been provisioned (see below), the message is
+POSTed to `/api/notify` with the body `{server_id, message}` and an `X-Server-Auth`
+header carrying that secret. **The server looks up the chat and sends to Telegram
+itself, so the bot token never leaves the host.** The legacy direct
+`api.telegram.org` path is used only as a fallback when no relay secret exists yet.
+
+This is the security keystone of centralized mode: the client stores a low-capability
+per-server secret, not the bot token.
+
+## TOFU secret provisioning
+
+The per-server relay secret is provisioned trust-on-first-use:
+
+1. **Fetch.** The client calls `GET /api/get-chat-id?server_id=<id>` with no
+   `X-Server-Auth` (there is no secret yet). It sends `X-Proxsave-Provision: 1` only
+   when a persist target exists (`BaseDir` set), so a run with nowhere to store a
+   secret never churns one on the server.
+2. **Adopt and persist.** If the `200` response carries a `notify_secret`, the client
+   registers it with the logger for scrubbing, then persists it to
+   `<BASE_DIR>/identity/.notify_secret` (mode `0600`, then `chattr +i`, the same
+   immutable mechanism used for the server identity file). Adoption **overwrites** any
+   existing secret rather than skipping: a `200` carrying a secret means the server
+   wants this one adopted, so a re-issued secret is never stranded.
+3. **Confirm.** The client POSTs `/api/confirm-secret` with `{server_id}` and the new
+   secret in `X-Server-Auth`, which tells the server to stop re-issuing it. This step
+   is best-effort and non-fatal.
+4. **Relay.** The same run then relays through `/api/notify` with the fresh secret.
+
+The persisted secret matches `^[0-9a-z]+(-[0-9a-z]+)*$` (for example
+`3h64-dyi8-q3d6-wcm5`) and is format-validated on **both write and read**.
+`LoadNotifySecret` returns an empty string for an absent, empty, or malformed file
+(junk is never fed into the auth header) and reads under `os.Root` confinement.
+
+`get-chat-id` status codes: `200` success; `403` first contact or the bot has not been
+started; `409` missing registration; `422` invalid `SERVER_ID`; `426` "Upgrade
+ProxSave to v0.28.0 or later to complete pairing".
+
+### Stale-secret recovery
+
+If `/api/notify` answers `401` or `403` (a rotated or stale secret), the notifier
+drops the in-memory secret, reprovisions once through the fetch path, and relays that
+run once (or falls back to the legacy token path). It never loops. Like every other
+notification failure, this is non-critical and never touches the backup.
+
+## The two-response delivery model
+
+Centralized Telegram delivery has **two responses**, and the distinction is the
+load-bearing subtlety of the whole channel.
+
+**Response 1, acceptance.** The `POST /api/notify` result is the success signal:
+
+- `200` means the legacy synchronous relay delivered inside the request (nothing to
+  poll).
+- `202` means the message was accepted onto the server's durable outbox and will be
+  retried server-side.
+
+Either way, acceptance sets `result.Success = true`. Other statuses: `404` server
+unknown, `409` registration missing, `413` message too long.
+
+**Response 2, delivery.** The real Telegram delivery outcome is learned separately by
+polling `GET /api/notify/status?server_id=<id>&notify_id=<id>`. This poll **never
+changes `result.Success`** and never fails the caller. Only `X-Server-Auth` is on the
+wire here; the bot token never appears. It resolves to one of `delivered`, `failed`,
+`pending`, or `unknown`:
+
+- Still pending at the deadline stays `pending` (the durable outbox keeps retrying).
+- A definitive miss or auth issue (`404` / `401` / `403`) is `unknown`, not retried.
+- Transient `5xx` or network errors are retried within the budget, then reported
+  `pending`.
+
+The poll is deliberately gentle: a deterministic per-notification jitter (0 to 499 ms,
+derived from the notify id) so a midnight burst of clients desynchronizes, an interval
+floored to 1 s and capped at 5 s, and a total timeout floored to 10 s and capped at
+60 s, so a mis-set value can neither spin nor hang the end of a backup for minutes.
+
+A single 32-hex-character **notify id** is minted once per send and reused across the
+relay POST, the status poll, and any retry, so the server's idempotency dedupe never
+double-queues a message. On the relay POST (and its retry) the id travels as the
+`X-Notify-Id` header; on the status poll it travels as the `notify_id` query
+parameter.
+
+Delivery confirmation is config-gated:
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `TELEGRAM_CONFIRM_DELIVERY` | `true` | poll for the real delivery outcome after acceptance |
+| `TELEGRAM_CONFIRM_TIMEOUT_SECONDS` | `10` | total poll budget (floored 10 s, capped 60 s) |
+| `TELEGRAM_CONFIRM_INTERVAL_SECONDS` | `1` | poll interval (floored 1 s, capped 5 s) |
+
+With `TELEGRAM_CONFIRM_DELIVERY=false` the state is `unconfirmed` (a quiet debug line,
+distinct from `pending`) and no poll runs.
+
+### Reading the result in the logs
+
+Telegram prints **two lines**. The first is server acceptance, the second is delivery:
+
+```
+✓ Telegram: sent to ProxSave server (in 240ms)
+✓ Telegram: delivered to Telegram
+```
+
+The first-line latency is acceptance-only (from `relay_accept_duration`), so it
+reports true relay latency, not latency plus the poll budget. The second line maps
+from the delivery state:
+
+| State | Second line | Level |
+|-------|-------------|-------|
+| `delivered` | `✓ Telegram: delivered to Telegram` | info |
+| `failed` | `❌ Telegram: not delivered (<reason>)` | warning |
+| `pending` | `⚠️ Telegram: accepted; delivery in progress (auto-retry)` | warning |
+| `unconfirmed` | (quiet, confirmation disabled) | debug |
+| `unknown` | `⚠️ Telegram: accepted; delivery not confirmed` | warning |
+
+If acceptance itself failed, the first line reads
+`❌ Telegram: could not send to ProxSave server`. The failure `<reason>` on the
+`failed` line is translated for humans: `bot blocked by the user` (`http_403`),
+`invalid chat` (`http_400` / `http_404`), `message too long` (`http_413`),
+`Telegram unreachable too long (expired)` and `too many failed attempts` (the
+server's give-up reasons), or `rejected by Telegram` when the reason is empty.
+
+Every non-success second line is at most a warning. None of it blocks the backup.
+
+### The monitoring sensor
+
+The Tier 2 `notify-telegram` sensor is stricter than `result.Success`: a relay-accepted
+message whose delivery poll came back `failed` drives the sensor to `error` (`/1`
+DOWN), even though the run stays green. Only `failed` counts; `pending` and
+`unconfirmed` do not. This is the whole point of Tier 2: an undelivered message must
+not report "ok" and defeat the monitoring.
+
+## The portal magic-link
+
+The bot-server can piggyback a fresh portal login link on its `/api/notify` response
+(field `login_url`), until the user's first portal login, after which it stops. The
+Healthchecks section can also mint one best-effort via
+`GET /api/healthcheck/config?server_id=<id>&login=1` (the daemon's own polls pass no
+`login=1`, so only install-time and run-phase callers request a mint).
+
+The link is short-lived (about an hour), single-use, and display-only (ProxSave never
+fetches it). It is handled with one specific discipline:
+
+- It is carried **raw** end-to-end (through `result.Metadata["login_url"]` onto
+  `stats.HealthcheckLink`) and is **never** registered as a log secret, because it has
+  to stay visible when printed.
+- It is sanitized through `serverbot.SanitizeLoginURL` at exactly **one** display
+  boundary (`logMonitoringPortalLink`), which prints
+  `Healthchecks Portal: <url>` right after the Server MAC address line at the end of
+  the run.
+
+`SanitizeLoginURL` is the single guard against a hostile or MITM bot-server injecting
+terminal escapes into your console: it returns the link only if it is a clean
+`http(s)` URL made entirely of printable ASCII (`0x21` to `0x7e`); anything else,
+including any control character, space, or Unicode bidi/format trick, fails closed to
+an empty string. It is all-or-nothing and never truncated (truncating would break the
+link).
+
+## Email
+
+Email supports three delivery methods, chosen by `EMAIL_DELIVERY_METHOD`:
+
+| Method | How | Fallback |
+|--------|-----|----------|
+| `relay` | POST a JSON report to the shared Cloudflare relay worker | `sendmail` (if `EMAIL_FALLBACK_SENDMAIL`) |
+| `pmf` | route via Proxmox `proxmox-mail-forward` | `relay`, then `sendmail` |
+| `sendmail` | hand off to the local `/usr/sbin/sendmail` | none |
+
+For `pmf` the relay fallback is skipped when the recipient is empty or `root`. If
+`EMAIL_FROM` is empty it defaults to `no-reply@proxmox.tis24.it`.
+
+**Recipient handling.** An empty `EMAIL_RECIPIENT` triggers auto-detection for
+`root@pam` (PVE order: `pvesh` on `/access/users/root@pam`, then `pveum user list`,
+then `/etc/pve/user.cfg`; PBS order: `proxmox-backup-manager user list`, then
+`/etc/proxmox-backup/user.cfg`). The detected address is logged redacted. An empty or
+malformed recipient is a hard failure for `relay` and `sendmail` (sending anyway
+would report a false success); `pmf` only warns, because it routes through Proxmox
+Notifications and uses the address only for the `To:` header.
+
+**`root@` is blocked only for `relay`.** With `sendmail` fallback enabled the notifier
+bypasses relay and goes straight to sendmail; without a fallback it hard-fails with
+`recipient <addr> is not allowed (root accounts are blocked)`. The `sendmail` and
+`pmf` methods accept `root` recipients.
+
+**Delivery is handoff, not guaranteed delivery.** Relay logs an accepted request
+(HTTP `200` from the worker); sendmail and pmf explicitly warn that exit code `0`
+means "accepted to queue, not necessarily delivered".
+
+### The shared cloud relay worker
+
+The `relay` method POSTs to a hardcoded Cloudflare Worker
+(`https://relay-tis24.weathered-hill-5216.workers.dev/send`) with these headers:
+`Authorization: Bearer <WorkerToken>`, `X-Signature` (HMAC-SHA256 of the JSON
+payload), `X-Script-Version`, `X-Server-MAC`, and a `proxsave/<version>` user agent.
+
+The `WorkerToken` (`v1_public_20251024`) and the HMAC secret are a **shared public
+anti-abuse credential, not a confidential secret**: the same values ship in every
+distributed binary and are published in the repository, so they cannot be kept secret
+on the client. They only gate the free shared worker, whose real protection is
+server-side rate limiting keyed on `server_mac` / `server_id`. Both sites carry a
+`#nosec G101` documenting this. See
+[SECURITY.md](SECURITY.md#hardcoded-relay-credential-g101). Operators who want a
+private relay can point `CLOUDFLARE_WORKER_URL` / `CLOUDFLARE_WORKER_TOKEN` /
+`CLOUDFLARE_HMAC_SECRET` at their own worker.
+
+The JSON report body (`buildReportData`) must byte-match the legacy Bash
+`collect_email_report_data()` output, otherwise the worker's HMAC signature check
+fails. Changing the report shape breaks relay auth.
+
+## Gotify
+
+Set `GOTIFY_ENABLED=true` with `GOTIFY_SERVER_URL` and `GOTIFY_TOKEN` (both required).
+ProxSave POSTs to `<GOTIFY_SERVER_URL>/message?token=<GOTIFY_TOKEN>`; success is any
+`2xx`. The token lives in the URL query, so on a request error it is redacted from the
+message via `RedactSecrets` (which masks both the raw and the URL-encoded form).
+
+Priority maps from the run outcome, with defaults you can override:
+
+| Outcome | Key | Default |
+|---------|-----|---------|
+| success | `GOTIFY_PRIORITY_SUCCESS` | `2` |
+| warning | `GOTIFY_PRIORITY_WARNING` | `5` |
+| failure | `GOTIFY_PRIORITY_FAILURE` | `8` |
+
+## Webhooks
+
+`WEBHOOK_ENABLED=true` plus `WEBHOOK_ENDPOINTS`, a comma-separated list of names. Each
+name expands to a block of `WEBHOOK_<NAME>_` keys:
+`URL`, `FORMAT`, `METHOD`, `AUTH_TYPE`, `AUTH_TOKEN`, `AUTH_USER`, `AUTH_PASS`,
+`AUTH_SECRET`, `HEADERS`, `PRIORITY`.
+
+- **Fan-out.** Every endpoint is tried. The channel succeeds if **at least one**
+  endpoint succeeds; it reports an error only when all fail (`all N endpoints failed`).
+- **Formats.** `discord`, `slack`, `teams`, `pushover`, `generic` (default; an unknown
+  format falls back to `generic` with a warning).
+- **Auth types.** `bearer` (`Authorization: Bearer`), `basic`
+  (`Authorization: Basic base64(user:pass)`), `hmac-sha256` (`X-Signature` plus
+  `X-Signature-Algorithm: hmac-sha256`), or none.
+- **Retry.** Per endpoint, `WEBHOOK_MAX_RETRIES` (default `3`) with `WEBHOOK_RETRY_DELAY`
+  (default `2s`). `2xx` succeeds; `400/401/403/404` are not retried; `429` retries after
+  a cooldown; `5xx` and unexpected codes retry. The protected headers `host`,
+  `content-length`, `content-type`, and `transfer-encoding` are stripped from any
+  custom `HEADERS`.
+
+**Pushover** is special-cased: the app `token` and `user` key go in the JSON **body**
+(not headers), `PRIORITY` is constrained to `-2..1` (emergency `2` is unsupported), and
+`METHOD` must be `POST`. Because the body carries credentials, the debug payload
+preview is suppressed (`Payload preview omitted: pushover payload contains
+credentials`). For Discord and Slack the endpoint URL is itself the secret, so on a
+request error the URL is redacted via `RedactSecrets` before logging.
+
+## Security model and log redaction
+
+The redaction rules are deliberate and asymmetric. What gets registered with the
+logger for scrubbing, and what deliberately does not:
+
+| Value | Registered as a log secret? | Why |
+|-------|-----------------------------|-----|
+| Telegram bot token | yes | confidential |
+| Telegram relay secret (`.notify_secret`) | yes | confidential per-server credential |
+| Gotify token | yes | confidential; lives in the URL query |
+| Webhook endpoint URL / token / secret / pass | yes | the URL is often the secret (Discord, Slack) |
+| Cloudflare relay worker token + HMAC secret | **no** | shared public anti-abuse credential, not confidential |
+| Portal magic-link (`login_url`) | **no** | must stay visible when printed; guarded by `SanitizeLoginURL` instead |
+
+The primitives (`internal/logging/redact.go`):
+
+- **`MaskSecret`** renders a fixed 12-asterisk prefix plus the last 4 characters;
+  secrets of 8 runes or fewer are fully masked. The prefix is fixed-width so the mask
+  never leaks the real length.
+- **`RedactSecrets`** replaces every occurrence of each secret in both raw and
+  URL-encoded form, skips secrets shorter than 6 runes, and orders the forms
+  longest-first so a short secret cannot partially mask a longer one.
+- **`RedactURLError`** unwraps a `*url.Error` and keeps only `<op>: <error>`, dropping
+  the full URL that Go prints verbatim (request URLs to the central servers embed
+  low-capability values like `server_id` in the query).
+
+The `serverbot` transport composes these: a `TransportError` is **pre-redacted** at
+construction (the `*url.Error` URL stripped and the per-request secret masked), so it
+is safe to log as-is. Debug logging in the transport is body-free and secret-free
+(method, path, and status only). One caveat: `Response.Snippet` strips non-printable
+runes for console safety but is **not** secret-redacted, so a caller must wrap it with
+`RedactSecrets` when the per-request secret could appear in the body.
+
+## Developer notes
+
+### The `serverbot` transport
+
+`internal/serverbot` is the single host-to-bot-server transport, and the **only**
+thing on the host that talks to `bot.proxsave.dev`. Telegram and Healthchecks
+delivery happen beyond the bot-server, not from the host directly. Key contracts:
+
+- It is a **leaf**: it owns headers, a per-request timeout (default 5 s), a bounded
+  response read (default 8192 bytes), and transport-error redaction, and nothing else.
+  It carries no endpoint paths, query keys, DTOs, or HTTP-status semantics; those live
+  in the callers (`notify`, `health`). A Makefile guard (`check-serverbot-leaf`)
+  fails the build if it imports `internal/health`, `internal/notify`,
+  `internal/orchestrator`, `internal/config`, or `internal/identity` (the packages
+  that would create an import cycle and drag endpoint vocabulary back into the
+  transport); the intended contract is `internal/logging`, `internal/version`, and
+  the standard library only.
+- **An HTTP status is never an error.** `Client.Do` returns `(Response, nil)` for any
+  completed exchange, including non-2xx; the caller inspects `Response.Status`. An
+  error comes back only on an encode, build, dial, or read failure, and it is a
+  pre-redacted `*TransportError`. `AuthRejected(status)` is a helper for the shared
+  `401`/`403` concept, not an error path.
+- The `serverID` and secret are **per-request**, not on the client. One stateless
+  client serves the no-secret `get-chat-id` call, the authenticated `notify` call, and
+  the `confirm-secret` call. Headers are stamped conditionally: `X-Proxsave-Version`
+  always, `X-Server-Auth` only when a secret is present, `X-Proxsave-Provision: 1` only
+  when provisioning, `X-Notify-Id` only when set.
+- It must never be pointed at `api.telegram.org` or the `hc.proxsave.dev` monitor.
+
+### Adding a notifier
+
+A channel is anything that implements `notify.Notifier`
+(`Name`, `IsEnabled`, `Send`, `IsCritical`). To add one:
+
+1. Implement the interface. `IsCritical()` **must** return `false`, and `Send` should
+   return a `*NotificationResult` with `Success=false` on failure rather than a
+   non-nil error where possible; a notification must never abort the backup.
+2. Register secrets (`RegisterSecret`) for any token or URL that could appear in a log
+   or an error before you make the first request.
+3. Wire it in `initializeBackupNotifications` (skip with a `disabled` log line when its
+   `*_ENABLED` flag is off) and add it to the fixed `dispatchNotifications` entries,
+   keeping Healthchecks last.
+4. The adapter records the per-channel severity into `.notify_results.json` for you, so
+   the daemon can raise a `proxsave-notify-<name>` sensor without further work.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Where to look |
+|---------|--------------|---------------|
+| Telegram: "sent to ProxSave server" but "delivery not confirmed" | acceptance ok, poll ended before a definite answer (durable outbox still retrying) | raise `TELEGRAM_CONFIRM_TIMEOUT_SECONDS`, or accept it (delivery is best-effort) |
+| Telegram: "not delivered (bot blocked by the user)" | the user blocked the bot | unblock the bot, re-pair |
+| Telegram: "could not send to ProxSave server" repeatedly | stale relay secret or unknown server | the client reprovisions once automatically; if it persists, re-pair (`--install` Telegram step) |
+| `426` on `get-chat-id` | server needs a newer client to finish pairing | upgrade ProxSave to v0.28.0 or later |
+| `notify-telegram` sensor DOWN but run green | message accepted but not delivered (Tier 2 is stricter than Tier 1) | fix the delivery cause above; the run staying green is by design |
+| Email relay `INVALID_SIGNATURE` | report shape changed, HMAC no longer matches; or a private worker misconfigured | keep the stock report shape; check `CLOUDFLARE_*` if self-hosting |
+| Email: "recipient is not allowed (root accounts are blocked)" | `relay` method with a `root@` recipient and no sendmail fallback | set a real recipient, enable `EMAIL_FALLBACK_SENDMAIL`, or use `sendmail`/`pmf` |
+| No portal link printed | link already consumed (first login done), or it failed the sanitizer | expected after first login; minting is best-effort and quiet |
+
+See [CONFIGURATION.md](CONFIGURATION.md) for every key, [DAEMON.md](DAEMON.md) for the
+monitoring sensors, and [INSTALL.md](INSTALL.md) for the Telegram pairing wizard.

--- a/docs/PROVENANCE_VERIFICATION.md
+++ b/docs/PROVENANCE_VERIFICATION.md
@@ -10,11 +10,23 @@ Every Proxsave release binary includes cryptographically signed provenance attes
 
 Attestations use the SLSA (Supply-chain Levels for Software Artifacts) standard and are registered in an immutable public transparency log (Sigstore).
 
+Proxsave publishes a single build target, `linux/amd64`. The release assets for a tag `vX.Y.Z` are:
+
+```
+proxsave_X.Y.Z_linux_amd64                     # uncompressed binary
+proxsave_X.Y.Z_linux_amd64.tar.gz              # binary + LICENSE + README
+proxsave_X.Y.Z_linux_amd64.tar.gz.sbom.cdx.json
+SHA256SUMS
+SHA256SUMS.sig
+```
+
+GoReleaser drops the leading `v` from the version in filenames, so tag `v0.29.0` produces `proxsave_0.29.0_linux_amd64`. There are no macOS or Windows binaries.
+
 ## Release signature (SHA256SUMS.sig)
 
 In addition to the SLSA attestations described below, every release ships a detached signature of its `SHA256SUMS` file: `SHA256SUMS.sig`. It is an **ECDSA P-256 / SHA-256** signature produced in CI with a private key that exists only as a GitHub Actions secret.
 
-**This is what the tooling enforces automatically.** `install.sh` and `proxsave --upgrade` download `SHA256SUMS.sig` and verify it against a public key **pinned in the tool itself** before trusting `SHA256SUMS` (and then the archive checksum). A missing or invalid signature aborts the install/upgrade — there is no fallback to checksum-only. Because the public key is pinned in the client, an attacker cannot substitute their own key: only the project's private key can produce a signature that verifies.
+**This is what the tooling enforces automatically.** `install.sh` and `proxsave --upgrade` download `SHA256SUMS.sig` and verify it against a public key **pinned in the tool itself** before trusting `SHA256SUMS` (and then the archive checksum). A missing or invalid signature aborts the install or upgrade; there is no fallback to checksum-only. Because the public key is pinned in the client, an attacker cannot substitute their own key: only the project's private key can produce a signature that verifies. The release workflow also validates the signing key against the same pinned public key before publishing.
 
 Pinned public key (sha256/DER fingerprint `fdbbba66cdb770b85a728c8aee0b920b4cd244c84f4fc5a0065188fbe9a5eddb`):
 
@@ -28,7 +40,7 @@ liDJEnB+RgiWOQR+6xLWeX7PyauuMxUh/HNnvBQAokK91fLWes4r9Xlwzw==
 ### Verify a download manually
 
 ```bash
-TAG=v0.0.0   # the release you downloaded
+TAG=vX.Y.Z          # the release you downloaded, e.g. v0.29.0
 base="https://github.com/tis24dev/proxsave/releases/download/${TAG}"
 curl -fsSLO "${base}/SHA256SUMS"
 curl -fsSLO "${base}/SHA256SUMS.sig"
@@ -43,19 +55,17 @@ sha256sum --ignore-missing -c SHA256SUMS
 
 > The release signature (above) and the SLSA attestations (below) are complementary: the signature is the lightweight check the installer enforces with no extra tooling, while attestations add an independently verifiable, transparency-logged build provenance via the GitHub CLI.
 
-## Why Attestations Matter
+## Why attestations matter
 
 Provenance attestations protect against:
-- **Supply chain attacks**: Verifies that the binary comes from the official repository
-- **Tampering**: Guarantees that no one has modified the binary after the build
-- **Compromises**: Proves that the binary was built in a trusted environment (GitHub Actions)
-- **Unauthorized builds**: Confirms that only maintainers can create releases
+- **Supply chain attacks**: verifies that the binary comes from the official repository
+- **Tampering**: guarantees that no one has modified the binary after the build
+- **Compromises**: proves that the binary was built in a trusted environment (GitHub Actions)
+- **Unauthorized builds**: confirms that only maintainers can create releases
 
 ## Prerequisites
 
-To verify attestations, you need to install GitHub CLI (`gh`).
-
-### Linux
+To verify attestations you need the GitHub CLI (`gh`). It runs on any OS even though the Proxsave binary is `linux/amd64` only.
 
 ```bash
 # Debian/Ubuntu
@@ -71,70 +81,57 @@ sudo dnf install gh
 sudo pacman -S github-cli
 ```
 
-### macOS
+See the [GitHub CLI install docs](https://github.com/cli/cli#installation) for other platforms.
+
+## Verification methods
+
+The examples below use a small setup block so you can paste any release tag:
 
 ```bash
-brew install gh
+TAG=vX.Y.Z                       # the release you are verifying, e.g. v0.29.0
+VER=${TAG#v}                     # version without the leading v (used in asset names)
+ASSET="proxsave_${VER}_linux_amd64"
 ```
 
-### Windows
-
-```powershell
-# With winget
-winget install --id GitHub.cli
-
-# With Chocolatey
-choco install gh
-
-# With Scoop
-scoop install gh
-```
-
-## Verification Methods
-
-### Method 1: Quick Verification (Single Binary)
-
-This is the simplest method to verify a single downloaded binary.
+### Method 1: quick verification (single binary)
 
 ```bash
-# Download the binary for your platform
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/proxsave-linux-amd64
+# Download the binary
+wget "https://github.com/tis24dev/proxsave/releases/download/${TAG}/${ASSET}"
 
 # Verify the attestation
-gh attestation verify proxsave-linux-amd64 --repo tis24dev/proxsave
+gh attestation verify "${ASSET}" --repo tis24dev/proxsave
 ```
 
 **Expected output:**
 ```
-Loaded digest sha256:abc123... for file://proxsave-linux-amd64
+Loaded digest sha256:abc123... for file://proxsave_0.29.0_linux_amd64
 Loaded 1 attestation from GitHub API
-✓ Verification succeeded!
+Verification succeeded!
 
 sha256:abc123... was attested by:
-REPO                        PREDICATE_TYPE                  WORKFLOW
-tis24dev/proxsave     https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v0.9.0
+REPO               PREDICATE_TYPE                  WORKFLOW
+tis24dev/proxsave  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v0.29.0
 ```
 
-### Method 2: Verify All Artifacts
+### Method 2: verify both artifacts
 
-Verify all binaries downloaded in a directory.
+Both the uncompressed binary and the `.tar.gz` are attested (the attestation subject-path `build/proxsave_*` also covers the SBOM document).
 
 ```bash
-# Download all the binaries you need
 cd ~/downloads
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/proxsave-linux-amd64
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/proxsave-darwin-amd64
+wget "https://github.com/tis24dev/proxsave/releases/download/${TAG}/${ASSET}"
+wget "https://github.com/tis24dev/proxsave/releases/download/${TAG}/${ASSET}.tar.gz"
 
-# Verify all together
-gh attestation verify proxsave-* --repo tis24dev/proxsave
+gh attestation verify proxsave_${VER}_linux_amd64* --repo tis24dev/proxsave
 ```
 
-### Method 3: Verification with JSON Output
+### Method 3: verification with JSON output
 
 For integrating verification into scripts or for detailed analysis.
 
 ```bash
-gh attestation verify proxsave-linux-amd64 \
+gh attestation verify "${ASSET}" \
   --repo tis24dev/proxsave \
   --format json | jq
 ```
@@ -144,19 +141,14 @@ gh attestation verify proxsave-linux-amd64 \
 {
   "verificationResult": {
     "verifiedTimestamps": [
-      {
-        "timestamp": "2024-11-28T10:30:45Z",
-        "source": "Rekor"
-      }
+      { "timestamp": "2025-06-20T10:30:45Z", "source": "Rekor" }
     ],
     "statement": {
       "_type": "https://in-toto.io/Statement/v1",
       "subject": [
         {
-          "name": "proxsave-linux-amd64",
-          "digest": {
-            "sha256": "abc123..."
-          }
+          "name": "proxsave_0.29.0_linux_amd64",
+          "digest": { "sha256": "abc123..." }
         }
       ],
       "predicateType": "https://slsa.dev/provenance/v1",
@@ -165,7 +157,7 @@ gh attestation verify proxsave-linux-amd64 \
           "buildType": "https://slsa.dev/provenance/github/actions/v1",
           "externalParameters": {
             "workflow": {
-              "ref": "refs/tags/v0.9.0",
+              "ref": "refs/tags/v0.29.0",
               "repository": "https://github.com/tis24dev/proxsave"
             }
           }
@@ -176,303 +168,163 @@ gh attestation verify proxsave-linux-amd64 \
 }
 ```
 
-### Method 4: Offline Verification (with downloaded bundle)
+### Method 4: offline verification (with downloaded bundle)
 
 Useful for air-gapped environments or for archiving attestations.
 
 ```bash
 # Download the attestation as a bundle
-gh attestation download proxsave-linux-amd64 \
+gh attestation download "${ASSET}" \
   --repo tis24dev/proxsave \
   --output attestation.jsonl
 
 # Verify offline using the bundle
-gh attestation verify proxsave-linux-amd64 \
+gh attestation verify "${ASSET}" \
   --bundle attestation.jsonl \
   --repo tis24dev/proxsave
 ```
 
-## Complete Practical Examples
-
-### Example 1: Linux - Verification and Installation
+## A complete verify-and-install example (Linux)
 
 ```bash
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# 1. Download the binary
-echo "Downloading binary..."
-wget -q https://github.com/tis24dev/proxsave/releases/download/v0.9.0/proxsave-linux-amd64
+TAG=vX.Y.Z                       # the release you want, e.g. v0.29.0
+VER=${TAG#v}
+ASSET="proxsave_${VER}_linux_amd64"
 
-# 2. Verify the attestation
+echo "Downloading ${ASSET}..."
+wget -q "https://github.com/tis24dev/proxsave/releases/download/${TAG}/${ASSET}"
+
 echo "Verifying attestation..."
-if gh attestation verify proxsave-linux-amd64 --repo tis24dev/proxsave; then
-    echo "✓ Attestation verified successfully!"
+if gh attestation verify "${ASSET}" --repo tis24dev/proxsave; then
+    echo "Attestation verified."
 else
-    echo "✗ Attestation verification failed!"
-    rm proxsave-linux-amd64
+    echo "Attestation verification failed."
+    rm -f "${ASSET}"
     exit 1
 fi
 
-# 3. Make executable
-chmod +x proxsave-linux-amd64
-
-# 4. Move to /usr/local/bin
-sudo mv proxsave-linux-amd64 /usr/local/bin/proxsave
-
-echo "Installation complete!"
+chmod +x "${ASSET}"
+sudo mv "${ASSET}" /usr/local/bin/proxsave
 proxsave --version
 ```
 
-### Example 2: macOS - Verification with Homebrew Alternative
+For most users the recommended path is still the install script, which performs the `SHA256SUMS.sig` signature check automatically:
 
 ```bash
-#!/bin/bash
-set -e
-
-VERSION="v0.9.0"
-BINARY="proxsave-darwin-$(uname -m)"
-URL="https://github.com/tis24dev/proxsave/releases/download/${VERSION}/${BINARY}"
-
-# Download
-echo "Downloading ${BINARY}..."
-curl -L -o proxsave "${URL}"
-
-# Verify
-echo "Verifying provenance..."
-gh attestation verify proxsave --repo tis24dev/proxsave || {
-    echo "Verification failed!"
-    rm proxsave
-    exit 1
-}
-
-# Install
-chmod +x proxsave
-sudo mv proxsave /usr/local/bin/
-echo "Installed successfully!"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/tis24dev/proxsave/main/install.sh)"
 ```
 
-### Example 3: Windows PowerShell - Verification and Installation
-
-```powershell
-# Download binary
-$version = "v0.9.0"
-$binary = "proxsave-windows-amd64.exe"
-$url = "https://github.com/tis24dev/proxsave/releases/download/$version/$binary"
-
-Write-Host "Downloading $binary..." -ForegroundColor Cyan
-Invoke-WebRequest -Uri $url -OutFile "proxsave.exe"
-
-# Verify attestation
-Write-Host "Verifying attestation..." -ForegroundColor Cyan
-$result = gh attestation verify proxsave.exe --repo tis24dev/proxsave
-
-if ($LASTEXITCODE -eq 0) {
-    Write-Host "✓ Attestation verified successfully!" -ForegroundColor Green
-
-    # Move to Program Files
-    $destPath = "$env:ProgramFiles\ProxmoxBackup"
-    New-Item -ItemType Directory -Force -Path $destPath | Out-Null
-    Move-Item -Path "proxsave.exe" -Destination "$destPath\proxsave.exe" -Force
-
-    # Add to PATH if not already there
-    $currentPath = [Environment]::GetEnvironmentVariable("Path", "Machine")
-    if ($currentPath -notlike "*$destPath*") {
-        [Environment]::SetEnvironmentVariable("Path", "$currentPath;$destPath", "Machine")
-        Write-Host "Added to system PATH" -ForegroundColor Green
-    }
-
-    Write-Host "Installation complete!" -ForegroundColor Green
-} else {
-    Write-Host "✗ Attestation verification failed!" -ForegroundColor Red
-    Remove-Item "proxsave.exe"
-    exit 1
-}
-```
-
-## What Gets Verified
+## What gets verified
 
 When you run `gh attestation verify`, the following checks are performed:
 
 | Verification | Description |
 |--------------|-------------|
-| ✓ **Source repository** | Confirms that the build comes from `github.com/tis24dev/proxsave` |
-| ✓ **Commit SHA** | Verifies the exact commit used for the build |
-| ✓ **Workflow** | Checks that `.github/workflows/release.yml` was used |
-| ✓ **Build environment** | Confirms that the build occurred on GitHub-hosted runner |
-| ✓ **SHA256 integrity** | Calculates the file hash and compares it with the attested one |
-| ✓ **Cryptographic signature** | Verifies the OIDC/Sigstore signature on the attestation |
-| ✓ **Rekor timestamp** | Checks the immutable record in the transparency log |
-| ✓ **SLSA compliance** | Verifies that the attestation complies with the SLSA v1 standard |
+| Source repository | Confirms the build comes from `github.com/tis24dev/proxsave` |
+| Commit SHA | Verifies the exact commit used for the build |
+| Workflow | Checks that `.github/workflows/release.yml` was used |
+| Build environment | Confirms the build occurred on a GitHub-hosted runner |
+| SHA256 integrity | Recomputes the file hash and compares it with the attested one |
+| Cryptographic signature | Verifies the OIDC/Sigstore signature on the attestation |
+| Rekor timestamp | Checks the immutable record in the transparency log |
+| SLSA compliance | Verifies the attestation complies with the SLSA v1 standard |
 
 ## Troubleshooting
 
+The variables `TAG`, `VER`, and `ASSET` below are the ones defined in [Verification methods](#verification-methods).
+
 ### Error: "no attestations found"
 
-**Cause**: The release does not include attestations (release prior to this feature).
+**Cause**: the release does not include attestations (a release created before this feature).
 
 **Solution**:
 ```bash
-# Check the release version
-gh release view v0.9.0 --repo tis24dev/proxsave
-
-# Note: older releases may not include attestations/provenance data.
+gh release view "${TAG}" --repo tis24dev/proxsave
+# Older releases may not include attestation/provenance data.
 ```
 
 ### Error: "gh: command not found"
 
 **Cause**: GitHub CLI is not installed or not in PATH.
 
-**Solution**: Install `gh` following the instructions in the Prerequisites section above.
+**Solution**: install `gh` following the Prerequisites section above.
 
 ### Error: "failed to verify signature"
 
-**Cause**: The file may have been tampered with or corrupted.
+**Cause**: the file may have been tampered with or corrupted.
 
 **Solution**:
 ```bash
-# Re-download the binary
-rm proxsave-linux-amd64
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/proxsave-linux-amd64
-
-# Retry verification
-gh attestation verify proxsave-linux-amd64 --repo tis24dev/proxsave
+rm -f "${ASSET}"
+wget "https://github.com/tis24dev/proxsave/releases/download/${TAG}/${ASSET}"
+gh attestation verify "${ASSET}" --repo tis24dev/proxsave
 ```
 
-If the problem persists, **DO NOT use the binary** and report the issue by opening an issue on GitHub.
+If the problem persists, **do not use the binary** and report the issue on GitHub.
 
 ### Error: "attestation verification failed: subject digest mismatch"
 
-**Cause**: The SHA256 hash of the file does not match the one in the attestation.
-
-**Possible causes**:
-- File downloaded partially (interrupted download)
-- File modified after download
-- File corrupted during transfer
+**Cause**: the SHA256 hash of the file does not match the attested one (partial download, modification, or corruption).
 
 **Solution**:
 ```bash
-# Check file size
-ls -lh proxsave-linux-amd64
+ls -lh "${ASSET}"
+rm -f "${ASSET}"
+wget "https://github.com/tis24dev/proxsave/releases/download/${TAG}/${ASSET}"
 
-# Re-download completely
-rm proxsave-linux-amd64
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/proxsave-linux-amd64
-
-# Manual checksum verification (optional)
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/SHA256SUMS
-sha256sum -c SHA256SUMS
+# Optional: cross-check against the signed checksums
+wget "https://github.com/tis24dev/proxsave/releases/download/${TAG}/SHA256SUMS"
+sha256sum --ignore-missing -c SHA256SUMS
 ```
 
 ### Error: "HTTP 401: Bad credentials"
 
-**Cause**: GitHub CLI is not authenticated or the token has expired.
+**Cause**: GitHub CLI is not authenticated or the token expired.
 
 **Solution**:
 ```bash
-# Authenticate with GitHub
 gh auth login
-
-# Or use a token
+# or
 export GITHUB_TOKEN=your_personal_access_token
 ```
 
 ### Slow verification or timeout
 
-**Cause**: Connection issues to the transparency log (Rekor).
+**Cause**: connection issues to the transparency log (Rekor).
 
-**Solution**:
-```bash
-# Use offline verification if you've already downloaded the attestation
-gh attestation download proxsave-linux-amd64 --repo tis24dev/proxsave -o attestation.jsonl
-gh attestation verify proxsave-linux-amd64 --bundle attestation.jsonl --repo tis24dev/proxsave
-```
+**Solution**: use offline verification if you already downloaded the attestation bundle (Method 4).
 
-## Security Considerations
+## Security considerations
 
-### Trust Model
+### Trust model
 
 Attestations are based on:
 1. **GitHub Actions OIDC**: GitHub signs attestations using short-lived OIDC tokens
-2. **Sigstore/Rekor**: Public transparency log that records all attestations
-3. **SLSA Framework**: Industry standard for provenance metadata
+2. **Sigstore/Rekor**: a public transparency log that records all attestations
+3. **SLSA framework**: an industry standard for provenance metadata
 
-**What this means**: You must trust GitHub as the root of trust. If GitHub is compromised, attestations could be forged.
+**What this means**: you must trust GitHub as the root of trust for the attestations. If GitHub is compromised, attestations could be forged. The pinned-key `SHA256SUMS.sig` signature is an independent check that does not rely on GitHub as a signer.
 
-### Transparency Log (Rekor)
+### Transparency log (Rekor)
 
-Every attestation is publicly recorded on https://search.sigstore.dev/
+Every attestation is publicly recorded and searchable at https://search.sigstore.dev/ (filter by `tis24dev/proxsave`).
 
-**Benefits**:
-- Immutable and publicly auditable registry
+Benefits:
+- Immutable, publicly auditable registry
 - Verifiable timestamps
 - No secrets to manage (keyless signing)
 
-**What you can check**:
-```bash
-# Search for attestations for this repository
-open "https://search.sigstore.dev/?logIndex=&email=&hash=&logEntry=&uuid="
-# Filter by: tis24dev/proxsave
-```
+### Best practices
 
-### Comparison with GPG Signing
-
-| Aspect | Attestations (new) | GPG Signing (old) |
-|--------|-------------------|-------------------|
-| **Key management** | None (keyless) | Requires private key management |
-| **Key rotation** | Automatic | Manual and complex |
-| **Revocation** | Timestamp-based | Requires key revocation |
-| **Transparency** | Public registry | Only if published on keyserver |
-| **Build metadata** | Complete SLSA provenance | Only checksum signature |
-| **Verification** | `gh attestation verify` | `gpg --verify` |
-| **Trust model** | GitHub OIDC + Sigstore | Web of trust / keyserver |
-
-### Best Practices
-
-1. **Always verify before use**: Do not run unverified binaries
-2. **Use HTTPS**: Always download from `https://github.com`
-3. **Verify the repository**: Ensure it's `tis24dev/proxsave`
-4. **Update gh CLI**: Keep GitHub CLI updated for the latest security features
-5. **Automation**: Integrate verification into your deployment scripts
-6. **Archive attestations**: Save attestations for future audits
-
-## Migration from GPG
-
-### For Users Who Used Old GPG Signing
-
-**What changed**:
-- ✗ We no longer generate `SHA256SUMS.asc` (GPG signature)
-- ✓ We generate SLSA provenance attestations
-- ✓ We continue to generate `SHA256SUMS` (plain checksums)
-
-**Previous releases** (v0.9.0 and earlier):
-- Use GPG signing (key: CD28A21CC11B270E)
-- Verify with: `gpg --verify SHA256SUMS.asc SHA256SUMS`
-
-**New releases** (v0.9.1+):
-- Use GitHub attestations
-- Verify with: `gh attestation verify`
-
-### Migration Script
-
-If you have scripts that use GPG, here's how to migrate them:
-
-**Before (GPG)**:
-```bash
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/proxsave-linux-amd64
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/SHA256SUMS
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.0/SHA256SUMS.asc
-gpg --verify SHA256SUMS.asc SHA256SUMS
-sha256sum -c SHA256SUMS
-```
-
-**After (Attestations)**:
-```bash
-wget https://github.com/tis24dev/proxsave/releases/download/v0.9.1/proxsave-linux-amd64
-gh attestation verify proxsave-linux-amd64 --repo tis24dev/proxsave
-```
-
-Much simpler! 🎉
+1. **Always verify before use**: do not run unverified binaries.
+2. **Use HTTPS**: always download from `https://github.com`.
+3. **Verify the repository**: ensure it is `tis24dev/proxsave`.
+4. **Keep `gh` updated**: newer versions carry the latest verification logic.
+5. **Automate**: integrate verification into your deployment scripts.
+6. **Archive attestations**: save attestation bundles for future audits.
 
 ## References
 
@@ -486,8 +338,8 @@ Much simpler! 🎉
 ## Support
 
 If you have problems with attestation verification:
-1. Check this documentation for troubleshooting
-2. Verify you have the latest version of `gh` CLI
-3. Open an issue on https://github.com/tis24dev/proxsave/issues
+1. Check this documentation for troubleshooting.
+2. Make sure you have the latest `gh` CLI.
+3. Open an issue on https://github.com/tis24dev/proxsave/issues.
 
-**Security note**: If you suspect that an attestation has been forged or compromised, **DO NOT use the binary** and immediately report it by opening a private security advisory on GitHub.
+**Security note**: if you suspect an attestation has been forged or compromised, **do not use the binary** and report it by opening a private security advisory on GitHub.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ below for the current operational and technical behavior.
 - [CLI_REFERENCE.md](CLI_REFERENCE.md): commands, flags, and workflow phases
 - [EXAMPLES.md](EXAMPLES.md): ready-to-use configuration examples
 - [RESTORE_GUIDE.md](RESTORE_GUIDE.md): full restore guide and category behavior
+- [NOTIFICATIONS.md](NOTIFICATIONS.md): notification channels and the centralized bot relay
 - [TROUBLESHOOTING.md](TROUBLESHOOTING.md): operational diagnostics and fixes
 
 ## Architecture & Developer Docs

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -1,73 +1,83 @@
 # Release Process (Proxsave Go)
 
-This document describes the safe, repeatable procedure to publish a new **Proxsave** release using the repository’s GitHub Actions workflows.
+This document describes the safe, repeatable procedure to publish a new **Proxsave** release using the repository's GitHub Actions workflows.
 
 ## Overview
 
-Release flow:
+You do not tag `main` by hand. A release is started by pushing a lightweight trigger tag on `dev`, and the automation opens the release PR, creates the authoritative version tag after the merge, and publishes the release:
 
 ```
-dev → Pull Request → main → tag vX.Y.Z → GitHub Actions (GoReleaser) → GitHub Release
+push pr-vX.Y.Z on dev
+  -> release-intake.yml opens a dev -> main PR (marker: <!-- release-tag: vX.Y.Z -->)
+  -> release-guard.yml validates the PR
+  -> squash-merge the PR into main
+  -> post-merge-release.yml force-moves dev and creates the vX.Y.Z tag on the squash commit
+  -> release.yml (GoReleaser) builds, signs, and publishes the GitHub Release
 ```
 
-No binaries should ever be committed to the repository. All release artifacts are produced by GoReleaser.
+No binaries are ever committed to the repository. All release artifacts are produced by GoReleaser.
 
 ## Branch model
 
-- `dev`: day-to-day development (features, fixes, refactors)
-- `main`: stable branch; releases are tagged from here
+- `dev`: day-to-day development (features, fixes, refactors). Releases are started from here.
+- `main`: the released branch. The `vX.Y.Z` tag is created on the squash commit that lands on `main`.
 
-After a PR is merged into `main`, the `dev` branch is automatically synced to `main` by `.github/workflows/sync-dev.yml`.
+After a dev -> main PR merges, `post-merge-release.yml` force-moves `dev` onto the squash commit with `--force-with-lease` (this replaced the old `sync-dev.yml`). The squash commit is not a descendant of the old `dev`, so the move is forced, not a fast-forward; a tree-equality check first guarantees the squash content matches `dev` exactly, so nothing is lost. Maintenance (non-release) dev -> main PRs are allowed too: they carry no release marker, so `dev` is synced but no release is published.
 
 ## Step-by-step
 
 ### 1) Work on `dev`
 
-- Make changes on `dev`
-- Commit using Conventional Commits (examples):
-  - `feat: ...` (new feature)
-  - `fix: ...` (bug fix)
-  - `refactor: ...` (refactor)
-  - `feat!: ...` or `BREAKING CHANGE:` (breaking change)
-- Push `dev` to origin
+- Make changes on `dev`.
+- Commit using Conventional Commits (`feat:`, `fix:`, `refactor:`, `feat!:` / `BREAKING CHANGE:` for breaking changes).
+- Push `dev` to origin.
 
-### 2) Open a PR `dev` → `main`
+### 2) Start the release: push a `pr-vX.Y.Z` trigger tag on `dev`
 
-- Create a Pull Request from `dev` to `main`
-- Wait for all checks to pass (CI/security/static analysis)
-
-### 3) Merge into `main`
-
-Merge the PR only when checks are green. The resulting commit on `main` (merge commit or squash commit) is what you will tag.
-
-### 4) Create and push a SemVer tag on `main`
-
-The release workflow triggers on tag pushes matching `v*` and validates a SemVer-like format:
-
-- Stable: `vMAJOR.MINOR.PATCH` (example: `v1.6.0`)
-- Prerelease: `vMAJOR.MINOR.PATCH-rc1` / `-beta1` / etc. (example: `v1.6.0-rc1`)
-
-CLI example:
+The trigger tag is `pr-` plus the version you want to publish. It is unprotected and deliberately does NOT match the `v*` glob, so it never triggers `release.yml` and can be created and deleted freely:
 
 ```bash
-git checkout main
+git checkout dev
 git pull --ff-only
-git tag v1.6.0
-git push origin v1.6.0
+git tag pr-v1.6.0        # or pr-v1.6.0-rc1 / pr-v1.6.0-beta1 for a prerelease
+git push origin pr-v1.6.0
 ```
 
-### 5) GitHub Actions builds and publishes the release
+`release-intake.yml` then:
 
-Once the tag is pushed:
+- checks the trigger tag points to the current HEAD of `dev`;
+- refuses if the version `v1.6.0` already exists as a tag or release (immutable versions), and fails closed on a transient lookup error;
+- refuses if a DIFFERENT dev -> main PR is already open (re-pushing the same `pr-v1.6.0` while its release PR is already open is a no-op);
+- deletes the `pr-v1.6.0` trigger tag (its job is done);
+- opens a PR `dev -> main` titled `Release v1.6.0` whose body carries the marker `<!-- release-tag: v1.6.0 -->`.
 
-- Workflow: `.github/workflows/release.yml`
-- GoReleaser config: `.github/.goreleaser.yml`
-- Output: GitHub Release with binaries, archives, checksums, and SBOMs
-- Provenance: `actions/attest-build-provenance` generates provenance for artifacts matching `build/proxsave_*`
+### 3) Let the guard validate the PR
+
+`release-guard.yml` runs on the PR and enforces its shape: the base is `main`, the head is `dev`, the PR comes from this same repository, and (when a release marker is present) the tag is a well-formed `vX.Y.Z`. Wait for CI, security, and static-analysis checks to pass.
+
+### 4) Squash-merge the PR into `main`
+
+Merge the PR using a SQUASH merge once checks are green. The merge must be a squash: `post-merge-release.yml` refuses a non-squash merge.
+
+### 5) Automation creates the tag and publishes the release
+
+`post-merge-release.yml` runs on the merged PR and, for a release PR:
+
+- force-moves `dev` onto the squash commit with `--force-with-lease` (safe because the squash content equals `dev`);
+- creates the authoritative annotated `v1.6.0` tag ONCE on that squash commit and pushes it (a tag creation, which the tag-immutability ruleset allows). It never force-pushes or moves a `v*` tag.
+
+Pushing the `v1.6.0` tag re-triggers `release.yml`, which:
+
+- gates the release on the tag being reachable from `origin/main` (a stray `v*` tag on a dev commit is not released);
+- validates the SemVer tag;
+- validates the signing key against the pinned public key BEFORE publishing (so a missing or wrong signing secret fails before anything goes live);
+- runs GoReleaser (`.github/.goreleaser.yml`) to build, archive, generate the SBOM and checksums, and create the GitHub Release;
+- signs `SHA256SUMS` with the project ECDSA P-256 key, verifies it against the pinned key, and uploads `SHA256SUMS.sig`;
+- attests build provenance for `build/proxsave_*` via `actions/attest-build-provenance`.
 
 ## What you should see in Release assets
 
-For tag `v1.6.0` (GoReleaser strips the leading `v` for the version in filenames), typical assets include:
+Only `linux/amd64` is built and published. For tag `v1.6.0` (GoReleaser drops the leading `v` in filenames) the assets are:
 
 ```
 proxsave_1.6.0_linux_amd64
@@ -77,13 +87,13 @@ SHA256SUMS
 SHA256SUMS.sig
 ```
 
-`SHA256SUMS.sig` is **mandatory**: the install/upgrade flow refuses to proceed
-without a verifiable release signature (`install.sh` downloads and verifies it),
-and the release workflow validates the signing key before publishing.
+`proxsave_1.6.0_linux_amd64` is the uncompressed binary (GoReleaser archive id `binary`); the `.tar.gz` is the same binary plus `LICENSE` and `README.md`.
 
-## Install script (optional)
+`SHA256SUMS.sig` is **mandatory**: the install and upgrade flow refuses to proceed without a verifiable release signature (`install.sh` and `proxsave --upgrade` download and verify it), and `release.yml` validates the signing key before publishing. See [PROVENANCE_VERIFICATION.md](PROVENANCE_VERIFICATION.md).
 
-Users can install the latest `main` version using:
+## Install script
+
+Users install the latest published version with:
 
 ```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/tis24dev/proxsave/main/install.sh)"
@@ -91,11 +101,11 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/tis24dev/proxsave/main/i
 
 ## What not to do
 
-- Do not commit binaries or the `build/` directory
-- Do not tag commits on `dev`
-- Do not create GitHub Releases manually (the workflow does it)
-- Do not tag old commits; tag the exact commit you want to ship on `main`
+- Do not commit binaries or the `build/` directory.
+- Do not push a bare `v*` tag on `dev`. The trigger you push on `dev` is the `pr-v*` tag; the real `v*` tag is created by the automation on the squash commit on `main`.
+- Do not create GitHub Releases manually (the workflow does it).
+- Do not try to move or re-tag a published `v*` tag: version tags are immutable, and the automation only ever creates one once.
 
-## Notes on future automation (auto-tagging)
+### Legacy escape hatch
 
-An auto-tag workflow exists at `.github/workflows/autotag.yml` but is currently disabled (`if: false`). If enabled, it can create tags automatically based on Conventional Commit messages.
+`release.yml` also releases a `v*` tag pushed directly onto a commit that is already on `main` (it passes the reachable-from-main gate immediately). This is a fallback only; the normal path is the `pr-v*` trigger tag on `dev`.

--- a/docs/RESTORE_DIAGRAMS.md
+++ b/docs/RESTORE_DIAGRAMS.md
@@ -10,7 +10,7 @@ textual restore rules.
 - [Complete Restore Workflow](#complete-restore-workflow)
 - [Category Decision Tree](#category-decision-tree)
 - [Service Management Flow](#service-management-flow)
-- [Two-Pass Extraction](#two-pass-extraction)
+- [Three-Tier Extraction](#three-tier-extraction)
 - [Cluster Database Restore Sequence](#cluster-database-restore-sequence)
 - [Error Handling Flow](#error-handling-flow)
 - [PBS Datastore Mount Guards](#pbs-datastore-mount-guards)
@@ -105,7 +105,7 @@ flowchart TD
     SystemFull -->|PVE| PVEFull[PVE Categories:<br/>- pve_cluster<br/>- storage_pve<br/>- pve_jobs<br/>- pve_notifications<br/>- pve_access_control<br/>- pve_firewall<br/>- pve_ha<br/>- pve_sdn<br/>- corosync<br/>- ceph<br/>+ Common]
     SystemFull -->|PBS| PBSFull[PBS Categories:<br/>- pbs_host<br/>- datastore_pbs<br/>- maintenance_pbs<br/>- pbs_jobs<br/>- pbs_remotes<br/>- pbs_notifications<br/>- pbs_access_control<br/>- pbs_tape<br/>+ Common]
     SystemFull -->|DUAL| DualFull[Dual Categories:<br/>- PVE categories<br/>- PBS categories<br/>- Common categories]
-    SystemFull -->|Unknown| CommonFull[Common Only:<br/>- filesystem<br/>- storage_stack<br/>- network<br/>- ssl<br/>- ssh<br/>- scripts<br/>- crontabs<br/>- services<br/>- user_data<br/>- zfs<br/>- proxsave_info]
+    SystemFull -->|Unknown| CommonFull[Common Only:<br/>- filesystem<br/>- storage_stack<br/>- network<br/>- ssl<br/>- ssh<br/>- scripts<br/>- crontabs<br/>- services<br/>- accounts<br/>- user_data<br/>- zfs<br/>- proxsave_info]
 
     Storage --> SystemStorage{System Type?}
     SystemStorage -->|PVE| PVEStorage[- pve_cluster<br/>- storage_pve<br/>- pve_jobs<br/>- filesystem<br/>- storage_stack<br/>- zfs]
@@ -214,58 +214,55 @@ sequenceDiagram
 
 ---
 
-## Two-Pass Extraction
+## Three-Tier Extraction
+
+`splitRestoreCategories` divides the selected categories into three tiers. Normal
+categories go straight to `/`, export-only categories go to a read-only export
+directory, and staged (sensitive) categories are extracted strictly into a stage
+directory and then applied (Phase 10). If any staged entry fails, the staged apply is
+skipped and the live system is left untouched (BH-002).
 
 ```mermaid
 flowchart LR
     subgraph Input
-        Archive[backup.tar.gz]
+        Archive[backup archive]
     end
 
-    subgraph "Pass 1: Normal Categories"
-        Open1[Open Archive]
-        Decompress1[Decompress]
-        Scan1[Scan TAR Entries]
-        Filter1{Matches Normal<br/>Category?}
+    subgraph "Tier 1: Normal categories"
+        Filter1{Matches a<br/>Normal category?}
         Extract1[Extract to /]
-        Skip1[Skip Entry]
     end
 
-    subgraph "Pass 2: Export-Only Categories"
-        Open2[Open Archive]
-        Decompress2[Decompress]
-        Scan2[Scan TAR Entries]
-        Filter2{Matches Export<br/>Category?}
-        Extract2[Extract to<br/>Export Dir]
-        Skip2[Skip Entry]
+    subgraph "Tier 2: Export-only categories"
+        Filter2{Matches an<br/>Export-only category?}
+        Extract2[Extract to<br/>Export Dir, read-only]
+    end
+
+    subgraph "Tier 3: Staged (sensitive) categories"
+        Filter3{Matches a<br/>Staged category?}
+        Stage3[Extract to<br/>stage dir, strict]
+        Apply3[Staged apply<br/>PBS/PVE/SDN/ACL/accounts/notify]
     end
 
     subgraph Output
         SystemRoot[System Root /<br/>- /var/lib/pve-cluster/<br/>- /etc/network/<br/>- etc.]
-        ExportDir[Export Directory<br/>BASE_DIR/proxmox-config-export-TIMESTAMP/<br/>- etc/pve/storage.cfg<br/>- etc/pve/datacenter.cfg<br/>- etc.]
+        ExportDir[Export Directory<br/>BASE_DIR/proxmox-config-export-TIMESTAMP/<br/>- etc/pve/storage.cfg<br/>- etc.]
+        Live[Live config applied<br/>atomically, or skipped on<br/>any staged failure - BH-002]
     end
 
-    Archive --> Open1
-    Open1 --> Decompress1
-    Decompress1 --> Scan1
-    Scan1 --> Filter1
-    Filter1 -->|Yes| Extract1
-    Filter1 -->|No| Skip1
-    Skip1 --> Scan1
-    Extract1 --> SystemRoot
+    Archive --> Filter1
+    Filter1 -->|Yes| Extract1 --> SystemRoot
 
-    Archive --> Open2
-    Open2 --> Decompress2
-    Decompress2 --> Scan2
-    Scan2 --> Filter2
-    Filter2 -->|Yes| Extract2
-    Filter2 -->|No| Skip2
-    Skip2 --> Scan2
-    Extract2 --> ExportDir
+    Archive --> Filter2
+    Filter2 -->|Yes| Extract2 --> ExportDir
+
+    Archive --> Filter3
+    Filter3 -->|Yes| Stage3 --> Apply3 --> Live
 
     style Archive fill:#87CEEB
     style SystemRoot fill:#90EE90
     style ExportDir fill:#FFD700
+    style Live fill:#FFA500
 ```
 
 ---
@@ -539,21 +536,16 @@ flowchart TD
     ReadManifest --> CheckEnc{EncryptionMode?}
 
     CheckEnc -->|"none"| Plain[Use Archive Directly]
-    CheckEnc -->|"age"| ShowOptions[Show Decryption Options]
+    CheckEnc -->|"age"| GetSecret[Prompt: AGE key or passphrase<br/>single field, 0 = exit]
 
-    ShowOptions --> UserChoice{User Selects?}
-    UserChoice -->|1. Passphrase| GetPass[Get AGE Passphrase]
-    UserChoice -->|2. Identity| GetKey[Get AGE Identity File]
-    UserChoice -->|0. Cancel| Abort([Abort])
-
-    GetPass --> PrepareTemp[Prepare /tmp/proxsave/proxmox-decrypt-XXXX/]
-    GetKey --> PrepareTemp
+    GetSecret -->|"0 = exit"| Abort([Abort])
+    GetSecret --> PrepareTemp[Prepare /tmp/proxsave/proxmox-decrypt-XXXX/]
 
     PrepareTemp --> Decrypt[Run AGE Decrypt]
     Decrypt --> DecryptResult{Success?}
 
     DecryptResult -->|No| RetryPrompt{Retry?}
-    RetryPrompt -->|Yes| ShowOptions
+    RetryPrompt -->|Yes| GetSecret
     RetryPrompt -->|No| Abort
 
     DecryptResult -->|Yes| ChecksumCheck{Checksum Available?}
@@ -696,8 +688,8 @@ flowchart TD
 ## PBS Datastore Mount Guards
 
 When restoring PBS configuration, a datastore's backing mount may be **offline**
-(not yet mounted). Without protection, restoring the datastore layout — or PBS
-starting afterwards — would write into the empty mount-point directory on the
+(not yet mounted). Without protection, restoring the datastore layout, or PBS
+starting afterwards, would write into the empty mount-point directory on the
 **root filesystem**, filling `/` and creating a "ghost" datastore. The mount
 guard blocks that path until the real storage is back.
 
@@ -722,7 +714,7 @@ flowchart TD
 ```
 
 **Auto-restore (shadowing)**: when the real datastore mount comes back online it
-stacks **on top of** the guard (overlay), so the datastore is usable again — but
+stacks **on top of** the guard (overlay), so the datastore is usable again, but
 the guard is only **shadowed**, not removed.
 
 **Warn-only fallback**: if the read-only bind mount cannot be created, ProxSave logs

--- a/docs/RESTORE_GUIDE.md
+++ b/docs/RESTORE_GUIDE.md
@@ -24,16 +24,19 @@ PVE+PBS backups using the interactive restore workflow.
 ### Basic Restore
 
 ```bash
-# Run the interactive restore workflow
+# Run the interactive restore workflow (launches the TUI by default)
 proxsave --restore
 
-# Follow the prompts:
+# Add --cli to force the classic text prompts instead of the TUI
+proxsave --restore --cli
+
+# The steps, either way:
 # 1. Select backup source location
 # 2. Choose specific backup from list
-# 3. Enter decryption passphrase (if encrypted)
+# 3. Enter the AGE key or passphrase in a single field (if encrypted)
 # 4. Select restore mode
 # 5. Review restore plan
-# 6. Type "RESTORE" to confirm
+# 6. Confirm twice: type RESTORE (or press the RESTORE button), then confirm the overwrite
 # 7. Wait for completion
 # 8. Verify services and cluster status
 ```
@@ -58,6 +61,18 @@ The restore documentation is split on purpose:
 - [RESTORE_GUIDE.md](RESTORE_GUIDE.md): operator workflow, modes, warnings, and practical examples
 - [RESTORE_TECHNICAL.md](RESTORE_TECHNICAL.md): implementation details, detection logic, and internal architecture
 - [RESTORE_DIAGRAMS.md](RESTORE_DIAGRAMS.md): visual companion for the main workflow and decision paths
+
+### Interactive UI: TUI by default, `--cli` for text prompts
+
+`proxsave --restore` and `proxsave --decrypt` launch a **Charm TUI** by default: a
+selector for the restore mode, a multi-select list for CUSTOM categories, and labeled
+confirmation buttons. Add **`--cli`** to force the classic text prompts and numbered
+menus instead (`--cli` works with `--install`, `--new-install`, `--newkey`,
+`--decrypt`, and `--restore`). Both paths run the same restore engine and ask the same questions.
+
+The numbered-menu and text transcripts throughout this guide show the `--cli`
+experience because it is the clearest to read on the page; in the default TUI the same
+steps appear as a selector, a multi-select, and buttons.
 
 ### Key Features
 
@@ -117,7 +132,11 @@ ProxSave warns because role-specific compatibility cannot be verified.
 
 ## Category System
 
-Restore operations are organized into **20–22 categories** (PBS = 20, PVE = 22) that group related configuration files.
+Restore operations are organized into categories that group related configuration
+files. The code defines **32 categories** in total: **11 PVE**, **9 PBS**, and **12
+Common**. A host only sees the categories relevant to it: a **PVE host sees 23** (11
+PVE + 12 Common) and a **PBS host sees 21** (9 PBS + 12 Common); a `dual` host sees all
+32.
 
 ### Category Handling Types
 
@@ -163,7 +182,7 @@ API apply is automatic for supported PBS staged categories; ProxSave may fall ba
 | `pbs_access_control` | PBS Access Control | **Staged** access control + secrets restored 1:1 (root@pam safety rail) | `./etc/proxmox-backup/user.cfg`<br>`./etc/proxmox-backup/domains.cfg`<br>`./etc/proxmox-backup/acl.cfg`<br>`./etc/proxmox-backup/token.cfg`<br>`./etc/proxmox-backup/shadow.json`<br>`./etc/proxmox-backup/token.shadow`<br>`./etc/proxmox-backup/tfa.json`<br>`./var/lib/proxsave-info/commands/pbs/user_list.json`<br>`./var/lib/proxsave-info/commands/pbs/realms_ldap.json`<br>`./var/lib/proxsave-info/commands/pbs/realms_ad.json`<br>`./var/lib/proxsave-info/commands/pbs/realms_openid.json`<br>`./var/lib/proxsave-info/commands/pbs/acl_list.json` |
 | `pbs_tape` | PBS Tape Backup | **Staged** tape config, jobs and encryption keys | `./etc/proxmox-backup/tape.cfg`<br>`./etc/proxmox-backup/tape-job.cfg`<br>`./etc/proxmox-backup/media-pool.cfg`<br>`./etc/proxmox-backup/tape-encryption-keys.json`<br>`./var/lib/proxsave-info/commands/pbs/tape_drives.json`<br>`./var/lib/proxsave-info/commands/pbs/tape_changers.json`<br>`./var/lib/proxsave-info/commands/pbs/tape_pools.json` |
 
-### Common Categories (11 categories)
+### Common Categories (12 categories)
 
 | Category | Name | Description | Paths |
 |----------|------|-------------|-------|
@@ -175,6 +194,7 @@ API apply is automatic for supported PBS staged categories; ProxSave may fall ba
 | `scripts` | Custom Scripts | User scripts and tools | `./usr/local/bin/`<br>`./usr/local/sbin/` |
 | `crontabs` | Scheduled Tasks | Cron jobs and systemd timers | `./etc/cron.d/`<br>`./etc/crontab`<br>`./var/spool/cron/` |
 | `services` | System Services | Systemd service configs and related system settings | `./etc/systemd/system/`<br>`./etc/default/`<br>`./etc/udev/rules.d/`<br>`./etc/apt/`<br>`./etc/logrotate.d/`<br>`./etc/timezone`<br>`./etc/sysctl.conf`<br>`./etc/sysctl.d/`<br>`./etc/modprobe.d/`<br>`./etc/modules`<br>`./etc/iptables/`<br>`./etc/nftables.conf`<br>`./etc/nftables.d/` |
+| `accounts` | System Accounts & Auth (WARNING) | Local system accounts and sudo policy, applied with a **safe merge** that preserves the current host root and system accounts (does not overwrite the auth database) | `./etc/passwd`<br>`./etc/group`<br>`./etc/shadow`<br>`./etc/gshadow`<br>`./etc/sudoers` |
 | `user_data` | User Data (Home Directories) | Root and user home directories (/root and /home) | `./root/`<br>`./home/` |
 | `zfs` | ZFS Configuration | ZFS pool cache and configs | `./etc/zfs/`<br>`./etc/hostid` |
 | `proxsave_info` | ProxSave Diagnostics (Export Only) | **Export-only** ProxSave command outputs and inventory reports (never written to system) | `./var/lib/proxsave-info/`<br>`./manifest.json` |
@@ -227,7 +247,12 @@ ProxSave restores `pbs_access_control` by applying staged files to `/etc/proxmox
 
 ## Restore Modes
 
-Four predefined modes provide common restoration scenarios, plus custom selection for advanced users.
+Four predefined modes provide common restoration scenarios, plus custom selection for advanced users. The mode ids are `full`, `storage`, `base`, and `custom`.
+
+> **Note on export-only categories.** FULL keeps the three export-only categories
+> (`pve_config_export`, `pbs_config`, `proxsave_info`) and writes them to the export
+> directory. The **STORAGE** and **SYSTEM BASE** presets strip export-only categories,
+> so an export-only id listed in a preset is silently dropped and never restored.
 
 ### 1. FULL Restore
 
@@ -487,16 +512,13 @@ Available backups:
 
 #### Phase 2: Decryption
 
-**For AGE-encrypted backups**:
+**For AGE-encrypted backups**, ProxSave asks for the secret in a **single field**
+that accepts either an AGE key or a passphrase (there is no separate "passphrase vs
+identity file" sub-menu). In the TUI this is a masked input labeled `Decrypt key`; the
+`--cli` prompt is:
+
 ```
-Backup is encrypted with AGE.
-
-Decryption options:
-  [1] Use AGE passphrase
-  [2] Use AGE identity file (key)
-  [0] Cancel
-
-Enter AGE passphrase: ********
+Enter decryption key or passphrase for pve01-backup-20251120-143052.tar.xz (0 = exit): ********
 Decrypting... (this may take several minutes)
 Decryption complete.
 Verifying SHA256 checksum...
@@ -612,8 +634,21 @@ Categories to restore:
   • Services may need to be restarted after restoration
   • PVE cluster services will be stopped during restore
 
-Type "RESTORE" (exact case) to proceed, or "cancel"/"0" to abort:
+Type 'RESTORE' to proceed or 'cancel' to abort:
 ```
+
+Confirmation is **two stages**. After you type `RESTORE` (or, in the TUI, press the
+`RESTORE` button), ProxSave asks a second, explicit overwrite question before touching
+anything:
+
+```
+This operation will overwrite existing configuration files on this system.
+
+Proceed with overwrite? (yes/no):
+```
+
+In the TUI this second gate is a danger-styled confirm with `Overwrite and restore` /
+`Cancel` buttons defaulting to Cancel. Only after both stages does extraction begin.
 
 #### Phase 8: Safety Backup
 
@@ -872,7 +907,7 @@ Cluster backup detected. Choose how to restore the cluster database:
 **Post-restore actions (SAFE mode)**:
 After export, the workflow offers interactive options to apply configurations via `pvesh`:
 1. **VM/CT configs**: Scans exported configs (under `/etc/pve/nodes/<node>/...`) and applies them via `pvesh set /nodes/<node>/qemu/<vmid>/config`
-   - If the target node hostname differs from the hostname stored in the backup (common after hardware migration / reinstall), ProxSave detects the mismatch and prompts you to select the exported node directory to import from (instead of silently reporting “No VM/CT configs found”).
+   - If the target node hostname differs from the hostname stored in the backup (common after hardware migration / reinstall), ProxSave detects the mismatch and prompts you to select the exported node directory to import from (instead of silently reporting "No VM/CT configs found").
 2. **Storage configuration**: Applies `storage.cfg` entries via `pvesh set /cluster/storage/<id>`
 3. **Datacenter configuration**: Applies `datacenter.cfg` via `pvesh set /cluster/config`
 
@@ -1837,12 +1872,12 @@ Type "RESTORE" (exact case) to proceed, or "cancel"/"0" to abort: _
 - Prevents accidental restoration
 
 **Prompt timeouts (auto-skip)**:
-- Some interactive prompts include a visible countdown (currently **90 seconds**) to avoid getting “stuck” waiting for input in remote/automated scenarios.
+- Some interactive prompts include a visible countdown (currently **90 seconds**) to avoid getting "stuck" waiting for input in remote/automated scenarios.
 - If the user does not answer before the countdown reaches 0, ProxSave proceeds with a **safe default** (no destructive action) and logs the decision.
 
 Current auto-skip prompts:
 - **Smart `/etc/fstab` merge**: defaults to **Skip** unless the backup root (and swap, when comparable) match the current system; when they match, the default is **Yes**.
-- **Live network apply** (“Apply restored network configuration now…”): defaults to **No** (stays staged/on-disk only; no live reload).
+- **Live network apply** ("Apply restored network configuration now..."): defaults to **No** (stays staged/on-disk only; no live reload).
 
 ### 3. Compatibility Validation
 
@@ -1864,12 +1899,12 @@ If the **network** category is restored, ProxSave can optionally apply the
 new network configuration immediately using a **transactional rollback timer**.
 
 **Apply prompt auto-skip**:
-- The “apply now” prompt includes a **90-second** countdown; if you do not answer in time, ProxSave defaults to **No** and skips the live reload.
+- The "apply now" prompt includes a **90-second** countdown; if you do not answer in time, ProxSave defaults to **No** and skips the live reload.
 
 **Important (console recommended)**:
 - Run the live network apply/commit step from the **local console** (physical console, IPMI/iDRAC/iLO, Proxmox console, or hypervisor console), not from SSH.
 - If the restored network config changes the management IP or routes, your SSH session will drop and you may be unable to type `COMMIT`.
-- In that case, ProxSave will treat the lack of `COMMIT` as “not confirmed” and will restore the previous network settings (rollback).
+- In that case, ProxSave will treat the lack of `COMMIT` as "not confirmed" and will restore the previous network settings (rollback).
 
 **How it works**:
 - On live restores (writing to `/`), ProxSave **stages** network files first under `/tmp/proxsave/restore-stage-*` and does **not** overwrite `/etc/network/*` during archive extraction.
@@ -1877,7 +1912,7 @@ new network configuration immediately using a **transactional rollback timer**.
 - If rollback backup creation fails (or ProxSave is not running as root), ProxSave keeps network files staged and avoids writing to `/etc`.
 - When you choose to apply live, ProxSave (re)validates and reloads networking inside the rollback timer window.
 - ProxSave arms a local rollback job **before** applying changes
-- Rollback restores **only network-related files** using a dedicated archive under `/tmp/proxsave/network_rollback_backup_*` (so it won’t undo other restored categories)
+- Rollback restores **only network-related files** using a dedicated archive under `/tmp/proxsave/network_rollback_backup_*` (so it won't undo other restored categories)
 - Rollback also prunes network config files that were **created after** the backup (e.g. extra files under `/etc/network/interfaces.d/`), so rollback returns to the exact pre-restore state
 - The user has **180 seconds** to type `COMMIT`
 - If `COMMIT` is not received, ProxSave triggers the rollback and restores the pre-restore network configuration
@@ -1930,7 +1965,7 @@ Notes:
 
 The `NETWORK ROLLBACK` block is printed just before the standard ProxSave footer (the footer color reflects the exit status, e.g. magenta on Ctrl+C).
 
-Example 1 — **ARMED** (rollback pending, countdown shown for a few seconds):
+Example 1, **ARMED** (rollback pending, countdown shown for a few seconds):
 ```text
 ===========================================
 NETWORK ROLLBACK
@@ -1950,7 +1985,7 @@ ProxSave - Go - <build signature>
 ===========================================
 ```
 
-Example 2 — **EXECUTED** (rollback already ran, no countdown):
+Example 2, **EXECUTED** (rollback already ran, no countdown):
 ```text
 ===========================================
 NETWORK ROLLBACK
@@ -1964,7 +1999,7 @@ Rollback executed: reconnect using the pre-apply IP: 192.168.1.100
 ===========================================
 ```
 
-Example 3 — **DISARMED/CLEARED** (rollback will not run, applied config remains active):
+Example 3, **DISARMED/CLEARED** (rollback will not run, applied config remains active):
 ```text
 ===========================================
 NETWORK ROLLBACK
@@ -2016,14 +2051,14 @@ if cleanDestRoot == "/" && strings.HasPrefix(target, "/etc/pve") {
 - Optional cleanup: `proxsave --cleanup-guards` (use `--dry-run` to preview). See **Clearing mount guards after the storage is back** below.
 
 **PVE Storage Mount Guards**:
-- When restoring PVE storage definitions (from `storage.cfg`), ProxSave applies the same “restore even if offline” strategy for mount-backed storage:
+- When restoring PVE storage definitions (from `storage.cfg`), ProxSave applies the same "restore even if offline" strategy for mount-backed storage:
   - Network storages (`nfs`, `cifs`, `cephfs`, `glusterfs`) use mountpoints under `/mnt/pve/<storageid>`. ProxSave attempts `pvesm activate <storageid>`; if the mountpoint still resolves to the root filesystem, it applies a temporary read-only bind-mount guard (or, if the bind mount cannot be created, logs a warning and proceeds unguarded).
   - `dir` storages are guarded only when their `path` lives under a mountpoint restored via `/etc/fstab` (to avoid guarding local root filesystem paths).
 - Purpose: prevent PVE from writing into `/mnt/pve/...` (or other mount roots) when the backing storage is offline at restore time.
 - Optional cleanup: `proxsave --cleanup-guards` (use `--dry-run` to preview). See **Clearing mount guards after the storage is back** below.
 
 **Clearing mount guards after the storage is back**:
-- Bringing the storage online again is enough to *use* it: a real mount stacks on top of a bind-mount guard automatically. The guard is not deleted, only shadowed — a reboot or `--cleanup-guards` removes the bind-mount leftover. A **legacy** `chattr +i` flag (set by older versions when a bind mount failed) leaves the directory immutable across reboots until it is cleared.
+- Bringing the storage online again is enough to *use* it: a real mount stacks on top of a bind-mount guard automatically. The guard is not deleted, only shadowed; a reboot or `--cleanup-guards` removes the bind-mount leftover. A **legacy** `chattr +i` flag (set by older versions when a bind mount failed) leaves the directory immutable across reboots until it is cleared.
 - `proxsave --cleanup-guards` (preview with `--dry-run`) unmounts bind-mount guards **and** clears any **legacy** `chattr +i` immutable flags, but only on mountpoints that are **not currently mounted** (clearing a live mount would touch the wrong inode); it prints a summary of what was cleared vs left pending. The guard directory is kept until nothing is pending.
 - To clear a legacy flag while the storage is mounted: unmount it, run `--cleanup-guards` again (or `chattr -i <mountpoint>`), then remount.
 - If you deleted `/var/lib/proxsave/guards` manually and a mountpoint is still read-only, ProxSave has no record left to clear: check `lsattr -d <mountpoint>` and run `chattr -i <mountpoint>` while the storage is unmounted.

--- a/docs/RESTORE_TECHNICAL.md
+++ b/docs/RESTORE_TECHNICAL.md
@@ -105,14 +105,15 @@ Service Management (if cluster)
   ├─ Stop PVE services
   └─ Unmount /etc/pve
   ↓
-File Extraction
+File Extraction (three tiers)
   ├─ Normal categories → /
-  ├─ Export categories → export dir
+  ├─ Export categories → export dir (read-only)
+  ├─ Staged categories → stage dir, then applied
   └─ Log all operations
   ↓
 Post-Restore Tasks
   ├─ Recreate directories
-  ├─ Check ZFS pools
+  ├─ Check ZFS pools (when the ZFS category is selected)
   └─ Restart services (deferred)
   ↓
 Completion Summary
@@ -162,9 +163,9 @@ if args.Restore {
 - Handle errors and exit codes
 - Distinguish user abort vs system error
 
-### File: internal/orchestrator/restore.go (entry point — workflow body in restore_workflow_ui_run.go)
+### File: internal/orchestrator/restore.go (entry point; workflow body in restore_workflow_ui_run.go)
 
-**Main function**: `RunRestoreWorkflow()` — thin dispatch stub that delegates to `runRestoreWorkflowWithUI()` (`restore_workflow_ui_run.go`)
+**Main function**: `RunRestoreWorkflow()`, a thin dispatch stub that delegates to `runRestoreWorkflowWithUI()` (`restore_workflow_ui_run.go`)
 
 **Signature**:
 ```go
@@ -247,7 +248,7 @@ instead of line numbers, which drift on every edit):
     `recreateStorageDirectories()` / `applyNetworkConfig()` / `applyFirewallConfig()` /
     `applyHAConfig()`; then `logRestoreCompletion()` and `checkZFSPoolsAfterRestore()`):
     - Recreate storage/datastore directories
-    - Check ZFS pools (PBS only)
+    - Check ZFS pools (only when the `zfs` category is selected; no-op if `zpool` is absent)
     - Display completion summary
 
 ### File: internal/orchestrator/categories.go
@@ -818,98 +819,90 @@ func unmountEtcPVE(ctx context.Context, logger *logging.Logger) error {
 
 #### Phase 8 & 9: File Extraction
 
-**Two-Pass Extraction**:
+**Three-tier extraction.** `splitRestoreCategories` (`staging.go`) divides the selected
+categories into three tiers: **export-only**, **staged** (sensitive), and **normal**.
+`prepareAndRestoreSelectedPayloads` (`restore_workflow_ui_run.go`) then processes them in
+a fixed order:
 
-**Pass 1: Normal Categories** (`internal/orchestrator/restore_workflow_ui_extract.go` → `extractNormalCategories()`):
+1. **Normal categories** are extracted directly to `destRoot` (`/` on a real restore) via
+   `extractNormalCategories`.
+2. **`/etc/fstab`** is smart-merged, never blindly overwritten (see Safety Mechanisms).
+3. **Export-only categories** (`pve_config_export`, `pbs_config`, `proxsave_info`) are
+   extracted read-only to an export dir (`proxmox-config-export-<ts>` under the base dir),
+   never onto the live system.
+4. **Cluster SAFE apply** runs when applicable.
+5. **Staged (sensitive) categories** are extracted into a per-run stage dir
+   (`/tmp/proxsave/restore-stage-<ts>_<seq>`) and then applied (Phase 10).
+
 ```go
-if len(normalCategories) > 0 {
-    destRoot := "/"
-    logPath, err := extractSelectiveArchive(
-        ctx,
-        prepared.ArchivePath,
-        destRoot,
-        normalCategories,
-        mode,
-        logger,
-    )
-    if err != nil {
-        logger.Warning("Restore completed with errors: %v", err)
-    }
-}
+// restore_workflow_ui_run.go: prepareAndRestoreSelectedPayloads (processing order)
+interceptFilesystemCategory(...)       // fstab handling
+extractNormalCategories(...)           // tier 1 -> destRoot
+smartMergeFilesystemCategory(...)      // fstab smart merge
+exportCategories(...)                  // tier 3 -> export dir (read-only)
+runClusterSafeApply(...)               // cluster SAFE apply
+stageAndApplySensitiveCategories(...)  // tier 2 -> stage dir, then Phase 10
 ```
 
-**Pass 2: Export Categories** (`internal/orchestrator/restore_workflow_ui_extract.go` → `exportCategories()`):
-```go
-if len(exportCategories) > 0 {
-    exportRoot := exportDestRoot(cfg.BaseDir)
-    logger.Info("Exporting /etc/pve contents to: %s", exportRoot)
+Staged categories are extracted **strictly**:
+`extractSelectiveArchiveStrict(..., failOnPartial=true)`. If any entry fails, the whole
+staged apply is skipped and the live system is left untouched (BH-002), so a partial tree
+is never applied to sensitive config. The plain (non-staged) tiers use
+`extractSelectiveArchive`, a thin wrapper over `extractSelectiveArchiveStrict(..., false)`
+that creates the detailed log under `/tmp/proxsave` and calls `extractArchiveNative`.
 
-    os.MkdirAll(exportRoot, 0o755)
+**Which categories are staged** (`isStagedCategoryID`, `staging.go`): `network`,
+`datastore_pbs`, `pbs_jobs`, `pbs_remotes`, `pbs_host`, `pbs_tape`, `storage_pve`,
+`pve_jobs`, `pve_notifications`, `pbs_notifications`, `pve_access_control`,
+`pbs_access_control`, `accounts`, `pve_firewall`, `pve_ha`, `pve_sdn`. Everything else is
+a normal category unless it is flagged `ExportOnly`.
 
-    exportLog, err := extractSelectiveArchive(
-        ctx,
-        prepared.ArchivePath,
-        exportRoot,
-        exportCategories,
-        RestoreModeCustom,
-        logger,
-    )
-}
-```
-
-**Extraction Implementation** (`internal/orchestrator/restore_archive.go` → `extractSelectiveArchive()`):
-```go
-func extractSelectiveArchive(
-    ctx context.Context,
-    archivePath string,
-    destRoot string,
-    categories []Category,
-    mode RestoreMode,
-    logger *logging.Logger,
-) (logPath string, err error) {
-    // Thin wrapper over extractSelectiveArchiveStrict(..., failOnPartial=false),
-    // which creates the detailed log under /tmp/proxsave and then calls
-    // extractArchiveNative with a restoreArchiveOptions struct:
-    //
-    //   err := extractArchiveNative(ctx, restoreArchiveOptions{
-    //       archivePath: archivePath,
-    //       destRoot:    destRoot,
-    //       logger:      logger,
-    //       categories:  categories,
-    //       mode:        mode,
-    //       logFile:     logFile,
-    //       logFilePath: logPath,
-    //   })
-    return extractSelectiveArchiveStrict(ctx, archivePath, destRoot, categories, mode, logger, false)
-}
-```
+When staging is unavailable (a non-real or test filesystem) the plan folds the staged
+categories back into the normal tier, so they are extracted directly instead of
+staged-and-applied (`restore_workflow_ui_plan.go`).
 
 ---
 
-#### Phase 10: Staged Apply (PVE/PBS)
+#### Phase 10: Staged Apply
 
-After extraction, **staged categories** are applied from the staging directory under `/tmp/proxsave/restore-stage-*`.
+After the sensitive categories are staged under `/tmp/proxsave/restore-stage-*`,
+`applyStagedCategories` (`restore_workflow_ui_extract.go`) applies them. It first runs the
+**PBS datastore mount guards** as a pre-step (see Safety Mechanisms), then a fixed ordered
+list of steps. Each step is individually gated on whether its category was selected,
+re-checks context cancellation between steps, and degrades a non-fatal error to a warning
+(only an abort or input error stops the apply):
 
-**PBS staged apply**:
-- Selected interactively during restore on PBS hosts: **Merge (existing PBS)** vs **Clean 1:1 (fresh PBS install)**.
-- ProxSave applies supported PBS categories via `proxmox-backup-manager`.
-  - **Merge**: create/update only (no deletions of existing objects not in the backup).
-  - **Clean 1:1**: attempts 1:1 reconciliation (may remove objects not present in the backup).
-- If API apply is unavailable or fails, ProxSave may fall back to applying staged `*.cfg` files back to `/etc/proxmox-backup` (**Clean 1:1 only**).
+1. **PBS staged config apply** (`maybeApplyPBSConfigsFromStage`, `pbs_staged_apply.go`): datastores/S3, remotes, sync/verify/prune jobs, node + traffic control, tape.
+2. **PVE staged config apply** (`maybeApplyPVEConfigsFromStage`, `pve_staged_apply.go`): `storage_pve`, `pve_jobs`.
+3. **PVE SDN staged apply** (`maybeApplyPVESDNFromStage`, `restore_sdn.go`).
+4. **Access control staged apply** (`applyAccessControlFromStage` -> `maybeApplyAccessControlWithUI`): PBS and PVE ACLs, with a rollback/commit UI. In a cluster backup it skips the 1:1 PVE apply in SAFE mode and skips entirely in RECOVERY mode (`config.db` owns that state). Requires root and a real filesystem.
+5. **System accounts staged apply** (`maybeApplyAccountsFromStage`, `restore_accounts.go`): the anti-lockout merge below.
+6. **Notifications staged apply** (`maybeApplyNotificationsFromStage`, `restore_notifications.go`): PVE and PBS notification endpoints/matchers.
 
-**Current PBS API coverage**:
-- `pbs_host`: node + traffic control
-- `datastore_pbs`: datastores + S3 endpoints
-- `pbs_remotes`: remotes
-- `pbs_jobs`: sync/verify/prune jobs
-- `pbs_notifications`: notification endpoints/matchers
+**PBS apply model (interactive).** On PBS hosts the apply offers **Merge (existing PBS)**
+vs **Clean 1:1 (fresh PBS install)**. Merge creates/updates only (no deletions); Clean 1:1
+attempts a 1:1 reconciliation (may remove objects not in the backup) via
+`proxmox-backup-manager`, and may fall back to writing staged `*.cfg` files into
+`/etc/proxmox-backup` (Clean 1:1 only). API coverage: `pbs_host` (node + traffic control),
+`datastore_pbs` (datastores + S3), `pbs_remotes`, `pbs_jobs` (sync/verify/prune),
+`pbs_notifications`. Other PBS categories remain file-based.
 
-Other PBS categories remain file-based (e.g. access control, tape, proxy/ACME/metricserver).
+**Anti-lockout account merge** (`applyAccountsFromStage`). Accounts are **merged**, not
+overwritten. ProxSave keeps every current host line and imports only regular backup
+accounts: a backup user is imported only if it is non-root, non-NIS, has a valid name,
+`uid >= 1000` (`systemAccountIDThreshold`), and no primary-gid escalation. It reads the
+current `/etc/passwd`, `/etc/group`, and `/etc/shadow` first and refuses to rewrite the
+auth DB if any is missing (no host baseline). A missing shadow line becomes a locked
+placeholder (`:*:::::::`). Existing host groups only gain imported members; new groups
+need `gid >= 1000`. All four files (`passwd`/`shadow`/`group`/`gshadow`) are written
+all-or-nothing with the current contents as rollback. `/etc/sudoers` is replaced only if
+the staged copy passes `visudo -c`.
 
-**Key code paths**:
-- `internal/orchestrator/pbs_staged_apply.go` (`maybeApplyPBSConfigsFromStage`)
-- `internal/orchestrator/restore_notifications.go` (`maybeApplyNotificationsFromStage`, `pbs_notifications`)
-- `internal/orchestrator/pbs_api_apply.go` / `internal/orchestrator/pbs_notifications_api_apply.go` (API apply engines)
+**PBS raw-config skips** (`shouldSkipProxmoxSystemRestore`, `restore_archive_paths.go`).
+These are never restored raw (they are recreated through the API instead):
+`etc/proxmox-backup/domains.cfg`, `etc/proxmox-backup/user.cfg`,
+`etc/proxmox-backup/acl.cfg`, plus the runtime locks `var/lib/proxmox-backup/.clusterlock`
+and anything under `var/lib/proxmox-backup/lock/`.
 
 ## Category System
 
@@ -982,12 +975,12 @@ func PathMatchesCategory(filePath string, category Category) bool {
 
 | Archive Path | Category Path | Match? | Reason |
 |--------------|---------------|--------|--------|
-| `./etc/network/interfaces` | `./etc/network/` | ✅ | Prefix match |
-| `./etc/network/interfaces` | `./etc/network/interfaces` | ✅ | Exact match |
-| `./etc/hostname` | `./etc/hostname` | ✅ | Exact match |
-| `./etc/hostname` | `./etc/network/` | ❌ | No match |
-| `./var/lib/pve-cluster/config.db` | `./var/lib/pve-cluster/` | ✅ | Prefix match |
-| `etc/network/interfaces` | `./etc/network/` | ✅ | Normalized to `./` |
+| `./etc/network/interfaces` | `./etc/network/` | yes | Prefix match |
+| `./etc/network/interfaces` | `./etc/network/interfaces` | yes | Exact match |
+| `./etc/hostname` | `./etc/hostname` | yes | Exact match |
+| `./etc/hostname` | `./etc/network/` | no | No match |
+| `./var/lib/pve-cluster/config.db` | `./var/lib/pve-cluster/` | yes | Prefix match |
+| `etc/network/interfaces` | `./etc/network/` | yes | Normalized to `./` |
 
 ### Adding New Categories
 
@@ -1324,131 +1317,111 @@ func extractArchiveNative(ctx context.Context, opts restoreArchiveOptions) error
             continue
         }
 
-        // 6. Extract based on type
+        // 6. Extract based on type (extractTypedTarEntry passes the cleaned
+        //    destRoot to symlink/hardlink so path escapes can be validated).
         switch header.Typeflag {
         case tar.TypeDir:
             extractDirectory(target, header, logger)
         case tar.TypeReg:
             extractRegularFile(tarReader, target, header, logger)
         case tar.TypeSymlink:
-            extractSymlink(target, header, logger)
+            extractSymlink(target, header, cleanDestRoot, logger)
         case tar.TypeLink:
-            extractHardlink(target, header, logger)
+            // BH-002: in selective mode a hardlink whose Linkname is outside the
+            // selected categories is refused, so an in-category name can never alias
+            // an out-of-category inode (for example /etc/shadow).
+            extractHardlink(target, header, cleanDestRoot)
         }
 
         filesExtracted++
     }
 
+    // BH-002: on the staged path (failOnPartialExtraction=true) any failed entry makes
+    // the whole extraction return an error, so a partial tree is never applied.
     return nil
 }
 ```
+
+The real loop is `processRestoreArchiveEntries`, and the per-entry `/etc/pve` hard guard
+plus the PBS raw-config skips live in `shouldSkipRestoreEntryTarget` (only when
+`cleanDestRoot == "/"`). After the loop, `extractArchiveNative` also runs dedup symlink
+materialization (below) before the fail-on-partial check.
 
 ### File Type Handling
 
-**Directories** (`internal/orchestrator/restore_archive_entries.go` → `extractDirectory()`):
+Extraction never writes onto the live target. A regular file is written to a **sibling
+temp file**, has its metadata set on the open file descriptor, and is then **atomically
+renamed** over the target, so a truncated archive entry or a crash can only affect the
+temp (removed on error), never the real file. The sibling temp name pattern is
+`.proxsave-tmp-*` (`restoreTempPattern`); the rename is atomic because the temp is created
+in the target's own directory (same filesystem). This replaces the older
+`os.Create(target)` + `io.Copy` model, which wrote directly onto the live file and could
+leave it truncated on a partial copy.
+
+**Regular files** (`restore_archive_entries.go` -> `extractRegularFile`):
 ```go
-func extractDirectory(target string, header *tar.Header, logger *logging.Logger) error {
-    // Create directory
-    os.MkdirAll(target, os.FileMode(header.Mode))
+func extractRegularFile(tarReader *tar.Reader, target string, header *tar.Header, logger *logging.Logger) (retErr error) {
+    // Sibling temp in the target's own directory
+    outFile, _ := restoreFS.CreateTemp(filepath.Dir(target), restoreTempPattern) // ".proxsave-tmp-*"
+    tmpPath := outFile.Name()
+    defer func() { if tmpPath != "" { _ = restoreFS.Remove(tmpPath) } }() // cleanup unless renamed
 
-    // Set ownership
-    os.Chown(target, header.Uid, header.Gid)
-
-    // Set permissions
-    os.Chmod(target, os.FileMode(header.Mode))
-
-    // Set timestamps
-    setTimestamps(target, header)
-
-    return nil
-}
-```
-
-**Regular Files** (`internal/orchestrator/restore_archive_entries.go` → `extractRegularFile()`):
-```go
-func extractRegularFile(
-    tarReader *tar.Reader,
-    target string,
-    header *tar.Header,
-    logger *logging.Logger,
-) error {
-    // Ensure parent directory exists
-    os.MkdirAll(filepath.Dir(target), 0755)
-
-    // Create file
-    outFile, _ := os.Create(target)
-    defer outFile.Close()
-
-    // Copy content
     io.Copy(outFile, tarReader)
+    atomicFileChown(outFile, header.Uid, header.Gid) // fchown on the FD, best-effort
+    atomicFileChmod(outFile, mode)                   // fchmod on the FD, hard error
+    outFile.Close()
 
-    // Set ownership
-    os.Chown(target, header.Uid, header.Gid)
-
-    // Set permissions
-    os.Chmod(target, os.FileMode(header.Mode))
-
-    // Set timestamps
-    setTimestamps(target, header)
-
+    restoreFS.Rename(tmpPath, target) // atomic replace
+    tmpPath = ""                      // rename done, skip cleanup
+    setTimestamps(target, header)     // atime/mtime on the final path
     return nil
 }
 ```
 
-**Symlinks** (`internal/orchestrator/restore_archive_entries.go` → `extractSymlink()`):
-```go
-func extractSymlink(target string, header *tar.Header, logger *logging.Logger) error {
-    // Ensure parent directory
-    os.MkdirAll(filepath.Dir(target), 0755)
+Ownership and permissions are set on the **open descriptor** (`fchown`/`fchmod`, via the
+`atomicFileChown`/`atomicFileChmod` helpers in `fs_atomic.go`) rather than by path, so a
+logical or test filesystem root never leaks to a host path. The order is always
+write -> fchown -> fchmod -> close -> rename -> timestamps.
 
-    // Remove existing
-    os.Remove(target)
+**Directories** (`extractDirectory`): `MkdirAll(target, 0o700)` (owner-accessible), then
+`Open` the directory and apply `fchown`/`fchmod` on the directory descriptor (mode masked
+with `&0o7777`), then set timestamps. Chown is best-effort; a chmod failure is a hard
+error.
 
-    // Create symlink
-    os.Symlink(header.Linkname, target)
+**Symlinks** (`extractSymlink(target, header, destRoot, logger)`): the link target is
+validated **before** creation with `resolvePathRelativeToBaseWithinRootFS` and again
+**after** creation (readlink + re-resolve). If it resolves outside `destRoot` the symlink
+is removed and the entry fails (`symlink target escapes root before/after creation`).
+Ownership uses `Lchown`.
 
-    // Set ownership (use Lchown to not follow symlink)
-    syscall.Lchown(target, header.Uid, header.Gid)
+**Hard links** (`extractHardlink(target, header, destRoot)`): empty and absolute link
+targets are rejected outright, then the target is resolved and validated with
+`resolvePathWithinRootFS` (`hardlink target escapes root`) before the link is created. No
+chown is applied to hard links.
 
-    return nil
-}
-```
+Config files applied outside tar extraction (staged apply, network, and so on) use a
+separate two-phase helper in `fs_atomic.go` (`prepareAtomicTempFile` +
+`commitAtomicTempFile`, wrapped by `writeFileAtomic` / `writeFilesAtomic`) with `fsync`
+plus a parent-directory `fsync` for durability. Note that helper uses a distinct temp
+pattern (`%s.proxsave.tmp.%d`), not `restoreTempPattern`.
 
-**Hard Links** (`internal/orchestrator/restore_archive_entries.go` → `extractHardlink()`):
-```go
-func extractHardlink(target string, header *tar.Header, logger *logging.Logger) error {
-    // Ensure parent directory
-    os.MkdirAll(filepath.Dir(target), 0755)
+### Dedup symlink materialization (issue #70)
 
-    // Resolve link target
-    linkTarget := filepath.Join(filepath.Dir(target), header.Linkname)
-
-    // Create hard link
-    os.Link(linkTarget, target)
-
-    return nil
-}
-```
+Deduplicated backups store repeated files once and record the duplicates as symlinks.
+After the tar loop, `materializeDedupSymlinks` (`restore_archive_extract.go`) reads the
+dedup manifest (always extracted regardless of the selected categories) and, for each
+recorded duplicate still present as a symlink, rebuilds it into a **regular file from the
+archive bytes** (never from the live target, never by deleting the symlink), using the
+same atomic sibling-temp-plus-rename write. The manifest is streamed once (bounded
+memory). If the pass does not complete it is **kept for retry** and, on the staged path,
+surfaces an error (BH-002); on success it is deleted. A genuinely missing canonical (a
+corrupt backup) is left as a symlink and does not block cleanup.
 
 ### Timestamp Preservation
 
-**File**: `internal/orchestrator/restore_archive_entries.go` → `setTimestamps()`
-
-```go
-func setTimestamps(target string, header *tar.Header) error {
-    // Extract times from header
-    atime := header.AccessTime
-    mtime := header.ModTime
-
-    // Use syscall for precise control
-    return syscall.UtimesNano(target, []syscall.Timespec{
-        {Sec: atime.Unix(), Nsec: int64(atime.Nanosecond())},
-        {Sec: mtime.Unix(), Nsec: int64(mtime.Nanosecond())},
-    })
-}
-```
-
-**Note**: `ctime` (change time) cannot be set by userspace - it's kernel-managed.
+`setTimestamps` sets atime and mtime on the final path with nanosecond precision via
+`restoreFS.UtimesNano`. `ctime` (change time) cannot be set from userspace, so
+`header.ChangeTime` is not restorable.
 
 ---
 
@@ -1482,10 +1455,10 @@ func targetWithinRoot(target string, destRoot string) bool {
 
 | Target | DestRoot | Secure? |
 |--------|----------|---------|
-| `/var/lib/pve-cluster/config.db` | `/` | ✅ |
-| `/../etc/passwd` | `/` | ❌ |
-| `/tmp/../etc/passwd` | `/` | ❌ |
-| `/opt/backup/file` | `/opt/backup` | ✅ |
+| `/var/lib/pve-cluster/config.db` | `/` | yes |
+| `/../etc/passwd` | `/` | no |
+| `/tmp/../etc/passwd` | `/` | no |
+| `/opt/backup/file` | `/opt/backup` | yes |
 
 ### 2. /etc/pve Hard Guard
 
@@ -1531,23 +1504,23 @@ When restoring to the real system root (`/`), ProxSave avoids blindly overwritin
 
 ### 4. PBS Datastore Mount Guards (Offline Storage)
 
-For PBS datastores whose paths live under typical mount roots (for example `/mnt/...`), ProxSave aims for a “restore even if offline” behavior:
+For PBS datastores whose paths live under typical mount roots (for example `/mnt/...`), ProxSave aims for a "restore even if offline" behavior:
 
 - PBS datastore definitions are applied even when the underlying storage is offline/not mounted, so PBS shows them as **unavailable** rather than silently dropping them.
 - When a mountpoint used by a datastore currently resolves to the root filesystem (mount missing), ProxSave applies a **read-only bind-mount guard** on the mount root.
 - Guards prevent PBS from writing into `/` if the storage is missing at restore time.
 - **Bind-mount guard:** when the real storage is mounted later it stacks on top of the read-only guard and the datastore becomes available again; the guard is then shadowed underneath and is discarded by a reboot or by `--cleanup-guards`.
-- **If the bind mount cannot be created** (rare; e.g. a locked-down/containerized mount namespace), ProxSave does **not** set a persistent flag — it logs a loud warning that the mountpoint is unguarded and proceeds. (Older versions set a `chattr +i` immutable flag here; that flag survived reboots and could silently re-block the mountpoint once the storage was later unmounted, so it was removed.) ProxSave's own directory recreation on the mountpoint is still skipped by the storage-mount preflight, and the config-only restore never extracts into datastore mountpoints, so only *external* writers are unblocked while the storage stays offline.
+- **If the bind mount cannot be created** (rare; e.g. a locked-down/containerized mount namespace), ProxSave does **not** set a persistent flag; it logs a loud warning that the mountpoint is unguarded and proceeds. (Older versions set a `chattr +i` immutable flag here; that flag survived reboots and could silently re-block the mountpoint once the storage was later unmounted, so it was removed.) ProxSave's own directory recreation on the mountpoint is still skipped by the storage-mount preflight, and the config-only restore never extracts into datastore mountpoints, so only *external* writers are unblocked while the storage stays offline.
 - At restore start, if persistent `chattr +i` flags from an older version are still recorded, ProxSave warns and points to `--cleanup-guards`.
 
 Optional maintenance:
-- `proxsave --cleanup-guards` (preview with `--dry-run`) unmounts guard bind mounts **and** clears any **legacy** `chattr +i` immutable flags recorded by older versions — but only on mountpoints that are **not currently mounted** (clearing a live mount would touch the wrong inode). It prints a summary (unmounted / hidden-remaining / immutable-cleared / immutable-pending) and keeps the guard directory and its index until nothing is pending.
+- `proxsave --cleanup-guards` (preview with `--dry-run`) unmounts guard bind mounts **and** clears any **legacy** `chattr +i` immutable flags recorded by older versions, but only on mountpoints that are **not currently mounted** (clearing a live mount would touch the wrong inode). It prints a summary (unmounted / hidden-remaining / immutable-cleared / immutable-pending) and keeps the guard directory and its index until nothing is pending.
 - To clear a legacy immutable flag on a mountpoint whose storage is already mounted: unmount it, run `--cleanup-guards` again (or `chattr -i <mountpoint>`), then remount.
 - If you deleted `/var/lib/proxsave/guards` manually and a mountpoint is still read-only, ProxSave no longer has a record to clear: check with `lsattr -d <mountpoint>` and clear it yourself with `chattr -i <mountpoint>` while the storage is unmounted.
 
 #### PVE Storage Mount Guards (Offline Storage)
 
-For PVE storages that use mountpoints (notably `nfs`, `cifs`, `cephfs`, `glusterfs`, and `dir` storages on dedicated mountpoints), ProxSave applies the same “restore even if offline” safety model:
+For PVE storages that use mountpoints (notably `nfs`, `cifs`, `cephfs`, `glusterfs`, and `dir` storages on dedicated mountpoints), ProxSave applies the same "restore even if offline" safety model:
 
 - Network storages use `/mnt/pve/<storageid>`. ProxSave attempts `pvesm activate <storageid>` with a short timeout.
 - If the mountpoint still resolves to the root filesystem afterwards (mount missing/offline), ProxSave applies a **read-only bind-mount guard** on the mountpoint. If the bind mount cannot be created it logs a warning and proceeds unguarded (no persistent flag is set; see the PBS section above).
@@ -1560,11 +1533,14 @@ This prevents accidental writes into the root filesystem when storage is offline
 **Pre-Extraction Check** (`internal/orchestrator/restore_archive.go` → `extractPlainArchive()`, `extractSelectiveArchiveStrict()`):
 
 ```go
-// For system path restoration
-if destRoot == "/" && os.Geteuid() != 0 {
+// For system-path restoration on the REAL filesystem only
+if destRoot == "/" && isRealRestoreFS(restoreFS) && os.Geteuid() != 0 {
     return fmt.Errorf("restore to %s requires root privileges", destRoot)
 }
 ```
+
+The `isRealRestoreFS` gate means the root check fires only against the real OS
+filesystem, not against a test or in-memory FS.
 
 ### 6. Checksum Verification
 
@@ -1620,6 +1596,27 @@ func ConfirmRestoreOperationWithReader(ctx context.Context, reader *bufio.Reader
     return false, nil
 }
 ```
+
+### 8. Secure Temp-Root Guard (issue #54)
+
+Before ProxSave uses the shared workspace root `/tmp/proxsave` (for backup, decrypt, and
+restore), `ensureSecureTempRoot` (`temp_registry.go`) validates it and creates it `0o700`
+if missing. It **rejects** the root when it is a symlink, is not a directory, is group- or
+world-writable (`perm & 0o022 != 0`), or is not owned by root or the effective uid. This
+stops an attacker from pre-planting `/tmp/proxsave` as a symlink or a writable dir to
+hijack restore temp files.
+
+### 9. Registry-Backed Orphan Cleanup (issue #55)
+
+Temp workspaces are tracked in a small registry (`TempDirRegistry`, default
+`/var/run/proxsave/temp-dirs.json`, flock-guarded, atomically written). Each workspace
+gets a `.proxsave-marker` file written **before** it is registered.
+`CleanupOrphaned(maxAge)` removes entries whose process is gone or that are older than
+`maxAge` (24h). Before deleting anything it calls `workspacePathIsRemovable`, which
+returns true only for a real, non-symlink directory **strictly under** `/tmp/proxsave`
+that carries the `.proxsave-marker`. An entry that fails the check is dropped from the
+registry without touching the filesystem, so a poisoned registry or a hostile
+`PROXMOX_TEMP_REGISTRY_PATH` can never make ProxSave delete an arbitrary path.
 
 ---
 
@@ -1904,31 +1901,23 @@ func AnalyzeBackupCategories(...) ([]Category, error) {
 }
 ```
 
-### Two-Pass Extraction
+### Multi-tier Extraction
 
-**Current**: Archive read twice if export-only categories exist
+The archive is opened once per tier that has selected categories (normal, export-only,
+and staged), plus one more streaming pass for dedup materialization when a dedup manifest
+is present. Each pass filters TAR entries by category, so a tier with no selected
+categories is skipped entirely.
+
 ```
-Pass 1: Normal categories
-Pass 2: Export-only categories
+Normal tier   -> destRoot (/)                     (skipped if empty)
+Export tier   -> proxmox-config-export-<ts>       (skipped if empty)
+Staged tier   -> /tmp/proxsave/restore-stage-*    (skipped if empty), then applied
+Dedup pass    -> streams the archive to rebuild deduplicated symlinks (issue #70)
 ```
 
-**Optimization**: Single-pass with dual writers
-```go
-func extractArchiveSinglePass(...) error {
-    normalWriter := createTarWriter("/")
-    exportWriter := createTarWriter(exportDir)
-
-    for {
-        header, _ := tarReader.Next()
-
-        if isExportOnly(header) {
-            exportWriter.Write(header, content)
-        } else {
-            normalWriter.Write(header, content)
-        }
-    }
-}
-```
+Trading a few extra reads for isolation is deliberate: the staged tier is extracted
+strictly and applied separately so sensitive config is never written half-applied
+(BH-002), and the export tier is kept off the live system entirely.
 
 ### Memory Usage
 
@@ -2027,8 +2016,8 @@ proxsave --restore --log-level=debug
 ### Review Detailed Logs
 
 ```bash
-# Restore log
-cat /tmp/proxsave/restore_20251120_143052.log
+# Restore log (name is restore_<timestamp>_<seq>.log, seq is a per-process counter)
+cat /tmp/proxsave/restore_20251120_143052_1.log
 
 # Service logs
 journalctl -u pve-cluster --since "10 minutes ago"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,58 +1,217 @@
 # Security
 
+This document describes the ProxSave runtime security model: the trust boundary,
+how external commands are executed, the preflight checks, and the layers that keep
+secrets and untrusted data from doing harm. For the notification and relay security
+model (per-server secret provisioning, the bot token staying on the host, log
+redaction per channel) see [NOTIFICATIONS.md](NOTIFICATIONS.md). For release
+signing and provenance see [PROVENANCE_VERIFICATION.md](PROVENANCE_VERIFICATION.md).
+
 ## Threat model
 
-ProxSave is a Proxmox (PVE/PBS) system backup & restore tool that runs **as root**
-on the host it protects. Reading and writing arbitrary system paths — `/etc/pve`,
-`/etc/proxmox-backup`, `/proc`, the configured backup destinations, and so on — is
-its core function, not a vulnerability: an attacker able to influence those paths
-would already need root on the host.
+ProxSave is a Proxmox (PVE/PBS) system backup and restore tool that runs **as root**
+on the host it protects. Reading and writing arbitrary system paths (`/etc/pve`,
+`/etc/proxmox-backup`, `/proc`, the configured backup destinations, and so on) is its
+core function, not a vulnerability: an attacker able to influence those paths would
+already need root on the host.
 
-The one place where **untrusted content** becomes a filesystem path is **restore
-archive extraction**, and that is contained independently:
+The interesting boundaries are the few places where **untrusted content** enters:
 
-- extracted entry targets are sanitized against the destination root, and
-  symlink/hardlink targets that escape the root are rejected
-  (`internal/orchestrator/restore_archive_entries.go`);
-- process-owned staging/temp and download/install I/O is confined with `os.Root`
-  (`internal/backup/optimizations.go`, `cmd/proxsave/upgrade.go`), so traversal via
-  `..` or escaping symlinks fails at the syscall level.
+- **Restore archive extraction.** Entry targets are sanitized against the destination
+  root, and symlink/hardlink targets that escape the root are rejected. Extraction is
+  atomic (sibling temp then rename) and process-owned staging, temp, and
+  download/install I/O is confined with `os.Root`, so traversal via `..` or an escaping
+  symlink fails at the syscall level. The full mechanism is in
+  [RESTORE_TECHNICAL.md](RESTORE_TECHNICAL.md).
+- **Backup-derived and server-derived display strings.** Text pulled from a backup
+  (filenames, config values) or returned by the central relay/monitor is scrubbed of
+  terminal escapes before it is printed (see below).
+- **Release artifacts.** Downloads are verified before use (ECDSA P-256 signature plus
+  SLSA build provenance; see [PROVENANCE_VERIFICATION.md](PROVENANCE_VERIFICATION.md)).
 
-Release artifacts are signed (ECDSA P-256) and the signature is verified by both
-the installer and the self-upgrade, in addition to SLSA build-provenance
-attestations — see [PROVENANCE_VERIFICATION.md](./PROVENANCE_VERIFICATION.md).
+## Execution model
+
+Every external process ProxSave runs goes through `internal/safeexec`. Nothing ProxSave
+builds is ever handed to a shell interpreter.
+
+- **No shell, argv only.** `safeexec.CommandContext(ctx, name, args...)` requires `name`
+  to be an exact key in a static, package-level allowlist (76 literal command names
+  today). Each entry builds `exec.CommandContext(ctx, "<literal>")` with the binary name
+  hard-coded and appends the caller's arguments as argv, with no metacharacter
+  interpretation. `CombinedOutput` and `Output` wrap the same gate.
+- **Name validation.** Before the allowlist lookup, a name that is empty, has leading or
+  trailing whitespace, or contains a path separator (`/` or `\`) is rejected with
+  `command not allowed` (`ErrCommandNotAllowed`). A name not in the allowlist is rejected
+  the same way.
+- **`/proc` access is narrowed.** `ProcPath(pid, leaf)` only permits the leaves `comm`,
+  `status`, and `exe`, so an arbitrary `/proc` path can never be constructed.
+- **The allowlist includes `sh`**, along with `cat`/`tail`/`echo`, but these are invoked
+  only with a fixed, constant argv. For example the background network rollback runs
+  `sh -c '<constant template>'` and feeds the untrusted values (sleep seconds, script
+  path) as positional parameters `$1`/`$2`, never interpolated into the command text.
+
+**Self re-execution.** When ProxSave runs its own binary, the path is validated by
+`ValidateTrustedExecutablePath`: it must be absolute, a regular file, have the execute
+bit, and not be world-writable. The `--upgrade-config-json` child and the `chattr`
+helper go through this `TrustedCommandContext` path. The one exception is the resident
+daemon's backup child, which re-execs the running binary (`os.Executable`) with fixed,
+literal arguments (`--backup [--config ...]`) under a documented `#nosec G204` waiver.
+
+**rclone inputs** are sanitized before they reach the rclone argv:
+`ValidateRcloneRemoteName` rejects an empty name, a leading `-` (flag injection), a
+`/`, `\`, or `:`, and any whitespace or control character; `ValidateRemoteRelativePath`
+rejects control characters and any `..` parent-directory traversal.
+
+## Security preflight
+
+Before a backup, ProxSave runs a preflight (`internal/security`, `security.Run`), gated
+by `SECURITY_CHECK_ENABLED` (default `true`). Checks run in this order: dependency
+availability, executable integrity, config file, sensitive files, directories,
+secure-account files, and a private-key scan; then, only if
+`CHECK_NETWORK_SECURITY` is on (default off), the firewall and open-port checks; and
+finally, always, the suspicious-process scan.
+
+**Executable integrity.** The binary is `Lstat`-ed and **refused if it is a symlink**,
+then opened and re-checked with `os.SameFile` to catch a swap during the check (a
+TOCTOU guard). Its SHA256 is compared against a sibling `<exe>.md5` file (read confined
+with `os.OpenRoot`). With `AUTO_UPDATE_HASHES` (default `true`) a missing or mismatched
+hash file is created or regenerated; otherwise it is a warning. The exact permission
+bits are not enforced (both a packaged `0755` and a self-managed `0700` are accepted),
+but a group- or world-writable executable is flagged and, on auto-fix, narrowed without
+ever widening.
+
+**Permissions and ownership.** Sensitive files are enforced at `0600` (the config file,
+`identity/.server_identity`, the AGE recipient file, and every `secure_account/*.json`),
+directories at `0700`/`0755`, all owned `root:root`. With `AUTO_FIX_PERMISSIONS`
+(default `true`) a wrong mode or owner is corrected, **except** that ProxSave refuses to
+`chmod` or `chown` a **symlink** (that refusal is an error, not a silent fix). Symlink
+status is re-derived with `Lstat`, so a fix never follows a link.
+
+**Private-key scan.** The identity directory is walked for the markers
+`AGE-SECRET-KEY-`, `BEGIN AGE PRIVATE KEY`, and `OPENSSH PRIVATE KEY`; a match is a
+warning to review manually.
+
+**Network and process checks** (opt-in via `CHECK_NETWORK_SECURITY`). The firewall check
+runs `iptables -L -n` and warns when no rules are present; the open-port check compares
+listeners against `SUSPICIOUS_PORTS` with a `program:port` `PORT_WHITELIST`. The
+suspicious-process scan matches against `SUSPICIOUS_PROCESSES` (with a built-in list),
+exempting anything in the user `SAFE_PROCESSES` allowlist and, for bracketed kernel-style
+names, `SAFE_BRACKET_PROCESSES` / `SAFE_KERNEL_PROCESSES` plus kernel-thread heuristics.
+
+**Abort semantics.** Warnings never abort. An **error** aborts the run with exit code
+`ExitSecurityError` unless `CONTINUE_ON_SECURITY_ISSUES=true`; with neither
+`CONTINUE_ON_SECURITY_ISSUES` nor `ABORT_ON_SECURITY_ISSUES` set, the default is to
+abort on error. Every preflight syscall is bounded by `FS_IO_TIMEOUT` (see below): on a
+dead or stale mount the check **warns and skips** rather than wedging the run.
+
+**Preflight configuration keys** (`backup.env`):
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `SECURITY_CHECK_ENABLED` | `true` | run the preflight (legacy alias `FULL_SECURITY_CHECK`) |
+| `AUTO_FIX_PERMISSIONS` | `true` | auto-correct mode/owner (never on a symlink) |
+| `AUTO_UPDATE_HASHES` | `true` | create/refresh the `<exe>.md5` integrity hash |
+| `CONTINUE_ON_SECURITY_ISSUES` | `false` | if false, a security error aborts the run |
+| `FS_IO_TIMEOUT` | `30` | per-syscall bound (seconds) for filesystem I/O; `0` = unbounded |
+| `CHECK_NETWORK_SECURITY` | `false` | enable the firewall and open-port checks |
+| `SET_BACKUP_PERMISSIONS` | `false` | skip root-ownership enforcement on the backup/log dirs (externally managed) |
+
+## Secret redaction in logs
+
+Secrets are kept out of logs at two layers. The logger has a `RegisterSecret` path that
+scrubs every log line, and `RedactSecrets` masks each secret in both its **raw and
+URL-encoded** form (so a token embedded in a `*url.Error` is caught too). Secrets shorter
+than 6 runes are not registered, and forms are ordered longest-first so a short secret
+cannot partially mask a longer one. `MaskSecret` renders a **fixed 12-asterisk prefix**
+plus the last 4 runes; a secret of 8 runes or fewer is fully masked. The fixed-width
+prefix deliberately hides the real length. `RedactURLError` strips the URL from a
+`*url.Error`, keeping only the operation and transport error, so request URLs (which
+carry low-capability values like a check UUID or `server_id`) never reach a log. The
+per-channel redaction rules and the deliberate exceptions (the public relay credential,
+the display-only portal link) are documented in [NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+## Terminal-escape scrubbing of untrusted display data
+
+Strings that originate from a backup or from the central server are scrubbed before they
+are printed, so a hostile filename or a MITM server response cannot inject terminal
+escapes into the operator's console (`internal/ui/components/sanitize.go`):
+
+- `SanitizeText` strips ANSI sequences and drops C0 controls, `DEL`, and C1 bytes,
+  keeping only newline and tab. `SanitizeLine` additionally collapses newline and tab to
+  spaces for single-line contexts (table cells, filenames, menu rows).
+- `sanitizeStreamLine` is the color-preserving variant for the live run viewport: it
+  keeps only SGR (color) sequences and drops every other escape (cursor moves, OSC, mode
+  toggles).
+
+These are applied to daemon status fields, the restore abort IP, backup-derived
+filenames, menu rows, and the streaming run panel. The portal magic-link has its own
+fail-closed sanitizer (`SanitizeLoginURL`, printable-ASCII http(s) only); see
+[NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+## Immutable identity secrets
+
+The server identity (`.server_identity`) and the relay secret (`.notify_secret`) live
+under `<BASE_DIR>/identity` and are written `0600` with `chattr +i` (the immutable flag
+is cleared before an overwrite and restored after). Reads are confined with `os.Root`,
+which resolves the gosec G304 concern structurally rather than with a `#nosec`
+suppression. See [NOTIFICATIONS.md](NOTIFICATIONS.md) for how `.notify_secret` is
+provisioned.
+
+## Bounded filesystem I/O
+
+A backup or restore can touch a mount that has gone dead or stale, where a normal
+syscall blocks forever in uninterruptible sleep. `internal/safefs` bounds each such
+syscall by `FS_IO_TIMEOUT` (default 30s): the call runs in a worker goroutine, and on
+timeout it is **abandoned** (the kernel call is not cancelled, the operation returns
+`ErrTimeout`, and the caller skips rather than wedging). File copies use a per-chunk
+no-progress budget, and the bounded directory walk never follows symlinks. This is the
+layer beneath the daemon's hang watchdog (see [DAEMON.md](DAEMON.md)); the logger caps
+its own log-write budget at 5s and then falls back to stdout only.
+
+## Read-only bind-mount guards
+
+When a datastore or storage mountpoint is offline at restore time, ProxSave read-only
+bind-mounts a guard directory over it (`MS_BIND | MS_REMOUNT | MS_RDONLY | MS_NODEV |
+MS_NOSUID | MS_NOEXEC`), so nothing can write into the root filesystem while the real
+storage is missing. Only mountpoints under `/mnt/`, `/media/`, or `/run/media/` are
+eligible, and the target is resolved through symlinks and re-checked against that
+allowlist **before** any `mkdir` or `mount`, closing a parent-component symlink escape.
+Guards live under `/var/lib/proxsave/guards`; a bind guard is shadowed by the real mount
+when it returns and is discarded on reboot. Legacy immutable (`chattr +i`) fallbacks are
+recorded in a `0600` index so `proxsave --cleanup-guards` can clear exactly those. See
+[RESTORE_TECHNICAL.md](RESTORE_TECHNICAL.md) and
+[CLUSTER_RECOVERY.md](CLUSTER_RECOVERY.md).
 
 ## Static-analysis policy (gosec)
 
-CI runs gosec (`.github/workflows/security-ultimate.yml`). Two rules deserve a note:
+CI runs gosec (`.github/workflows/security-ultimate.yml`). Three rules deserve a note:
 
-- **G305** (archive-extraction traversal / zip-slip) — **kept enabled**; the restore
-  extraction containment described above is what satisfies it.
-- **G304** ("file path from a variable") — **kept enabled project-wide**, but the
-  current findings on the collectors, config readers and backup-output writers are
-  **dismissed as false positives** in Code Scanning: those paths are
-  tool/system/config-controlled per the threat model. The rule stays enabled so any
-  **new** variable-path I/O is still surfaced for review; genuinely contained I/O
-  should use `os.Root` rather than a `#nosec` suppression.
-- **G101** ("potential hardcoded credentials") — **kept enabled**. With one
-  intentional exception (below), every current finding is a **name-only false
-  positive**: a constant or identifier whose name matches `token`/`secret`/`salt`
-  but whose value is a file path (`/etc/pve/priv/token.cfg`), a KDF
-  domain-separation salt (public by construction), a token *name* (`backup@pbs!go-client`,
-  not its secret), or an enum id (`pbs_runtime_access_user_tokens`). These are
-  dismissed as false positives in Code Scanning rather than renamed, since the names
-  are correct as written.
+- **G305** (archive-extraction traversal / zip-slip): **kept enabled**; the restore
+  extraction containment above is what satisfies it.
+- **G304** ("file path from a variable"): **kept enabled project-wide**, but the current
+  findings on the collectors, config readers, and backup-output writers are **dismissed
+  as false positives** in Code Scanning, since those paths are tool/system/config
+  controlled per the threat model. The rule stays enabled so any **new** variable-path
+  I/O is surfaced for review. New contained I/O should prefer `os.Root` over a `#nosec`
+  suppression; a few legacy `#nosec G304` sites remain.
+- **G101** ("potential hardcoded credentials"): **kept enabled**. With one intentional
+  exception (below), every current finding is a **name-only false positive**: a constant
+  whose name matches `token`/`secret`/`salt` but whose value is a file path
+  (`/etc/pve/priv/token.cfg`), a KDF domain-separation salt (public by construction), a
+  token *name* (`backup@pbs!go-client`, not its secret), or an enum id
+  (`pbs_runtime_access_user_tokens`). These are dismissed as false positives rather than
+  renamed, since the names are correct as written.
 
 ### Hardcoded relay credential (G101)
 
 The cloud email relay ships a hardcoded `WorkerToken` and `HMACSecret`
 (`notify.DefaultCloudRelayConfig`, mirrored in `config.applyDefaults`). These are a
-**shared, public anti-abuse credential**, not a confidential secret: the same value
-is compiled into every distributed binary and published in this open-source
-repository, so it cannot be kept secret on the client side. The token name is
-literally `v1_public_...`. It only gates the free shared relay worker, whose real
-protection is server-side (rate limiting, per-request `server_mac`/`server_id`); it
-grants no access to user data or the host. The two sites carry a `#nosec G101`
-documenting this, and the Code Scanning alert is dismissed accordingly. Operators
-who want a private relay can point `CLOUDFLARE_*` / the relay config at their own
-worker with their own secret.
+**shared, public anti-abuse credential**, not a confidential secret: the same value is
+compiled into every distributed binary and published in this open-source repository, so
+it cannot be kept secret on the client side. The token name is literally
+`v1_public_...`. It only gates the free shared relay worker, whose real protection is
+server-side (rate limiting, per-request `server_mac`/`server_id`); it grants no access to
+user data or the host. The two sites carry a `#nosec G101` documenting this, and the Code
+Scanning alert is dismissed accordingly. Operators who want a private relay can point
+`CLOUDFLARE_*` / the relay config at their own worker with their own secret. See
+[NOTIFICATIONS.md](NOTIFICATIONS.md#the-shared-cloud-relay-worker).

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -1,59 +1,82 @@
-# Test strategy — proxsave
+# Test strategy (proxsave)
 
-## Revisione progressiva della suite + convenzione `*_audited_test.go`
+## Progressive suite review and the `*_audited_test.go` convention
 
-È in corso una revisione progressiva dell'intera test suite esistente per verificare
-che nessun test cristallizzi un bug (cioè asserisca come "corretto" un comportamento
-in realtà difettoso del codice non testato). Per distinguere a colpo d'occhio i test
-già vagliati da quelli ancora da rivedere si usa il **suffisso del nome file**:
+The existing test suite is being reviewed progressively to make sure no test
+crystallizes a bug (that is, asserts as "correct" a behavior of the untested code that
+is actually wrong). To tell reviewed tests from not-yet-reviewed ones at a glance, we
+use a **filename suffix**:
 
-- **`*_test.go`** (senza marcatore) = test **legacy, ancora da rivedere**.
-- **`*_audited_test.go`** = test **vagliato**, in uno di questi due casi:
-  - è **nato dopo la baseline** (scritto sapendo già che il codice sotto è corretto), oppure
-  - è un file legacy che è stato **riletto e approvato** (nessun bug cristallizzato).
+- **`*_test.go`** (no marker) = **legacy, not yet reviewed**.
+- **`*_audited_test.go`** = **reviewed**, in one of two cases:
+  - it was **written after the baseline** (with the code under test already known good), or
+  - it is a legacy file that was **reread and approved** (no bug crystallized).
 
-Go richiede solo che il file finisca in `_test.go`, quindi `*_audited_test.go` viene
-raccolto normalmente da `go test`: la convenzione non ha alcun costo a runtime.
+Go only requires the file to end in `_test.go`, so `*_audited_test.go` is collected by
+`go test` like any other test: the convention has no runtime cost.
 
-### Regole operative
+### Operating rules
 
-- Quando scrivi **nuovi** test, nominali direttamente `<qualcosa>_audited_test.go`.
-- Quando **finisci di rivedere** un file legacy, rinominalo con `git mv`:
-  `git mv foo_test.go foo_audited_test.go` (la history viene preservata; il rename è
-  di per sé il log della revisione, fai un commit atomico per file/area).
-- Per i file enormi rivisti a pezzi, granularità **per funzione** con un tag-commento
-  datato sopra la `func Test...`:
-  `// audited: 2026-06-09 — verificato che non cristallizza bug`
-- **Non** rinominare in blocco i 238 file legacy: il rename avviene solo a revisione
-  effettivamente completata.
+- When you write **new** tests, name them `<something>_audited_test.go` directly.
+- When you **finish reviewing** a legacy file, rename it with `git mv`:
+  `git mv foo_test.go foo_audited_test.go` (history is preserved; the rename is itself
+  the review log, so make one atomic commit per file or area).
+- For huge files reviewed in pieces, use **per-function** granularity with a dated tag
+  comment above the `func Test...`:
+  `// audited: 2026-06-09 verified it does not crystallize a bug`
+- **Do not** bulk-rename the legacy files: a rename happens only once a review is
+  actually complete.
 
-### Avanzamento
+### Progress
 
 ```bash
-# quanti restano da rivedere
+# how many are left to review
 find . -name '*_test.go' -not -name '*_audited_test.go' -not -path './vendor/*' | wc -l
-# quanti già vagliati
+# how many are already reviewed
 find . -name '*_audited_test.go' -not -path './vendor/*' | wc -l
-# prossimi da fare in un package
+# next ones to do in a package
 find internal/orchestrator -name '*_test.go' -not -name '*_audited_test.go'
 ```
 
-### Baseline git
+As of this writing there are 347 legacy files still to review and 30 audited files.
 
-Il tag **`tests-audit-baseline`** (su `3222a30`, 2026-06-09) marca lo stato della suite
-all'avvio della revisione. Per sapere *cosa* è cambiato nei test rispetto a quel punto:
+### Git baseline
+
+The tag **`tests-audit-baseline`** (on `3222a30`, 2026-06-09) marks the state of the
+suite at the start of the review. To see *what* changed in the tests relative to that
+point:
 
 ```bash
 git diff --name-only tests-audit-baseline -- '*_test.go'
 ```
 
-Il suffisso `_audited_` risponde a "rivisto / da rivedere"; il tag risponde a
-"creato prima/dopo la baseline". Insieme coprono entrambe le domande.
+The `_audited_` suffix answers "reviewed / to review"; the tag answers "created
+before/after the baseline". Together they cover both questions.
 
-## Contesto
+## UI driver tests (`internal/uitest`)
 
-La revisione nasce dall'audit di correttezza pre-test del 2026-06-09
-(`diagnostics/precoverage-bughunt-2026-06-09.md`), che ha confermato 26 bug nel codice
-non coperto che stavamo per testare: la prova che scrivere test su codice non vagliato
-rischia di cristallizzare i difetti. Da qui la regola: prima si verifica la correttezza
-del codice, poi si scrive il test, che nasce `_audited`.
+`internal/uitest` holds test-only helpers for the Charm/bubbletea driver tests. It is
+imported only from `_test.go` files and is never linked into the production binary.
+
+The driver tests poll a render buffer until a screen or line appears. Under the race
+detector the bubbletea event loop runs roughly an order of magnitude slower, so a fixed
+wall-clock deadline can fire spuriously even when the logic is correct.
+`uitest.Deadline(base)` scales a base render-poll timeout by a **race-aware factor**
+(`raceScale` = 8 under `-race`, 1 otherwise, selected by build tag). Because those polls
+return as soon as the condition is met, a wider deadline is free on the success path: it
+only adds headroom before a genuine hang is reported. Use it **only** for UI-render
+polling deadlines, never for a test that asserts an operation's own timeout behavior.
+
+The driver tests are also sensitive to CPU saturation: run them **one package at a
+time** rather than fanning out `go test` (or `-race`) across packages in parallel, or the
+Charm driver can still hit spurious render-poll timeouts under load. Always read the real
+exit code rather than piping the output through `tail` or similar.
+
+## Context
+
+The review grew out of the pre-test coverage and correctness audit of 2026-06-09
+(`diagnostics/coverage-audit-2026-06-09.md`, dev @ `3222a30`, the same commit as the
+`tests-audit-baseline` tag), which surveyed how much of the code we were about to test
+was still unvetted. Writing tests over unvetted code risks freezing its defects in
+place, so the rule is: verify the code is correct first, then write the test, which is
+born `_audited`.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,6 +15,7 @@ Complete troubleshooting guide for Proxsave with common issues, solutions, and d
   - [Restore Issues](#7-restore-issues)
 - [Debug Procedures](#debug-procedures)
 - [Getting Help](#getting-help)
+- [Exit Codes](#exit-codes)
 - [Related Documentation](#related-documentation)
 
 ---
@@ -159,7 +160,7 @@ Linux permission modes and `root:root` ownership are often synthetic on CIFS/SMB
 ```bash
 # Check valid values
 nano configs/backup.env
-COMPRESSION_TYPE=xz    # Valid: xz, zstd, gzip, bzip2, lz4
+COMPRESSION_TYPE=xz    # Valid: gzip, bzip2, xz, lzma, zstd (also pigz; none to disable)
 ```
 
 **Test configuration**:
@@ -310,7 +311,7 @@ iptables -L -n | grep -i drop
 
 ---
 
-#### Restore/Decrypt: stuck on “Scanning backup path…” or timeout (cloud/rclone)
+#### Restore/Decrypt: stuck on "Scanning backup path..." or timeout (cloud/rclone)
 
 **Cause**: ProxSave scans cloud backups by listing the remote (`rclone lsf`) and inspecting each candidate by reading the manifest/metadata (`rclone cat`). Each rclone call is protected by `RCLONE_TIMEOUT_CONNECTION` (the timer resets per command). On slow remotes or very large directories this can time out.
 
@@ -590,7 +591,7 @@ This mode uses Proxmox Notifications via `proxmox-mail-forward`. It is the recom
   - **PVE**: `pvesh get /access/users/root@pam` → fallback to `pveum user list` → fallback to `/etc/pve/user.cfg`
   - **PBS**: `proxmox-backup-manager user list` → fallback to `/etc/proxmox-backup/user.cfg`
   - **Dual**: intentionally reuses the **PVE** path for `root@pam` email discovery
-- Relay blocks `root@…` recipients; use a real non-root mailbox for `EMAIL_RECIPIENT`.
+- Relay blocks `root@...` recipients; use a real non-root mailbox for `EMAIL_RECIPIENT`.
 - If `EMAIL_FALLBACK_SENDMAIL=true`, ProxSave will fall back to local `/usr/sbin/sendmail` when relay delivery fails. If relay cannot start because no recipient is available, sendmail cannot help either; configure `EMAIL_RECIPIENT` or the `root@pam` email in Proxmox.
 - Check the proxsave logs for `email-relay` warnings/errors.
 - `Email relay accepted request ...` means the relay accepted the submission. It does **not** guarantee final inbox delivery; later provider-side failures/bounces are outside the ProxSave process.
@@ -824,13 +825,10 @@ proxsave --dry-run --log-level debug
 # Check output for loaded config values
 ```
 
-**Expected dry-run output**:
-```
-[DRY-RUN] Configuration loaded from: configs/backup.env
-[DRY-RUN] CLOUD_ENABLED: true
-[DRY-RUN] CLOUD_REMOTE: gdrive:pbs-backups
-[DRY-RUN] Would create backup...
-```
+Dry-run runs the full workflow at the chosen log level but makes no changes (no archive
+written, no upload, no retention delete). With `--log-level debug` the loaded
+configuration and the actions ProxSave *would* take are written to the log, so use it to
+confirm the config parsed as expected before a real run.
 
 ---
 
@@ -1024,10 +1022,40 @@ proxsave --support
 **Support mode workflow**:
 1. Requests GitHub username and issue number
 2. Runs backup with DEBUG logging
-3. Emails log to `github-support@tis24.it`
+3. Emails the log to the maintainer address baked into the build (injected at build time, not hardcoded; a dev build without it skips the email and logs a warning)
 4. Requires existing GitHub issue for tracking
 
 **Note**: Logs may contain file paths and hostnames. Credentials are never logged.
+
+---
+
+## Exit Codes
+
+`proxsave` returns a specific exit code so scripts and the daemon can react to the
+failure class. `0` is success; any non-zero code is a failure.
+
+| Code | Name | Meaning |
+|------|------|---------|
+| `0` | success | Execution completed successfully |
+| `1` | generic error | Unspecified error |
+| `2` | configuration error | Invalid or missing configuration |
+| `3` | environment error | Invalid or unsupported Proxmox environment |
+| `4` | backup error | Error during the backup operation (generic) |
+| `5` | storage error | Error during storage operations |
+| `6` | network error | Network error (upload, notifications, and so on) |
+| `7` | permission error | Permission error |
+| `8` | verification error | Integrity verification failed |
+| `9` | collection error | Error collecting configuration files |
+| `10` | archive error | Error creating the archive |
+| `11` | compression error | Error during compression |
+| `12` | disk space error | Insufficient disk space |
+| `13` | panic error | An unhandled panic was caught |
+| `14` | security error | The security check reported errors |
+| `15` | encryption error | Error during encryption setup or processing |
+
+A backup that finishes with warnings (no errors) is promoted from `0` to exit `1`
+(generic error) before the notification phase; a run that raised errors becomes `4`
+(backup error) when its code is still `0`/`1`, otherwise it keeps its more specific code.
 
 ---
 
@@ -1105,7 +1133,7 @@ A: Use `--dry-run` mode: `proxsave --dry-run --log-level debug`
 A: Update your configuration: `proxsave --upgrade-config`
 
 **Q: Can I run backup while another backup is in progress?**
-A: No. Proxsave uses a lock file (`BACKUP_PATH/.backup.lock`) to prevent concurrent runs. The lock stores `pid/host/time`; on the same host, proxsave checks PID liveness to avoid “stuck” locks after an interrupted run.
+A: No. Proxsave uses a lock file (`.backup.lock` under `LOCK_PATH`, default `<BASE_DIR>/lock/.backup.lock`) to prevent concurrent runs. The lock stores `pid/host/time`; on the same host, proxsave checks PID liveness to avoid "stuck" locks after an interrupted run.
 
 **Q: Backup hangs during PVE datastore detection when a network storage is unreachable.**
 A: Set `FS_IO_TIMEOUT` to cap how long proxsave waits on any individual filesystem syscall (stat/readdir/open/read/write/close/glob/copy/hash) across the preflight, logging, storage, cloud and restore paths, and `PVESH_TIMEOUT` to cap `pvesh` calls. This reduces the likelihood of indefinite hangs when a storage becomes unreachable mid-run.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tis24dev/proxsave
 go 1.25.12
 
 require (
-	charm.land/bubbles/v2 v2.1.0
+	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	filippo.io/age v1.3.1
@@ -25,7 +25,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
+	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tis24dev/proxsave
 
-go 1.25.11
+go 1.25.12
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAwLGRZ+sebTUruuM4Ra3M=
 c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
-charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
-charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
+charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
+charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
@@ -36,8 +36,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
-github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
+github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -35,20 +35,23 @@ type Args struct {
 	ShowHelp            bool
 	Upgrade             bool
 	UpgradeAutoYes      bool
-	ForceNewKey         bool
-	Decrypt             bool
-	Restore             bool
-	Install             bool
-	NewInstall          bool
-	UpgradeConfig       bool
-	UpgradeConfigDry    bool
-	UpgradeConfigJSON   bool
-	CleanupGuards       bool
-	Backup              bool
-	Daemon              bool
-	DaemonSetup         bool
-	DaemonRemove        bool
-	DaemonStatus        bool
+	// LocalFile modifies --upgrade: skip the release check + download and finalize
+	// using the binary already on disk (upgrade-beta.sh swaps it in first).
+	LocalFile         bool
+	ForceNewKey       bool
+	Decrypt           bool
+	Restore           bool
+	Install           bool
+	NewInstall        bool
+	UpgradeConfig     bool
+	UpgradeConfigDry  bool
+	UpgradeConfigJSON bool
+	CleanupGuards     bool
+	Backup            bool
+	Daemon            bool
+	DaemonSetup       bool
+	DaemonRemove      bool
+	DaemonStatus      bool
 }
 
 var osExit = os.Exit
@@ -114,6 +117,8 @@ func Parse() *Args {
 		"Reset the installation directory (preserving build/env/identity) and launch the interactive installer")
 	flag.BoolVar(&args.Upgrade, "upgrade", false,
 		"Download and install the latest ProxSave binary (also upgrades backup.env by adding missing keys from the new template). Append 'y' to auto-confirm (e.g., --upgrade y)")
+	flag.BoolVar(&args.LocalFile, "localfile", false,
+		"With --upgrade: skip the release check and download, and finalize using the binary already on disk (upgrade backup.env, refresh docs/symlinks, install/restart the daemon, fix permissions). Used by upgrade-beta.sh after it swaps in a binary")
 	flag.BoolVar(&args.CleanupGuards, "cleanup-guards", false,
 		"Cleanup ProxSave guard bind mounts and directories (/var/lib/proxsave/guards). Use with --dry-run to preview")
 

--- a/internal/health/daemon_state_test.go
+++ b/internal/health/daemon_state_test.go
@@ -227,7 +227,7 @@ func TestCheckDaemonStateProcStaleStale(t *testing.T) {
 		t.Fatalf("StaleReason should be set when the /proc probe reports stale")
 	}
 	// The behind render gate: AlignChecked && !Aligned suffices (no record required).
-	if !(s.AlignChecked && !s.Aligned) {
+	if !s.AlignChecked || s.Aligned {
 		t.Fatalf("stale daemon must be behind-eligible via AlignChecked && !Aligned")
 	}
 }

--- a/internal/logging/bootstrap.go
+++ b/internal/logging/bootstrap.go
@@ -192,7 +192,7 @@ func (b *BootstrapLogger) Info(format string, args ...interface{}) {
 		// Logger; record() still keeps the RAW msg so Flush re-formats it once.
 		now := time.Now().Format(bootstrapTimeFormat)
 		line := FormatConsoleLogLine(now, types.LogLevelInfo, msg, consoleUseColor(os.Stdout))
-		fmt.Fprint(os.Stdout, line)
+		_, _ = fmt.Fprint(os.Stdout, line)
 	}
 	b.mirrorLog(types.LogLevelInfo, msg)
 	b.record(types.LogLevelInfo, msg)

--- a/internal/orchestrator/healthcheck_setup_test.go
+++ b/internal/orchestrator/healthcheck_setup_test.go
@@ -85,7 +85,7 @@ func TestClassifyHealthcheckSetupResult(t *testing.T) {
 		{"not ready retry", HealthcheckCheckResult{Err: health.ErrHCNotReady}, false, false, ""},
 		{"network retry keeps login", HealthcheckCheckResult{Err: errors.New("dial"), LoginURL: "https://hc/L2"}, false, false, "https://hc/L2"},
 		{"hostile ansi login dropped", HealthcheckCheckResult{Err: nil, Reachable: true, LoginURL: "https://hc/\x1b[2Jx"}, true, false, ""},
-		{"c1 control login dropped", HealthcheckCheckResult{Err: nil, Reachable: true, LoginURL: "https://hc/x"}, true, false, ""},
+		{"c1 control login dropped", HealthcheckCheckResult{Err: nil, Reachable: true, LoginURL: "https://hc/\u009bx"}, true, false, ""},
 		{"non-https login dropped", HealthcheckCheckResult{Err: nil, Reachable: true, LoginURL: "ftp://evil/x"}, true, false, ""},
 	}
 	for _, tc := range tests {

--- a/internal/orchestrator/pve_staged_apply_additional_test.go
+++ b/internal/orchestrator/pve_staged_apply_additional_test.go
@@ -631,7 +631,7 @@ func TestPVEStorageMountGuardItems_CoversFilteringAndFallbacks(t *testing.T) {
 			t.Fatalf("items len=%d; want 2 (%v)", len(items), items)
 		}
 		targets := []string{items[0].GuardTarget, items[1].GuardTarget}
-		if !(containsGuardTarget(targets, "/mnt/pool") && containsGuardTarget(targets, "/mnt/pve/nas-net")) {
+		if !containsGuardTarget(targets, "/mnt/pool") || !containsGuardTarget(targets, "/mnt/pve/nas-net") {
 			t.Fatalf("unexpected guard targets: %v", targets)
 		}
 	})

--- a/internal/orchestrator/restore_dedup_materialize_test.go
+++ b/internal/orchestrator/restore_dedup_materialize_test.go
@@ -59,7 +59,9 @@ func TestMaterializeDedupSymlinksFullRestore(t *testing.T) {
 	}
 	writeDedupManifestForTest(t, destRoot, []backup.DedupManifestEntry{{Path: "a/two.cfg", Mode: 0o640}})
 
-	materializeDedupSymlinks(context.Background(), archive, destRoot, logging.New(types.LogLevelError, false))
+	if err := materializeDedupSymlinks(context.Background(), archive, destRoot, logging.New(types.LogLevelError, false)); err != nil {
+		t.Fatalf("materialize dedup symlinks: %v", err)
+	}
 
 	two := filepath.Join(destRoot, "a", "two.cfg")
 	info, err := os.Lstat(two)
@@ -104,7 +106,9 @@ func TestMaterializeDedupCrossCategoryRebuildsFromArchive(t *testing.T) {
 	}
 	writeDedupManifestForTest(t, destRoot, []backup.DedupManifestEntry{{Path: "b/two.cfg", Mode: 0o640}})
 
-	materializeDedupSymlinks(context.Background(), archive, destRoot, logging.New(types.LogLevelError, false))
+	if err := materializeDedupSymlinks(context.Background(), archive, destRoot, logging.New(types.LogLevelError, false)); err != nil {
+		t.Fatalf("materialize dedup symlinks: %v", err)
+	}
 
 	two := filepath.Join(destRoot, "b", "two.cfg")
 	info, err := os.Lstat(two)
@@ -173,7 +177,9 @@ func TestMaterializeDedupMissingCanonicalKeepsSymlink(t *testing.T) {
 	}
 	writeDedupManifestForTest(t, destRoot, []backup.DedupManifestEntry{{Path: "b/two.cfg", Mode: 0o640}})
 
-	materializeDedupSymlinks(context.Background(), archive, destRoot, logging.New(types.LogLevelError, false))
+	if err := materializeDedupSymlinks(context.Background(), archive, destRoot, logging.New(types.LogLevelError, false)); err != nil {
+		t.Fatalf("materialize dedup symlinks: %v", err)
+	}
 
 	info, err := os.Lstat(filepath.Join(destRoot, "b", "two.cfg"))
 	if err != nil {
@@ -209,7 +215,9 @@ func TestMaterializeDedupUsesArchiveNotStaleDisk(t *testing.T) {
 	}
 	writeDedupManifestForTest(t, destRoot, []backup.DedupManifestEntry{{Path: "a/two.cfg", Mode: 0o640}})
 
-	materializeDedupSymlinks(context.Background(), archive, destRoot, logging.New(types.LogLevelError, false))
+	if err := materializeDedupSymlinks(context.Background(), archive, destRoot, logging.New(types.LogLevelError, false)); err != nil {
+		t.Fatalf("materialize dedup symlinks: %v", err)
+	}
 
 	data, err := os.ReadFile(filepath.Join(destRoot, "a", "two.cfg"))
 	if err != nil {

--- a/internal/orchestrator/workflow_ui_charm.go
+++ b/internal/orchestrator/workflow_ui_charm.go
@@ -65,7 +65,7 @@ const workflowStatusResultActionContinue workflowStatusResultAction = iota
 // on a real UI error. This is a Selector, NOT a components.Notice.
 func (u *charmWorkflowUI) ShowStatusResult(ctx context.Context, screenTitle string, level HealthcheckSetupLevel, keyword, explanation string) error {
 	errWorkflowStatusEsc := errors.New("workflow status: esc")
-	prompt := buildWorkflowStatusPrompt(level, keyword, explanation)
+	prompt := BuildStatusPrompt(level, keyword, explanation)
 	items := []components.SelectorItem[workflowStatusResultAction]{
 		{Label: "Continue", Description: "continue the workflow", Value: workflowStatusResultActionContinue},
 	}

--- a/internal/orchestrator/workflow_ui_status.go
+++ b/internal/orchestrator/workflow_ui_status.go
@@ -25,15 +25,12 @@ func RenderStatusLevel(level HealthcheckSetupLevel, text string) string {
 	}
 }
 
-// buildWorkflowStatusPrompt renders the styled "Status:" block for a workflow outcome screen,
-// identical to dashboard.go buildDaemonResultPrompt: a colored keyword line + a Subtle
-// explanation on the next line (separated by a blank line). This is the single styled
-// renderer for the decrypt-workflow outcomes, so they can never disagree visually with the
-// daemon / check result screens. Keyword and explanation are free-form (may embed external
-// tool output / error strings), so both are SanitizeText-scrubbed before theme rendering to
-// keep raw ANSI/OSC/C0/C1 escapes out of the verbatim WithSelectorPromptStyled path. The
-// scrub-then-render shape is BYTE-IDENTICAL to buildDaemonResultPrompt.
-func buildWorkflowStatusPrompt(level HealthcheckSetupLevel, keyword, explanation string) string {
+// BuildStatusPrompt renders the styled "Status:" block shared by dashboard and workflow
+// outcome screens: a colored keyword line plus an optional Subtle explanation separated by a
+// blank line. Keyword and explanation are free-form (may embed external tool output / error
+// strings), so both are SanitizeText-scrubbed before theme rendering to keep raw ANSI/OSC/C0/C1
+// escapes out of the verbatim WithSelectorPromptStyled path.
+func BuildStatusPrompt(level HealthcheckSetupLevel, keyword, explanation string) string {
 	var b strings.Builder
 	b.WriteString(theme.Text.Render("Status: "))
 	b.WriteString(RenderStatusLevel(level, components.SanitizeText(keyword)))

--- a/internal/orchestrator/workflow_ui_status_test.go
+++ b/internal/orchestrator/workflow_ui_status_test.go
@@ -41,15 +41,15 @@ func TestRenderStatusLevel(t *testing.T) {
 	}
 }
 
-// TestBuildWorkflowStatusPromptStripsInjectedEscapes proves buildWorkflowStatusPrompt scrubs
+// TestBuildStatusPromptStripsInjectedEscapes proves BuildStatusPrompt scrubs
 // free-form keyword/explanation before theme rendering, so raw ANSI/OSC/C0/C1 escapes from
 // external tool output (e.g. rclone lsf embedded in an error) can never reach the terminal via
 // the verbatim WithSelectorPromptStyled path. The theme's own SGR (ESC[..m) still wraps the
 // text, so we assert the INJECTED marker sequences are gone rather than "no 0x1b anywhere".
-func TestBuildWorkflowStatusPromptStripsInjectedEscapes(t *testing.T) {
+func TestBuildStatusPromptStripsInjectedEscapes(t *testing.T) {
 	keyword := "\x1b[2JBOOM"
 	explanation := "failed: \x1b[31m\x1b]0;pwned\x07evil\x07"
-	got := buildWorkflowStatusPrompt(HealthcheckSetupLevelError, keyword, explanation)
+	got := BuildStatusPrompt(HealthcheckSetupLevelError, keyword, explanation)
 
 	// Injected escapes must be absent: the raw OSC/BEL/CSI-clear sequences and the C1 CSI byte.
 	for _, bad := range []string{"\x1b]0;pwned", "\x1b[2J", "\x07"} {
@@ -69,10 +69,10 @@ func TestBuildWorkflowStatusPromptStripsInjectedEscapes(t *testing.T) {
 	}
 }
 
-// TestBuildWorkflowStatusPromptPreservesNewline confirms a clean multi-line explanation keeps
+// TestBuildStatusPromptPreservesNewline confirms a clean multi-line explanation keeps
 // its newline (SanitizeText keeps \n/\t), so multi-line outcomes still render across lines.
-func TestBuildWorkflowStatusPromptPreservesNewline(t *testing.T) {
-	got := buildWorkflowStatusPrompt(HealthcheckSetupLevelOk, "ok", "line one\nline two")
+func TestBuildStatusPromptPreservesNewline(t *testing.T) {
+	got := BuildStatusPrompt(HealthcheckSetupLevelOk, "ok", "line one\nline two")
 	for _, want := range []string{"line one", "line two"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("clean line %q missing from output %q", want, got)

--- a/internal/ui/components/formgrid_test.go
+++ b/internal/ui/components/formgrid_test.go
@@ -279,7 +279,7 @@ func TestFormGridNoteAboveFields(t *testing.T) {
 		t.Fatalf("the field label must render:\n%s", view)
 	}
 	// The note sits ABOVE the fields, in order, one clause per line (never merged).
-	if !(noteTop < noteMid && noteMid < noteBot && noteBot < label) {
+	if noteTop >= noteMid || noteMid >= noteBot || noteBot >= label {
 		t.Fatalf("note must be above the fields, in order: top=%d mid=%d bot=%d label=%d\n%s",
 			noteTop, noteMid, noteBot, label, view)
 	}

--- a/internal/ui/components/sanitize_test.go
+++ b/internal/ui/components/sanitize_test.go
@@ -71,7 +71,7 @@ func TestSanitizeText(t *testing.T) {
 		},
 		{
 			name:    "c1 csi byte removed",
-			in:      "x31my",
+			in:      "x\u009b31my",
 			absent:  []rune{0x9b},
 			contain: []string{"x", "31my"},
 		},

--- a/internal/ui/flows/install/audit.go
+++ b/internal/ui/flows/install/audit.go
@@ -143,7 +143,7 @@ type auditResultAction int
 const auditResultActionBack auditResultAction = iota
 
 // auditResultPrompt builds the styled "Status:" block for an audit outcome, mirroring
-// buildWorkflowStatusPrompt: a colored keyword line + an optional Subtle explanation. It is a
+// orchestrator.BuildStatusPrompt: a colored keyword line + an optional Subtle explanation. It is a
 // pure string builder (extracted for testability). Keyword and explanation are free-form (may
 // embed external tool output / error strings), so both are SanitizeText-scrubbed before theme
 // rendering to keep raw ANSI/OSC/C0/C1 escapes out of the verbatim WithSelectorPromptStyled path.

--- a/internal/ui/flows/install/audit.go
+++ b/internal/ui/flows/install/audit.go
@@ -85,14 +85,14 @@ func RunPostInstallAudit(ctx context.Context, session *shell.Session, execPath, 
 	if collectErr != nil {
 		result.CollectErr = collectErr
 		showAuditResult(ctx, session, "Post-install check", orchestrator.HealthcheckSetupLevelWarn,
-			"check failed", fmt.Sprintf("Non-blocking: %v", collectErr), backToMenu)
+			"CHECK FAILED", fmt.Sprintf("Non-blocking: %v", collectErr), backToMenu)
 		return result, nil
 	}
 	result.Suggestions = suggestions
 
 	if len(suggestions) == 0 {
 		showAuditResult(ctx, session, "Post-install check", orchestrator.HealthcheckSetupLevelOk,
-			"no unused components", "", backToMenu)
+			"NO UNUSED COMPONENTS", "", backToMenu)
 		return result, nil
 	}
 
@@ -120,18 +120,18 @@ func RunPostInstallAudit(ctx context.Context, session *shell.Session, execPath, 
 	}
 	if len(keys) == 0 {
 		showAuditResult(ctx, session, "Post-install check", orchestrator.HealthcheckSetupLevelNeutral,
-			"no changes", "No components were selected; nothing was modified.", backToMenu)
+			"NO CHANGES", "No components were selected; nothing was modified.", backToMenu)
 		return result, nil
 	}
 
 	if err := installer.ApplyAuditDisables(configPath, keys); err != nil {
 		showAuditResult(ctx, session, "Post-install check", orchestrator.HealthcheckSetupLevelError,
-			"update failed", err.Error(), backToMenu)
+			"UPDATE FAILED", err.Error(), backToMenu)
 		return result, nil
 	}
 	result.AppliedKeys = normalizeAuditKeys(keys)
 	showAuditResult(ctx, session, "Post-install check", orchestrator.HealthcheckSetupLevelOk,
-		"updated", fmt.Sprintf("Disabled %d component(s): %s",
+		"UPDATED", fmt.Sprintf("Disabled %d component(s): %s",
 			len(result.AppliedKeys), strings.Join(result.AppliedKeys, ", ")), backToMenu)
 	return result, nil
 }

--- a/internal/ui/flows/install/install_test.go
+++ b/internal/ui/flows/install/install_test.go
@@ -475,10 +475,10 @@ func TestRunPostInstallAudit(t *testing.T) {
 	d.keys("space down down down enter")
 	// The outcome is now the shared styled "Post-install check" result screen (a
 	// selector with a colored Status keyword), not a Notice. Assert the green
-	// "✓ updated" keyword + the disabled-component line. In the install flow the
+	// "✓ UPDATED" keyword + the disabled-component line. In the install flow the
 	// leave item is "Continue" (mirrors the Telegram check that follows), NOT "Back".
 	d.waitScreen("Post-install check")
-	d.waitText("✓ updated")
+	d.waitText("✓ UPDATED")
 	d.waitText("Disabled 1 component(s): BACKUP_X")
 	d.waitText("Continue")
 	d.keys("enter")
@@ -505,7 +505,7 @@ func TestRunPostInstallAudit(t *testing.T) {
 
 // TestRunPostInstallAuditNoSuggestions drives the empty-suggestions outcome: it must
 // render the shared styled "Post-install check" result screen with the green
-// "✓ no unused components" Status keyword (and, per the daemon-result convention, no
+// "✓ NO UNUSED COMPONENTS" Status keyword (and, per the daemon-result convention, no
 // redundant explanation sentence), dismissible via Continue in the install flow.
 func TestRunPostInstallAuditNoSuggestions(t *testing.T) {
 	d := newDriver(t)
@@ -529,7 +529,7 @@ func TestRunPostInstallAuditNoSuggestions(t *testing.T) {
 	d.waitScreen("Post-install check") // the Run check confirm
 	d.keys("enter")                    // run the dry-run
 	d.waitScreen("Post-install check") // the outcome screen (same title)
-	d.waitText("✓ no unused components")
+	d.waitText("✓ NO UNUSED COMPONENTS")
 	d.keys("enter") // dismiss via Back
 
 	res := <-resCh

--- a/internal/ui/flows/menu/menu.go
+++ b/internal/ui/flows/menu/menu.go
@@ -25,12 +25,15 @@ const (
 	ActionInstallMenu // one menu row that opens an Edit install / Wipe install chooser
 	ActionReconfigure // "Edit install" -> the --install flow (chosen inside ActionInstallMenu)
 	ActionNewInstall  // "Wipe install" -> the --new-install flow (chosen inside ActionInstallMenu)
-	// Second group (diagnostics): each re-opens an existing setup/check screen
-	// in the live dashboard session; the caller loops back to the menu after.
+	// Second group: each re-opens an existing setup/check screen in the live dashboard
+	// session (dispatched through runDashboardDiagnostic); the caller loops back to the menu
+	// after. This is a DISPATCH grouping, not the menu layout: the menu positions these rows
+	// by user task, so ActionCheckUpgrade renders under "Maintenance" (next to New key and
+	// Install) while the other three render under "Diagnostic Checks".
 	ActionCheckTelegram
 	ActionCheckHealthcheck
 	ActionPostInstallCheck
-	ActionCheckUpgrade // check for a newer release and (on confirm) install it in-session
+	ActionCheckUpgrade // check for a newer release and (on confirm) install it in-session; shown under Maintenance
 	// Third group (daemon scheduler): setup/remove run the same admin path as the
 	// --daemon-setup / --daemon-remove flags; status runs a read-only screen.
 	ActionDaemonSetup   // install OR re-enable the resident daemon (--daemon-setup)

--- a/upgrade-beta.sh
+++ b/upgrade-beta.sh
@@ -195,6 +195,8 @@ else
     exit 0
   fi
 
+  BETA_TAG="${LATEST_TAG}"
+
   # Guard against a publish-order downgrade: /releases is ordered by publish date,
   # not semver, so a back-ported beta published AFTER a newer stable would show up
   # as .[0]. Refuse to auto-install a beta that is not newer than the installed
@@ -211,8 +213,6 @@ else
       exit 0
     fi
   fi
-
-  BETA_TAG="${LATEST_TAG}"
 fi
 
 VERSION="${BETA_TAG#v}"

--- a/upgrade-beta.sh
+++ b/upgrade-beta.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+###############################################
+# ProxSave BETA upgrader
+#
+# Installs a PRERELEASE (beta/rc) build onto an existing ProxSave install and
+# finalizes it exactly like the normal upgrade, WITHOUT downloading again: it
+# swaps in the beta binary, then runs `proxsave --upgrade --localfile` so the
+# freshly installed binary upgrades backup.env, refreshes docs/symlinks,
+# installs/restarts the daemon and fixes permissions.
+#
+# Why a separate script: the built-in `--upgrade` (and install.sh) only ever see
+# `/releases/latest`, which GitHub defines as the latest NON-prerelease release,
+# so a beta is invisible to them.
+#
+# What it does: it looks at the newest release overall (stable or beta).
+#   - newest is a BETA   -> shows installed vs available, asks to confirm, installs it.
+#   - newest is STABLE   -> tells you to use the standard upgrade and stops (so a
+#                           month-old beta is never installed over a newer stable).
+#
+# Usage:
+#   sh upgrade-beta.sh                 # newest release; installs it only if it is a beta (needs jq)
+#   sh upgrade-beta.sh -y              # same, no confirmation prompt
+#   sh upgrade-beta.sh v5.0.0-beta1    # force a specific tag (escape hatch, no jq needed)
+###############################################
+
+###############################################
+# 1) Parse arguments (-y/--yes, optional explicit tag)
+###############################################
+ASSUME_YES=0
+TAG_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y|--yes)
+      ASSUME_YES=1
+      ;;
+    -*)
+      echo "❌ Unknown option: $1"
+      exit 1
+      ;;
+    *)
+      if [ -z "${TAG_ARG}" ]; then
+        TAG_ARG="$1"
+      else
+        echo "❌ Unexpected argument: $1"
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+###############################################
+# 2) Ensure running as root
+###############################################
+if [ "$EUID" -ne 0 ]; then
+  echo "❌ Please run as root"
+  exit 1
+fi
+
+###############################################
+# 3) Config
+###############################################
+REPO="tis24dev/proxsave"
+TARGET_DIR="/opt/proxsave"
+BUILD_DIR="${TARGET_DIR}/build"
+TARGET_BIN="${BUILD_DIR}/proxsave"
+
+# Pinned release-signing public key (ECDSA P-256), IDENTICAL to install.sh and the
+# in-binary verifier. Prereleases are signed with the same key (GoReleaser signs
+# every release), so an archive whose SHA256SUMS does not verify against this key
+# is rejected. Fingerprint (sha256 of DER):
+# fdbbba66cdb770b85a728c8aee0b920b4cd244c84f4fc5a0065188fbe9a5eddb
+PUBKEY_PEM='-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElks05mPtm1vm0YtHlSGX1HlgdXjn
+liDJEnB+RgiWOQR+6xLWeX7PyauuMxUh/HNnvBQAokK91fLWes4r9Xlwzw==
+-----END PUBLIC KEY-----'
+
+###############################################
+# 4) Require an existing install (this UPGRADES, it does not install)
+###############################################
+if [ ! -x "${TARGET_BIN}" ]; then
+  echo "❌ No existing ProxSave install found at ${TARGET_BIN}"
+  echo "   This script upgrades an existing install to a beta. Install first:"
+  echo "   sh install.sh"
+  exit 1
+fi
+
+###############################################
+# 5) OS/ARCH detection
+###############################################
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH_RAW="$(uname -m)"
+
+if [ "${OS}" != "linux" ]; then
+  echo "❌ Only Linux systems are supported"
+  exit 1
+fi
+
+case "$ARCH_RAW" in
+  x86_64) ARCH="amd64" ;;
+  *)
+    echo "❌ Unsupported architecture: ${ARCH_RAW} (only linux/amd64 is published; build from source for other architectures)"
+    exit 1
+    ;;
+esac
+
+###############################################
+# 6) HTTP helpers (curl/wget)
+###############################################
+fetch() {
+  local url="$1"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "${url}"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O - "${url}"
+  else
+    echo "❌ Neither curl nor wget is installed" >&2
+    exit 1
+  fi
+}
+
+download() {
+  local url="$1"
+  local out="$2"
+
+  fetch "${url}" > "${out}"
+}
+
+###############################################
+# 7) Detect the installed version (best-effort)
+###############################################
+# The `|| CURRENT_VERSION=""` keeps a corrupt installed binary (whose --version
+# exits non-zero) from aborting the whole script under `set -euo pipefail` before
+# the "unknown" fallback below can run.
+CURRENT_VERSION="$("${TARGET_BIN}" --version 2>/dev/null | awk -F': ' '/^Version:/ {print $2; exit}')" || CURRENT_VERSION=""
+if [ -z "${CURRENT_VERSION}" ]; then
+  CURRENT_VERSION="unknown"
+fi
+
+###############################################
+# 8) Resolve the target tag and decide whether to proceed
+#
+# Explicit tag  -> force it (escape hatch), no stable guard.
+# Auto-detect   -> newest release overall; proceed only if it is a prerelease,
+#                  otherwise point the user at the standard upgrade and stop.
+###############################################
+if [ -n "${TAG_ARG}" ]; then
+  BETA_TAG="${TAG_ARG}"
+  echo "--------------------------------------------"
+  echo " ProxSave BETA upgrader (forced tag)"
+  echo " Installed version:  ${CURRENT_VERSION}"
+  echo " Requested tag:      ${BETA_TAG}"
+  echo "--------------------------------------------"
+else
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "❌ jq is required to detect the newest release."
+    echo "   Install jq, or pass a tag explicitly: sh upgrade-beta.sh vX.Y.Z-beta1"
+    exit 1
+  fi
+  # /releases (the LIST endpoint) includes prereleases and is newest-first, so the
+  # first non-draft entry is the most recent release overall (stable or beta).
+  RELEASES_JSON="$(fetch "https://api.github.com/repos/${REPO}/releases")"
+  LATEST_TAG="$(jq -r 'map(select(.draft == false)) | .[0].tag_name // empty' <<<"${RELEASES_JSON}")"
+  LATEST_PRE="$(jq -r 'map(select(.draft == false)) | (.[0].prerelease // false) | tostring' <<<"${RELEASES_JSON}")"
+
+  if [ -z "${LATEST_TAG}" ]; then
+    echo "❌ No release found for ${REPO} (the API may be rate-limited)."
+    echo "   You can pass a tag explicitly: sh upgrade-beta.sh vX.Y.Z-beta1"
+    exit 1
+  fi
+
+  if [ "${LATEST_PRE}" = "true" ]; then
+    LATEST_TYPE="beta / prerelease"
+  else
+    LATEST_TYPE="stable"
+  fi
+
+  echo "--------------------------------------------"
+  echo " ProxSave BETA upgrader"
+  echo " Installed version:  ${CURRENT_VERSION}"
+  echo " Latest available:   ${LATEST_TAG} (${LATEST_TYPE})"
+  echo "--------------------------------------------"
+
+  if [ "${LATEST_PRE}" != "true" ]; then
+    echo "ℹ The newest release is STABLE, not a beta."
+    echo "  This script only installs betas. Use the standard upgrade instead:"
+    echo ""
+    echo "    proxsave --upgrade"
+    echo ""
+    echo "  (or run it from the dashboard). Nothing was changed."
+    exit 0
+  fi
+
+  # Guard against a publish-order downgrade: /releases is ordered by publish date,
+  # not semver, so a back-ported beta published AFTER a newer stable would show up
+  # as .[0]. Refuse to auto-install a beta that is not newer than the installed
+  # version (version-sort compares the numeric cores). Escape hatch: pass the tag
+  # explicitly to force it.
+  BETA_VERSION="${BETA_TAG#v}"
+  if [ "${CURRENT_VERSION}" != "unknown" ] && [ "${CURRENT_VERSION}" != "${BETA_VERSION}" ]; then
+    NEWEST="$(printf '%s\n%s\n' "${CURRENT_VERSION}" "${BETA_VERSION}" | sort -V | tail -n1)"
+    if [ "${NEWEST}" = "${CURRENT_VERSION}" ]; then
+      echo "ℹ The newest beta (${BETA_TAG}) is OLDER than your installed version (${CURRENT_VERSION})."
+      echo "  Installing it would be a downgrade. Refusing."
+      echo "  To force this specific beta anyway:"
+      echo "    sh upgrade-beta.sh ${BETA_TAG}"
+      exit 0
+    fi
+  fi
+
+  BETA_TAG="${LATEST_TAG}"
+fi
+
+VERSION="${BETA_TAG#v}"
+
+###############################################
+# 9) Confirm (skipped with -y)
+###############################################
+if [ "${ASSUME_YES}" -ne 1 ]; then
+  if [ -r /dev/tty ]; then
+    printf 'Install BETA %s over %s? [y/N]: ' "${BETA_TAG}" "${CURRENT_VERSION}" > /dev/tty
+    read -r REPLY < /dev/tty || REPLY=""
+    case "${REPLY}" in
+      y|Y|yes|YES) : ;;
+      *)
+        echo "Aborted; nothing was changed."
+        exit 0
+        ;;
+    esac
+  else
+    echo "❌ Not attached to a terminal and -y was not given; refusing to install a beta unattended."
+    echo "   Re-run interactively, or pass -y to confirm: sh upgrade-beta.sh -y"
+    exit 1
+  fi
+fi
+
+###############################################
+# 10) Build archive/checksum/signature URLs
+###############################################
+FILENAME="proxsave_${VERSION}_${OS}_${ARCH}.tar.gz"
+
+BINARY_URL="https://github.com/${REPO}/releases/download/${BETA_TAG}/${FILENAME}"
+CHECKSUM_URL="https://github.com/${REPO}/releases/download/${BETA_TAG}/SHA256SUMS"
+SIG_URL="https://github.com/${REPO}/releases/download/${BETA_TAG}/SHA256SUMS.sig"
+
+echo "➡ Archive URL:   ${BINARY_URL}"
+echo "➡ Checksum URL:  ${CHECKSUM_URL}"
+echo "➡ Signature URL: ${SIG_URL}"
+
+###############################################
+# 11) Download archive, checksum and signature
+###############################################
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+cd "${TMP_DIR}"
+
+echo "[+] Downloading archive..."
+download "${BINARY_URL}" "${FILENAME}"
+
+echo "[+] Downloading SHA256SUMS..."
+download "${CHECKSUM_URL}" "SHA256SUMS"
+
+echo "[+] Downloading SHA256SUMS.sig..."
+if ! download "${SIG_URL}" "SHA256SUMS.sig"; then
+  echo "❌ Could not download SHA256SUMS.sig for ${BETA_TAG}"
+  echo "   Refusing to install without a verifiable release signature."
+  exit 1
+fi
+
+###############################################
+# 12) Verify SHA256SUMS signature (authenticity)
+###############################################
+echo "[+] Verifying SHA256SUMS signature..."
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "❌ openssl is required to verify the release signature"
+  exit 1
+fi
+
+printf '%s\n' "${PUBKEY_PEM}" > pubkey.pem
+if ! openssl dgst -sha256 -verify pubkey.pem -signature SHA256SUMS.sig SHA256SUMS >/dev/null 2>&1; then
+  echo "❌ SHA256SUMS signature verification FAILED, refusing to install"
+  exit 1
+fi
+echo "✔ Signature OK (release authenticity verified)"
+
+###############################################
+# 13) Verify checksum (integrity)
+###############################################
+echo "[+] Verifying checksum..."
+# Match the filename exactly, normalizing sha256sum's optional binary-mode '*'
+# marker on the name (mirrors the Go verifyChecksum). The original line is printed
+# unchanged so "sha256sum -c" still understands the marker.
+awk -v f="${FILENAME}" '{n=$2; sub(/^\*/,"",n)} n==f' SHA256SUMS > CHECK
+if [ ! -s CHECK ]; then
+  echo "❌ Checksum entry not found for ${FILENAME}"
+  exit 1
+fi
+
+sha256sum -c CHECK
+echo "✔ Checksum OK"
+
+###############################################
+# 14) Extract ONLY the binary
+###############################################
+echo "[+] Extracting binary from tar.gz..."
+tar -xzf "${FILENAME}" proxsave
+
+if [ ! -f proxsave ]; then
+  echo "❌ Binary 'proxsave' not found inside archive"
+  exit 1
+fi
+chmod 755 proxsave
+
+###############################################
+# 15) Swap in the beta binary (keep a rollback copy)
+###############################################
+echo "[+] Backing up current binary -> ${TARGET_BIN}.prev"
+cp -f "${TARGET_BIN}" "${TARGET_BIN}.prev"
+
+echo "[+] Installing beta binary -> ${TARGET_BIN}"
+# Conventional executable mode 0755 (owner rwx, group/other r-x). The binary runs
+# as root and only root can replace it; the security check verifies it is
+# root-owned and not group/other-writable, not an exact mode.
+mv proxsave "${TARGET_BIN}"
+chmod 755 "${TARGET_BIN}"
+
+# Sanity-check the swapped binary actually runs before finalizing. A corrupt or
+# incompatible binary is rolled back to the previous one immediately.
+if ! "${TARGET_BIN}" --version >/dev/null 2>&1; then
+  echo "❌ The installed beta binary failed to run; rolling back to the previous binary."
+  mv -f "${TARGET_BIN}.prev" "${TARGET_BIN}"
+  chmod 755 "${TARGET_BIN}"
+  exit 1
+fi
+
+###############################################
+# 16) Finalize locally (no re-download): --upgrade --localfile
+###############################################
+cd "${TARGET_DIR}"
+
+echo "[+] Finalizing: ${TARGET_BIN} --upgrade --localfile"
+# The beta binary is already swapped in and verified to run. If the local finalize
+# fails (daemon migrate/restart, backup.env merge, permission fixes -- the parts
+# that touch the live system), surface the rollback path explicitly: set -e would
+# otherwise abort here and never print the footer that documents .prev.
+if ! "${TARGET_BIN}" --upgrade --localfile; then
+  echo "--------------------------------------------"
+  echo "❌ Finalize failed. The beta binary IS installed but the local upgrade did"
+  echo "   not complete (backup.env / daemon / permissions may be half-applied)."
+  echo ""
+  echo "   Re-run the finalize:   ${TARGET_BIN} --upgrade --localfile"
+  echo "   Or roll back:          mv -f ${TARGET_BIN}.prev ${TARGET_BIN}"
+  echo "--------------------------------------------"
+  exit 1
+fi
+
+echo "--------------------------------------------"
+echo "✔ Beta upgrade completed!"
+echo " Version:  ${VERSION}"
+echo " Binary:   ${TARGET_BIN}"
+echo " Rollback: mv -f ${TARGET_BIN}.prev ${TARGET_BIN}"
+echo ""
+echo " You are now on a PRERELEASE. When a stable release of the same or newer"
+echo " version ships, 'proxsave --upgrade' will move you back onto stable."
+echo "--------------------------------------------"


### PR DESCRIPTION
Slice 6 of 6 (final) — completes the progressive rebuild of dev (base=dev), cherry-picked checkpoint range, tree matches `b1c847f`, `go build ./...` verified. ~59 files.

Content: characterization tests, docs rewrites (DAEMON, CONFIGURATION, RELEASE-PROCESS, CLUSTER_RECOVERY, ENCRYPTION), upgrade-beta.sh + `--upgrade --localfile`, golangci-lint fixes, dependabot bumps (bubbles v2.1.1, actions group).

After merge, dev == dev-temp (full work reconstructed in 6 reviewed PRs). Trigger review with `@coderabbitai review`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the final rebuild slice. The main changes are:

- Adds signed beta-upgrade tooling and `--upgrade --localfile` finalization.
- Adds characterization tests for upgrade, daemon, restore, health, and UI behavior.
- Consolidates status rendering and applies lint fixes.
- Rewrites operational, recovery, security, and configuration documentation.
- Adds lint CI and updates pinned actions and Go dependencies.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The local upgrade path invokes the installed executable directly and retains trusted-executable checks during finalization.
- The shared status renderer preserves sanitization and existing output behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| upgrade-beta.sh | Adds authenticated beta download, binary replacement, sanity-check rollback, and local finalization. |
| cmd/proxsave/upgrade.go | Splits binary acquisition from shared post-install finalization and adds local-file mode. |
| internal/cli/args.go | Adds parsing support for the local-file upgrade option. |
| cmd/proxsave/main_modes.go | Restricts `--localfile` to upgrade mode. |
| internal/orchestrator/workflow_ui_status.go | Exports shared sanitized status rendering for dashboard and workflow screens. |
| cmd/proxsave/dashboard.go | Uses the shared status renderer and standardizes dashboard status labels. |
| .github/workflows/lint.yml | Adds a pinned golangci-lint workflow. |
| go.mod | Updates Bubbles and its runewidth dependency. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start upgrade] --> B{Local file mode?}
    B -- No --> C[Fetch and install latest release]
    B -- Yes --> D[Use installed binary]
    C --> E[Shared finalization]
    D --> E
    E --> F[Upgrade configuration]
    F --> G[Refresh docs and symlinks]
    G --> H[Migrate or restart daemon]
    H --> I[Normalize permissions]

    J[upgrade-beta.sh] --> K[Download beta assets]
    K --> L[Verify signature and checksum]
    L --> M[Back up and replace binary]
    M --> N{Version check passes?}
    N -- No --> O[Restore previous binary]
    N -- Yes --> P[Run local-file finalization]
    P --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Start upgrade] --> B{Local file mode?}
    B -- No --> C[Fetch and install latest release]
    B -- Yes --> D[Use installed binary]
    C --> E[Shared finalization]
    D --> E
    E --> F[Upgrade configuration]
    F --> G[Refresh docs and symlinks]
    G --> H[Migrate or restart daemon]
    H --> I[Normalize permissions]

    J[upgrade-beta.sh] --> K[Download beta assets]
    K --> L[Verify signature and checksum]
    L --> M[Back up and replace binary]
    M --> N{Version check passes?}
    N -- No --> O[Restore previous binary]
    N -- Yes --> P[Run local-file finalization]
    P --> E
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: bump the actions-updates group acros..."](https://github.com/tis24dev/proxsave/commit/210389366b8c8d73821e8f5601811c257a3e405f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44410496)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--localfile` upgrade support to finalize upgrades without downloading another binary.
  * Added a verified beta upgrade script with signature and checksum checks plus rollback protection.
  * Added automated Go linting and expanded security/testing workflows.
* **Bug Fixes**
  * Improved upgrade validation and handling of cancellation, already-current versions, and failures.
  * Standardized dashboard and workflow status messages with clearer uppercase labels and safer text rendering.
* **Documentation**
  * Expanded guidance for daemon scheduling, restores, cloud storage, notifications, security, upgrades, and release verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->