### PR TITLE
ci(release): disable Go cache in privileged release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,10 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version-file: 'go.mod'
+          # Privileged job (contents: write, id-token: write): opt out of the
+          # default Go cache to avoid cache-poisoning from lower-privileged
+          # workflows, matching codecov/codeql/security-ultimate.
+          cache: false
 
       - name: Show Go version
         run: go version


### PR DESCRIPTION
## What
Add `cache: false` to the `actions/setup-go` step in `.github/workflows/release.yml`.

## Why
CodeRabbit/zizmor (`cache-poisoning`, Major) flagged the release job: it runs with `contents: write` + `id-token: write` (OIDC attestations) while `actions/setup-go@v7` enables the Go cache by default. A lower-privileged PR workflow (lint/race use `cache: true`) can poison the shared Go cache that the privileged release job then restores → code execution in a signing-capable context.

## Fix
Opt out of caching in the release job, matching the repo's existing convention — `codecov.yml`, `codeql.yml`, and `security-ultimate.yml` already set `cache: false`.

Flows into release PR #267 (head `dev`).

## Summary by Sourcery

CI:
- Update the release GitHub Actions workflow to set `cache: false` on the Go setup step for the signing-capable job.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables Go caching in the privileged release job. The main change is:

- Sets `cache: false` on the job's only `actions/setup-go` step.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The release job has one setup-go invocation and no separate cache action.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Disables setup-go caching in the privileged release job without changing Go version selection or release execution. |

<sub>Reviews (1): Last reviewed commit: ["ci(release): disable Go cache in privile..."](https://github.com/tis24dev/proxsave/commit/4558b1fc2c18b96ada2a92316a035fd1eccbe480) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45592680)</sub>

<!-- /greptile_comment -->