### PR TITLE
ci: add authoritative go-licenses dependency license gate

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,44 @@
+name: License Check
+
+on:
+  pull_request:
+    branches: [ main, dev ]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/license-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # No later step uses the git remote, so don't leave the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@v1.6.0
+
+      # Authoritative license gate. go-licenses reads the actual LICENSE files
+      # from the module cache and classifies each linked dependency, so vanity
+      # import paths like golang.org/x/* resolve to their real license
+      # (BSD-3-Clause) instead of the null/"Unknown" that GitHub's dependency
+      # graph reports for freshly published versions. Fails the PR if any
+      # dependency carries a license outside the allow-list.
+      - name: Check dependency licenses
+        run: |
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          go-licenses check ./... \
+            --allowed_licenses=MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC


### PR DESCRIPTION
## Problem
`dependency-review-action` shows `golang.org/x/crypto|sync|sys|term|text` as **Null / "Unknown License"** (and OpenSSF Scorecard `Unknown`). Root cause: those tables read the `license` field from **GitHub's dependency graph**, which returns `null` for the just-bumped versions until its backend indexes them. It is **data lag on GitHub's side** — deps.dev already reports all five as `BSD-3-Clause` — and it is **not fixable from our config** (the action only consumes GitHub's field; there is no per-package license override that isn't just suppression).

## Fix (authoritative, not suppression)
Add a `License Check` workflow running [`go-licenses`](https://github.com/google/go-licenses) `check ./...`. It reads the **actual LICENSE files** from the module cache and classifies each linked dependency, so vanity paths resolve to their real license instead of `null`.

## Verified locally
`go-licenses report ./...` — all 26 linked modules classify, **zero Unknown/empty**:

```
golang.org/x/crypto        v0.54.0  BSD-3-Clause
golang.org/x/sync/errgroup v0.22.0  BSD-3-Clause
golang.org/x/sys           v0.47.0  BSD-3-Clause
golang.org/x/term          v0.45.0  BSD-3-Clause
golang.org/x/text          v0.40.0  BSD-3-Clause
```

`go-licenses check ./... --allowed_licenses=MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC` → **exit 0**.

## Notes
- Pinned action SHAs + `permissions: contents: read` + `cache: false`, matching the repo's security-oriented workflows.
- Complements `dependency-review` (which still handles vulnerability scanning); this job owns the license decision authoritatively.

## Summary by Sourcery

CI:
- Introduce a License Check GitHub Actions workflow that runs go-licenses on Go modules in pull requests touching dependency files or the workflow itself.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an authoritative Go dependency license gate. The main changes are:

- Runs on dependency-file changes in pull requests to `main` and `dev`.
- Installs the pinned `go-licenses` release.
- Allows five permissive license classifications.
- Uses read-only permissions and SHA-pinned actions.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The trigger covers the repository's root Go dependency files.
- The setup, installation path, and license-check command form a consistent workflow.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/license-check.yml | Adds a pull-request workflow that checks linked Go dependencies against an explicit license allowlist. |

<sub>Reviews (1): Last reviewed commit: ["ci: add authoritative go-licenses depend..."](https://github.com/tis24dev/proxsave/commit/cb8059cc47f7589758c2f3547578f4ad7fe94094) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45593564)</sub>

<!-- /greptile_comment -->