### PR TITLE
Release v0.30.0-beta4

### DIFF
--- a/cmd/proxsave/daemon.go
+++ b/cmd/proxsave/daemon.go
@@ -741,14 +741,14 @@ func provisionRelaySecretBestEffort(ctx context.Context, cfg *config.Config, log
 	if serverID == "" {
 		return ""
 	}
-	provisioned, err := provisionRelaySecretFn(ctx, cfg.ServerAPIHost, serverID, baseDir, logger)
-	if err != nil {
+	if _, err := provisionRelaySecretFn(ctx, cfg.ServerAPIHost, serverID, baseDir, logger); err != nil {
 		logging.Debug("daemon: relay-secret provisioning attempt failed (will retry later): %v", err)
 		return ""
 	}
-	if !provisioned {
-		return ""
-	}
+	// Reload regardless of the provisioned flag: ProvisionRelaySecret returns false when it
+	// adopts a secret a concurrent provisioner persisted under the cross-process lock, so a
+	// usable secret may be on disk even then; LoadNotifySecret yields "" when there is
+	// genuinely none, degrading gracefully.
 	s, _ := identity.LoadNotifySecret(baseDir)
 	return strings.TrimSpace(s)
 }

--- a/cmd/proxsave/daemon.go
+++ b/cmd/proxsave/daemon.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tis24dev/proxsave/internal/health"
 	"github.com/tis24dev/proxsave/internal/identity"
 	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/notify"
 	"github.com/tis24dev/proxsave/internal/types"
 	"github.com/tis24dev/proxsave/internal/version"
 )
@@ -76,10 +77,11 @@ type daemon struct {
 	configPath string
 	now        func() time.Time
 
-	mu           sync.Mutex
-	reporter     backupReporter
-	fetchWarned  bool // centralized fetch already warned once (throttle recurring WARN)
-	updateWarned bool // an update is already known available (WARN once per transition)
+	mu            sync.Mutex
+	reporter      backupReporter
+	fetchWarned   bool      // centralized fetch already warned once (throttle recurring WARN)
+	updateWarned  bool      // an update is already known available (WARN once per transition)
+	provisionLast time.Time // last relay-secret self-heal attempt (throttle); guarded by mu
 	// newBackupCmd builds the child backup command; overridable in tests.
 	newBackupCmd func(ctx context.Context) *exec.Cmd
 
@@ -624,8 +626,26 @@ func (d *daemon) buildReporter(ctx context.Context) *health.Reporter {
 	}
 
 	// centralized
-	alive, backup, checks, err := d.fetchCentralized(ctx)
+	alive, backup, checks, secretUsed, err := d.fetchCentralized(ctx)
 	if err != nil {
+		// A DEFINITIVE auth rejection (ErrHCAuth) means the on-disk relay secret no longer
+		// matches the server's stored hash (a server DB restore/rollback, or a lost
+		// double-issuance race). Clear it so the next throttled maybeProvisionRelaySecret
+		// mints a fresh one - restoring the Telegram path's self-heal. ONLY ErrHCAuth: a
+		// transient / unreachable / not-ready / unknown error must NOT churn a
+		// possibly-good secret (a working confirmed secret never returns 401/403). The clear
+		// is value-guarded under LockNotifySecret against the EXACT secret fetchCentralized
+		// used (secretUsed), so a concurrent hook that persisted+confirmed a fresh secret in
+		// the meantime is never clobbered (which would strand the host).
+		if errors.Is(err, health.ErrHCAuth) {
+			if cleared, rmErr := identity.RemoveNotifySecretIfMatches(d.cfg.BaseDir, secretUsed); rmErr != nil {
+				logging.Debug("daemon: clear rejected relay secret failed: %v", rmErr)
+			} else if cleared {
+				logging.Debug("daemon: relay secret rejected by server (auth); cleared for re-provisioning")
+			} else {
+				logging.Debug("daemon: relay secret rejected by server (auth) but on-disk secret changed concurrently; keeping it")
+			}
+		}
 		// The heartbeat loop retries this every interval; warn ONCE (so the
 		// operator sees healthchecks isn't working, e.g. Telegram not paired yet),
 		// then drop to Debug to avoid a recurring WARN every few minutes.
@@ -666,19 +686,113 @@ func (d *daemon) registerReporterSecrets(alive, backup string, checks map[string
 // fetchCentralized asks the proxsave_server for this client's ping URLs, reusing
 // the same identity/secret as /api/notify. The optional updates URL rides in the additive
 // Checks map (absent on old servers -> "").
-func (d *daemon) fetchCentralized(ctx context.Context) (string, string, map[string]string, error) {
+func (d *daemon) fetchCentralized(ctx context.Context) (alive, backup string, checks map[string]string, secretUsed string, err error) {
 	secret, _ := identity.LoadNotifySecret(d.cfg.BaseDir)
 	if strings.TrimSpace(secret) == "" {
-		return "", "", nil, fmt.Errorf("no relay secret on disk (pair Telegram first)")
+		// No relay secret yet. Attempt a THROTTLED, Telegram-independent provisioning (hook b):
+		// the server now issues the relay secret for a chat-less known ServerID. On success,
+		// continue with the fresh secret; otherwise degrade gracefully (buildReporter warns once,
+		// the heartbeat loop retries, and beats still record no_url).
+		secret = d.maybeProvisionRelaySecret(ctx)
+		if strings.TrimSpace(secret) == "" {
+			return "", "", nil, "", fmt.Errorf("no relay secret on disk (centralized provisioning pending)")
+		}
 	}
 	// Send the authoritative enabled-notification set so the server provisions one check per
 	// enabled channel (Fase 2C). Always non-nil in centralized mode (empty -> "none" sentinel).
 	channels := enabledNotifyChannels(d.cfg)
-	cfg, err := health.FetchCentralizedConfigWithChannels(ctx, nil, d.cfg.ServerAPIHost, d.cfg.ServerID, secret, false, channels)
-	if err != nil {
-		return "", "", nil, err
+	// Return the exact secret sent to the server as secretUsed so buildReporter can
+	// value-guard an ErrHCAuth secret removal against precisely this comparand.
+	cfg, ferr := health.FetchCentralizedConfigWithChannels(ctx, nil, d.cfg.ServerAPIHost, d.cfg.ServerID, secret, false, channels)
+	if ferr != nil {
+		return "", "", nil, secret, ferr
 	}
-	return cfg.AliveURL, cfg.BackupURL, cfg.Checks, nil
+	return cfg.AliveURL, cfg.BackupURL, cfg.Checks, secret, nil
+}
+
+// daemonProvisionRetryInterval throttles the daemon's relay-secret self-heal so a persistent
+// provisioning failure (server down, or the host not yet known to the server) does not hit the
+// server on every heartbeat interval.
+const daemonProvisionRetryInterval = 15 * time.Minute
+
+// provisionRelaySecretFn is the relay-secret provisioner seam (stubbed in tests so the
+// self-heal logic is exercised without touching the network).
+var provisionRelaySecretFn = notify.ProvisionRelaySecret
+
+// provisionRelaySecretBestEffort attempts one relay-secret provisioning for a centralized
+// healthcheck host that has none on disk, so centralized monitoring works WITHOUT Telegram
+// pairing. Best-effort and non-blocking: it returns the relay secret now on disk, or "" when
+// provisioning is not applicable (self mode / disabled / no ServerID) or the attempt failed.
+// It NEVER returns/propagates an error. When a secret is already present it returns it
+// unchanged (never overwrites a possibly-confirmed secret). Callers gate frequency: the
+// daemon throttles via provisionLast; the one-shot daemon-setup path runs it once.
+func provisionRelaySecretBestEffort(ctx context.Context, cfg *config.Config, logger *logging.Logger) string {
+	if cfg == nil || !cfg.HealthcheckEnabled || cfg.HealthcheckMode != config.HealthcheckModeCentralized {
+		return ""
+	}
+	baseDir := strings.TrimSpace(cfg.BaseDir)
+	if baseDir == "" {
+		return ""
+	}
+	if s, _ := identity.LoadNotifySecret(baseDir); strings.TrimSpace(s) != "" {
+		return strings.TrimSpace(s) // already provisioned; do not churn
+	}
+	serverID := strings.TrimSpace(cfg.ServerID)
+	if serverID == "" {
+		return ""
+	}
+	provisioned, err := provisionRelaySecretFn(ctx, cfg.ServerAPIHost, serverID, baseDir, logger)
+	if err != nil {
+		logging.Debug("daemon: relay-secret provisioning attempt failed (will retry later): %v", err)
+		return ""
+	}
+	if !provisioned {
+		return ""
+	}
+	s, _ := identity.LoadNotifySecret(baseDir)
+	return strings.TrimSpace(s)
+}
+
+// maybeProvisionRelaySecret is the daemon's throttled relay-secret self-heal (hook b). It
+// returns a freshly persisted secret, or "" when throttled / not applicable / failed. The
+// throttle is recorded even on failure so a down server is not hit every heartbeat.
+func (d *daemon) maybeProvisionRelaySecret(ctx context.Context) string {
+	d.mu.Lock()
+	if !d.provisionLast.IsZero() && d.now().Sub(d.provisionLast) < daemonProvisionRetryInterval {
+		d.mu.Unlock()
+		return ""
+	}
+	d.provisionLast = d.now()
+	d.mu.Unlock()
+	return provisionRelaySecretBestEffort(ctx, d.cfg, d.logger)
+}
+
+// provisionRelaySecretOnDaemonSetup is the one-shot relay-secret self-heal (hook a) run during
+// --daemon-setup / the upgrade migration, right after HEALTHCHECK_ENABLED=true is written. It
+// re-reads the just-written config (the caller's cfg predates the write, so its
+// HealthcheckEnabled is stale), resolves the ServerID from the identity file when backup.env
+// carries none, and provisions the relay secret so a retrofitted centralized host obtains it
+// WITHOUT Telegram pairing. Best-effort and non-blocking.
+func provisionRelaySecretOnDaemonSetup(ctx context.Context, configPath, baseDir string) {
+	baseDir = strings.TrimSpace(baseDir)
+	if baseDir == "" {
+		return
+	}
+	cfg, err := config.LoadConfigWithBaseDir(configPath, baseDir)
+	if err != nil || cfg == nil {
+		logging.Debug("daemon-setup: relay-secret provisioning skipped: config reload failed: %v", err)
+		return
+	}
+	if strings.TrimSpace(cfg.ServerID) == "" {
+		// identity.DetectWithContext has a write side effect (creates .server_identity if
+		// absent) - acceptable in this setup/write context.
+		if info, derr := identity.DetectWithContext(ctx, baseDir, nil); derr == nil && info != nil {
+			cfg.ServerID = strings.TrimSpace(info.ServerID)
+		}
+	}
+	if provisionRelaySecretBestEffort(ctx, cfg, nil) != "" {
+		logging.Info("Centralized monitoring: relay secret provisioned for this host.")
+	}
 }
 
 // enabledNotifyChannels returns the lowercased notification-channel names enabled in cfg,

--- a/cmd/proxsave/daemon_relay_provision_test.go
+++ b/cmd/proxsave/daemon_relay_provision_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/identity"
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+const relayTestSecret = "3h64-dyi8-q3d6-wcm5"
+
+func TestProvisionRelaySecretBestEffortGating(t *testing.T) {
+	orig := provisionRelaySecretFn
+	t.Cleanup(func() { provisionRelaySecretFn = orig })
+	called := 0
+	provisionRelaySecretFn = func(ctx context.Context, host, id, baseDir string, logger *logging.Logger) (bool, error) {
+		called++
+		return false, nil
+	}
+	cent := func(baseDir, serverID string) *config.Config {
+		return &config.Config{HealthcheckEnabled: true, HealthcheckMode: config.HealthcheckModeCentralized, BaseDir: baseDir, ServerID: serverID, ServerAPIHost: "https://h"}
+	}
+
+	// self mode -> never attempts.
+	if got := provisionRelaySecretBestEffort(context.Background(), &config.Config{HealthcheckEnabled: true, HealthcheckMode: config.HealthcheckModeSelf, BaseDir: t.TempDir(), ServerID: "1"}, nil); got != "" || called != 0 {
+		t.Fatalf("self mode must not provision: got=%q called=%d", got, called)
+	}
+	// disabled -> never attempts.
+	if got := provisionRelaySecretBestEffort(context.Background(), &config.Config{HealthcheckEnabled: false, HealthcheckMode: config.HealthcheckModeCentralized, BaseDir: t.TempDir(), ServerID: "1"}, nil); got != "" || called != 0 {
+		t.Fatalf("disabled must not provision: got=%q called=%d", got, called)
+	}
+	// centralized, no ServerID -> never attempts.
+	if got := provisionRelaySecretBestEffort(context.Background(), cent(t.TempDir(), ""), nil); got != "" || called != 0 {
+		t.Fatalf("no ServerID must not provision: got=%q called=%d", got, called)
+	}
+	// centralized + ServerID + no secret -> attempts exactly once.
+	if got := provisionRelaySecretBestEffort(context.Background(), cent(t.TempDir(), "123456789012"), nil); got != "" || called != 1 {
+		t.Fatalf("centralized+id+no-secret must attempt once: got=%q called=%d", got, called)
+	}
+}
+
+func TestProvisionRelaySecretBestEffortSkipsWhenSecretPresent(t *testing.T) {
+	orig := provisionRelaySecretFn
+	t.Cleanup(func() { provisionRelaySecretFn = orig })
+	called := 0
+	provisionRelaySecretFn = func(ctx context.Context, host, id, baseDir string, logger *logging.Logger) (bool, error) {
+		called++
+		return false, nil
+	}
+	base := t.TempDir()
+	if err := identity.PersistNotifySecret(context.Background(), base, relayTestSecret, nil); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+	cfg := &config.Config{HealthcheckEnabled: true, HealthcheckMode: config.HealthcheckModeCentralized, BaseDir: base, ServerID: "123456789012", ServerAPIHost: "https://h"}
+	if got := provisionRelaySecretBestEffort(context.Background(), cfg, nil); got != relayTestSecret {
+		t.Fatalf("existing secret should be returned unchanged, got %q", got)
+	}
+	if called != 0 {
+		t.Fatalf("must NOT attempt provisioning when a secret is present, called=%d", called)
+	}
+}
+
+func TestProvisionRelaySecretBestEffortSuccessReturnsPersistedSecret(t *testing.T) {
+	orig := provisionRelaySecretFn
+	t.Cleanup(func() { provisionRelaySecretFn = orig })
+	base := t.TempDir()
+	provisionRelaySecretFn = func(ctx context.Context, host, id, baseDir string, logger *logging.Logger) (bool, error) {
+		// Emulate the real provisioner persisting the secret before returning true.
+		if err := identity.PersistNotifySecret(ctx, baseDir, relayTestSecret, nil); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	cfg := &config.Config{HealthcheckEnabled: true, HealthcheckMode: config.HealthcheckModeCentralized, BaseDir: base, ServerID: "123456789012", ServerAPIHost: "https://h"}
+	if got := provisionRelaySecretBestEffort(context.Background(), cfg, nil); got != relayTestSecret {
+		t.Fatalf("want freshly persisted secret %q, got %q", relayTestSecret, got)
+	}
+}
+
+// A definitive server auth rejection (403 -> health.ErrHCAuth) means the on-disk relay
+// secret no longer matches the server hash. buildReporter must clear it so the next
+// provisioning cycle mints a fresh one (self-heal), instead of leaving the host stuck.
+func TestBuildReporterClearsSecretOnAuthReject(t *testing.T) {
+	base := t.TempDir()
+	if err := identity.PersistNotifySecret(context.Background(), base, relayTestSecret, nil); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden) // reject the secret -> ErrHCAuth
+	}))
+	defer server.Close()
+
+	d := &daemon{
+		cfg: &config.Config{
+			HealthcheckEnabled: true,
+			HealthcheckMode:    config.HealthcheckModeCentralized,
+			BaseDir:            base,
+			ServerID:           "123456789012",
+			ServerAPIHost:      server.URL,
+		},
+		now: time.Now,
+	}
+	if r := d.buildReporter(context.Background()); r != nil {
+		t.Fatalf("expected nil reporter after auth reject (no cached URLs), got %v", r)
+	}
+	if s, _ := identity.LoadNotifySecret(base); s != "" {
+		t.Fatalf("relay secret must be cleared after ErrHCAuth, still on disk: %q", s)
+	}
+}
+
+// A NON-auth fetch failure (503 -> ErrHCNotReady) must NOT churn the on-disk secret: a
+// possibly-good secret is preserved so a transient server hiccup does not force a re-mint.
+func TestBuildReporterKeepsSecretOnTransientFailure(t *testing.T) {
+	base := t.TempDir()
+	if err := identity.PersistNotifySecret(context.Background(), base, relayTestSecret, nil); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // transient -> ErrHCNotReady, not auth
+	}))
+	defer server.Close()
+
+	d := &daemon{
+		cfg: &config.Config{
+			HealthcheckEnabled: true,
+			HealthcheckMode:    config.HealthcheckModeCentralized,
+			BaseDir:            base,
+			ServerID:           "123456789012",
+			ServerAPIHost:      server.URL,
+		},
+		now: time.Now,
+	}
+	_ = d.buildReporter(context.Background())
+	if s, _ := identity.LoadNotifySecret(base); s != relayTestSecret {
+		t.Fatalf("relay secret must be preserved on a transient failure, got %q", s)
+	}
+}
+
+func TestDaemonMaybeProvisionRelaySecretThrottle(t *testing.T) {
+	orig := provisionRelaySecretFn
+	t.Cleanup(func() { provisionRelaySecretFn = orig })
+	called := 0
+	provisionRelaySecretFn = func(ctx context.Context, host, id, baseDir string, logger *logging.Logger) (bool, error) {
+		called++
+		return false, nil
+	}
+	now := time.Unix(1_700_000_000, 0)
+	d := &daemon{
+		cfg: &config.Config{HealthcheckEnabled: true, HealthcheckMode: config.HealthcheckModeCentralized, BaseDir: t.TempDir(), ServerID: "123456789012", ServerAPIHost: "https://h"},
+		now: func() time.Time { return now },
+	}
+	d.maybeProvisionRelaySecret(context.Background())
+	if called != 1 {
+		t.Fatalf("first attempt must call the provisioner, called=%d", called)
+	}
+	// Immediate retry within the throttle window: no second call.
+	d.maybeProvisionRelaySecret(context.Background())
+	if called != 1 {
+		t.Fatalf("within throttle window must NOT re-attempt, called=%d", called)
+	}
+	// Advance beyond the throttle window: attempts again.
+	now = now.Add(daemonProvisionRetryInterval + time.Second)
+	d.maybeProvisionRelaySecret(context.Background())
+	if called != 2 {
+		t.Fatalf("after throttle window must re-attempt, called=%d", called)
+	}
+}

--- a/cmd/proxsave/daemon_setup.go
+++ b/cmd/proxsave/daemon_setup.go
@@ -153,6 +153,20 @@ func applyDaemonMode(ctx context.Context, cfg *config.Config, configPath, execTo
 		logging.Warning("daemon: failed to record SCHEDULER_MODE=daemon in %s: %v", configPath, err)
 		return nil
 	}
+	// One-shot relay-secret self-heal (hook a): a retrofitted centralized host can obtain the
+	// healthcheck relay secret WITHOUT Telegram pairing now that the server issues it for a
+	// chat-less known ServerID. Runs after HEALTHCHECK_ENABLED=true was written above but
+	// BEFORE the try-restart below: persisting+confirming the secret first means the restarted
+	// daemon finds it already on disk, so its startup self-heal (hook b) skips provisioning.
+	// This avoids a concurrent double-issuance race (hook a and a HC-enabled restarted daemon
+	// both minting a fresh secret, whose last-write-wins persist could leave the on-disk secret
+	// and the server hash mismatched and the host stuck failing centralized auth). The
+	// pre-restart daemon read config BEFORE the write above so it has HC disabled and never
+	// runs hook b meanwhile. Best-effort (the daemon's startup self-heal retries if this misses,
+	// e.g. the server change has not landed yet or the host is not known to the server yet).
+	if cfg != nil {
+		provisionRelaySecretOnDaemonSetup(ctx, configPath, cfg.BaseDir)
+	}
 	// installDaemonService already `enable --now`-started the daemon, but it read
 	// the config as it was BEFORE the write above. Restart it (only if running) so
 	// the resident process picks up HEALTHCHECK_ENABLED=true immediately instead of

--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -257,13 +257,19 @@ func runDashboardDiagnostic(ctx context.Context, session *shell.Session, action 
 		logging.DebugStepBootstrap(bootstrap, "dashboard", "action=check-telegram")
 		res, _ := dashboardRunTelegramSetup(ctx, session, baseDir, configPath)
 		if !res.Shown {
-			dashboardNotConfiguredNotice(ctx, session, "Telegram", "Telegram notifications are not enabled (centralized) on this host.")
+			// Distinct copy per skip verdict (disabled / personal / config / identity),
+			// so the twin no longer collapses to one generic "not enabled" line.
+			st := orchestrator.ClassifyTelegramSetupSkip(res.TelegramSetupBootstrap)
+			showDaemonResultScreen(ctx, session, "Telegram", st.Level, st.Keyword, st.Message)
 		}
 	case menu.ActionCheckHealthcheck:
 		logging.DebugStepBootstrap(bootstrap, "dashboard", "action=check-healthcheck")
 		res, _ := dashboardRunHealthcheckSetup(ctx, session, baseDir, configPath)
 		if !res.Shown {
-			dashboardNotConfiguredNotice(ctx, session, "Backup monitoring", "Backup monitoring (healthchecks) is not enabled on this host.")
+			// Distinct copy per skip verdict; the centralized missing-secret state is
+			// A-aware (auto-provisioned on the next daemon run, no Telegram pairing).
+			st := orchestrator.ClassifyHealthcheckSetupSkip(res.HealthcheckSetupBootstrap)
+			showDaemonResultScreen(ctx, session, "Backup monitoring", st.Level, st.Keyword, st.Message)
 		}
 	case menu.ActionPostInstallCheck:
 		logging.DebugStepBootstrap(bootstrap, "dashboard", "action=post-install-check")
@@ -674,14 +680,6 @@ var (
 		return flowinstall.RunPostInstallAudit(ctx, session, execPath, configPath, true)
 	}
 )
-
-// dashboardNotConfiguredNotice shows a not-configured diagnostic when a screen has
-// nothing to show because the feature is not enabled on this host. It reuses the
-// shared styled result screen (showDaemonResultScreen) so it reads
-// "Status: ⚠ NOT CONFIGURED" exactly like the configured check screens.
-func dashboardNotConfiguredNotice(ctx context.Context, session *shell.Session, title, msg string) {
-	showDaemonResultScreen(ctx, session, title, orchestrator.HealthcheckSetupLevelWarn, "NOT CONFIGURED", msg)
-}
 
 // testDashboardSession lets tests inject a renderless session (the seam used
 // to be newAgeSetupSession; the handoff needs the dashboard to own a real

--- a/cmd/proxsave/healthcheck_setup_cli.go
+++ b/cmd/proxsave/healthcheck_setup_cli.go
@@ -28,7 +28,10 @@ func logHealthcheckSetupBootstrapOutcome(bootstrap *logging.BootstrapLogger, sta
 	case orchestrator.HealthcheckSetupSkipSelfMode:
 		logBootstrapInfo(bootstrap, "Healthcheck setup: self mode but no alive URL configured yet (skipping)")
 	case orchestrator.HealthcheckSetupSkipIdentityUnavailable:
-		logBootstrapWarning(bootstrap, "Healthcheck setup: identity/relay secret unavailable; skipping (pair Telegram to enable centralized monitoring)")
+		// A-aware: no ServerID vs missing relay secret read distinctly, and the
+		// missing-secret copy no longer says "pair Telegram" (the relay secret is now
+		// provisioned automatically without Telegram). Shared with the dashboard notice.
+		logBootstrapWarning(bootstrap, "Healthcheck setup: %s", orchestrator.ClassifyHealthcheckSetupSkip(state).Message)
 	}
 	// SkipDisabled (cron mode) is a silent skip, mirroring Telegram when disabled.
 }
@@ -38,7 +41,7 @@ func logHealthcheckSetupBootstrapOutcome(bootstrap *logging.BootstrapLogger, sta
 // non-blocking connection check with retry/skip. Only renders when the daemon
 // engine with centralized monitoring was chosen and the identity/secret exist.
 func runHealthcheckSetupCLI(ctx context.Context, reader *bufio.Reader, baseDir, configPath string, bootstrap *logging.BootstrapLogger) error {
-	state, err := healthcheckSetupBuildBootstrap(configPath, baseDir)
+	state, err := healthcheckSetupBuildBootstrap(ctx, configPath, baseDir)
 	if err != nil {
 		logBootstrapWarning(bootstrap, "Healthcheck setup bootstrap failed (non-blocking): %v", err)
 		return nil

--- a/cmd/proxsave/healthcheck_setup_cli_test.go
+++ b/cmd/proxsave/healthcheck_setup_cli_test.go
@@ -34,7 +34,7 @@ func TestRunHealthcheckSetupCLI_SelfBranch(t *testing.T) {
 	stubHealthcheckSetupCLIDeps(t)
 	centralizedCalled := false
 	var gotURL string
-	healthcheckSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+	healthcheckSetupBuildBootstrap = func(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 		return orchestrator.HealthcheckSetupBootstrap{
 			Eligibility:         orchestrator.HealthcheckSetupEligibleSelf,
 			HealthcheckMode:     "self",
@@ -103,7 +103,7 @@ func TestRunHealthcheckSelfParamsCLI(t *testing.T) {
 func TestRunHealthcheckSetupCLI_SkipWhenNotEligible(t *testing.T) {
 	stubHealthcheckSetupCLIDeps(t)
 	called := false
-	healthcheckSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+	healthcheckSetupBuildBootstrap = func(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 		return orchestrator.HealthcheckSetupBootstrap{Eligibility: orchestrator.HealthcheckSetupSkipDisabled}, nil
 	}
 	healthcheckSetupCheck = func(ctx context.Context, host, id, baseDir string, hbInterval time.Duration) orchestrator.HealthcheckCheckResult {
@@ -129,7 +129,7 @@ func TestRunHealthcheckSetupCLI_SkipWhenNotEligible(t *testing.T) {
 
 func TestRunHealthcheckSetupCLI_VerifiedShowsMagicLink(t *testing.T) {
 	stubHealthcheckSetupCLIDeps(t)
-	healthcheckSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+	healthcheckSetupBuildBootstrap = func(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 		return orchestrator.HealthcheckSetupBootstrap{
 			Eligibility:   orchestrator.HealthcheckSetupEligibleCentralized,
 			ServerID:      "123456789012",
@@ -165,7 +165,7 @@ func TestRunHealthcheckSetupCLI_VerifiedShowsMagicLink(t *testing.T) {
 func TestRunHealthcheckSetupCLI_DeclineCheck(t *testing.T) {
 	stubHealthcheckSetupCLIDeps(t)
 	checkCalled := false
-	healthcheckSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+	healthcheckSetupBuildBootstrap = func(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 		return orchestrator.HealthcheckSetupBootstrap{Eligibility: orchestrator.HealthcheckSetupEligibleCentralized, ServerID: "1", ServerAPIHost: "h"}, nil
 	}
 	healthcheckSetupPromptYesNo = func(ctx context.Context, r *bufio.Reader, q string, d bool) (bool, error) {
@@ -188,7 +188,7 @@ func TestRunHealthcheckSetupCLI_DeclineCheck(t *testing.T) {
 
 func TestRunHealthcheckSetupCLI_FatalStopsRetry(t *testing.T) {
 	stubHealthcheckSetupCLIDeps(t)
-	healthcheckSetupBuildBootstrap = func(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+	healthcheckSetupBuildBootstrap = func(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 		return orchestrator.HealthcheckSetupBootstrap{Eligibility: orchestrator.HealthcheckSetupEligibleCentralized, ServerID: "1", ServerAPIHost: "h"}, nil
 	}
 	prompts := 0

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -35,10 +35,11 @@ const (
 	maxMachineIDBytes        = 32
 	systemKeyPrefixLength    = 8
 	serverIDLength           = 16
-	// notifySecretMinLen mirrors logging.secretMinRegister (6): a secret shorter than this
+	// NotifySecretMinLen mirrors logging.secretMinRegister (6): a secret shorter than this
 	// is NOT masked in logs, so a too-short value must never reach disk (and later a log
-	// line). Enforced at the single sink (PersistNotifySecret) so every caller is covered.
-	notifySecretMinLen = 6
+	// line). Enforced at the single sink (PersistNotifySecret) so every caller is covered;
+	// exported so the relay provisioner shares the one floor instead of duplicating it.
+	NotifySecretMinLen = 6
 )
 
 // notifySecretFormat matches the server's generate_notify_secret output: lowercase
@@ -75,13 +76,13 @@ func PersistNotifySecret(ctx context.Context, baseDir, secret string, logger *lo
 		logDebug(logger, "Identity: PersistNotifySecret: malformed secret, refusing (len=%d)", len(secret))
 		return fmt.Errorf("refusing to persist a malformed notify secret")
 	}
-	// Length floor at the single sink: a secret below notifySecretMinLen is not masked in
+	// Length floor at the single sink: a secret below NotifySecretMinLen is not masked in
 	// logs (redact.go secretMinRegister), so refuse it here so NO caller - the new relay
 	// provisioner and the legacy Telegram path alike - can write an unmaskable value. The
 	// server format is 19 chars, so a real secret never trips this; it is a defensive floor.
-	if len([]rune(secret)) < notifySecretMinLen {
-		logDebug(logger, "Identity: PersistNotifySecret: secret below min length, refusing (len=%d min=%d)", len([]rune(secret)), notifySecretMinLen)
-		return fmt.Errorf("refusing to persist a notify secret shorter than %d runes", notifySecretMinLen)
+	if n := len([]rune(secret)); n < NotifySecretMinLen {
+		logDebug(logger, "Identity: PersistNotifySecret: secret below min length, refusing (len=%d min=%d)", n, NotifySecretMinLen)
+		return fmt.Errorf("refusing to persist a notify secret shorter than %d runes", NotifySecretMinLen)
 	}
 	dir := filepath.Join(baseDir, identityDirName)
 	if err := os.MkdirAll(dir, 0o750); err != nil { // same mode as Detect

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/logging"
@@ -25,13 +27,18 @@ import (
 )
 
 const (
-	identityDirName       = "identity"
-	identityFileName      = ".server_identity"
-	notifySecretFileName  = ".notify_secret"
-	maxProcVersionBytes   = 100
-	maxMachineIDBytes     = 32
-	systemKeyPrefixLength = 8
-	serverIDLength        = 16
+	identityDirName          = "identity"
+	identityFileName         = ".server_identity"
+	notifySecretFileName     = ".notify_secret"
+	notifySecretLockFileName = ".notify_secret.lock"
+	maxProcVersionBytes      = 100
+	maxMachineIDBytes        = 32
+	systemKeyPrefixLength    = 8
+	serverIDLength           = 16
+	// notifySecretMinLen mirrors logging.secretMinRegister (6): a secret shorter than this
+	// is NOT masked in logs, so a too-short value must never reach disk (and later a log
+	// line). Enforced at the single sink (PersistNotifySecret) so every caller is covered.
+	notifySecretMinLen = 6
 )
 
 // notifySecretFormat matches the server's generate_notify_secret output: lowercase
@@ -67,6 +74,14 @@ func PersistNotifySecret(ctx context.Context, baseDir, secret string, logger *lo
 	if !notifySecretFormat.MatchString(secret) {
 		logDebug(logger, "Identity: PersistNotifySecret: malformed secret, refusing (len=%d)", len(secret))
 		return fmt.Errorf("refusing to persist a malformed notify secret")
+	}
+	// Length floor at the single sink: a secret below notifySecretMinLen is not masked in
+	// logs (redact.go secretMinRegister), so refuse it here so NO caller - the new relay
+	// provisioner and the legacy Telegram path alike - can write an unmaskable value. The
+	// server format is 19 chars, so a real secret never trips this; it is a defensive floor.
+	if len([]rune(secret)) < notifySecretMinLen {
+		logDebug(logger, "Identity: PersistNotifySecret: secret below min length, refusing (len=%d min=%d)", len([]rune(secret)), notifySecretMinLen)
+		return fmt.Errorf("refusing to persist a notify secret shorter than %d runes", notifySecretMinLen)
 	}
 	dir := filepath.Join(baseDir, identityDirName)
 	if err := os.MkdirAll(dir, 0o750); err != nil { // same mode as Detect
@@ -143,6 +158,129 @@ func readFileUnderRoot(dir, name string) ([]byte, error) {
 	defer func() { _ = f.Close() }()
 
 	return io.ReadAll(f)
+}
+
+// LockNotifySecret takes an exclusive advisory (flock LOCK_EX) lock on a sidecar lock
+// file in the identity directory, creating the directory and lock file when absent, so
+// relay-secret provisioning (issue -> persist -> confirm) is serialized ACROSS PROCESSES.
+// It exists because a concurrent hook a (installer) and hook b (enable-now daemon) can run
+// against the same server_id, and two DISTINCT minted secrets strand the host (last-write
+// wins on disk vs confirm-locks-reissue on the server). It returns an unlock func the
+// caller MUST defer and call exactly once. The lock file is opened confined to the identity
+// directory via os.Root (the basename is a constant, mirroring LoadNotifySecret).
+func LockNotifySecret(baseDir string) (unlock func(), err error) {
+	baseDir = strings.TrimSpace(baseDir)
+	if baseDir == "" {
+		return nil, fmt.Errorf("base directory is empty; cannot lock notify secret")
+	}
+	dir := filepath.Join(baseDir, identityDirName)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("failed to create identity directory %s: %w", dir, err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	f, err := root.OpenFile(notifySecretLockFileName, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		_ = root.Close()
+		return nil, fmt.Errorf("flock notify secret: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		_ = root.Close()
+	}, nil
+}
+
+// RemoveNotifySecret deletes the persisted relay secret, first clearing the immutable
+// (+i) attribute (unlinking an immutable file returns EPERM) and confining the unlink to
+// the identity directory via os.Root (mirrors LoadNotifySecret). It is the remediation for
+// a secret the server has DEFINITIVELY rejected (health.ErrHCAuth): clearing it lets the
+// next provisioning cycle mint a fresh one, restoring the Telegram path's self-heal. An
+// absent file (or absent identity dir) is a no-op, so this is idempotent.
+func RemoveNotifySecret(baseDir string, logger ...*logging.Logger) error {
+	var lg *logging.Logger
+	if len(logger) > 0 {
+		lg = logger[0]
+	}
+	baseDir = strings.TrimSpace(baseDir)
+	if baseDir == "" {
+		return nil
+	}
+	dir := filepath.Join(baseDir, identityDirName)
+	path := filepath.Join(dir, notifySecretFileName)
+	// Clear +i first so the unlink is permitted; best-effort, exactly like the write path.
+	if err := writeIdentityFileWithContextSetImmutable(context.Background(), path, false, lg); err != nil {
+		logDebug(lg, "Identity: RemoveNotifySecret: clear immutable failed for %s: %v", path, err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	if err := root.Remove(notifySecretFileName); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	logDebug(lg, "Identity: RemoveNotifySecret: removed %s", path)
+	return nil
+}
+
+// RemoveNotifySecretIfMatches deletes the persisted relay secret ONLY when the on-disk value
+// still equals rejected, all UNDER LockNotifySecret. It is the value-guarded ErrHCAuth
+// remediation: buildReporter loaded secret S_old and the server rejected it (403), so the
+// daemon must clear S_old to trigger a re-provision - but NEVER a fresh confirmed S_new that a
+// concurrent provisioner (hook a installer / hook c manual Check / hook b daemon) persisted in
+// the meantime, since deleting that would strand the host with no centralized healthcheck
+// until a manual server-side secret_confirmed reset. It re-reads the secret under the same
+// lock the provisioners hold and constant-time-compares it to rejected; on a mismatch (or an
+// empty rejected comparand, or an already-absent file) it leaves the file in place and returns
+// removed=false. Returns removed=true only when it actually unlinked.
+func RemoveNotifySecretIfMatches(baseDir, rejected string, logger ...*logging.Logger) (removed bool, err error) {
+	var lg *logging.Logger
+	if len(logger) > 0 {
+		lg = logger[0]
+	}
+	baseDir = strings.TrimSpace(baseDir)
+	if baseDir == "" {
+		return false, nil
+	}
+	rejected = strings.TrimSpace(rejected)
+	if rejected == "" {
+		// No comparand: never delete blindly (that is exactly the unconditional-remove
+		// regression this function replaces).
+		return false, nil
+	}
+	unlock, lerr := LockNotifySecret(baseDir)
+	if lerr != nil {
+		return false, lerr
+	}
+	defer unlock()
+	// Re-read UNDER the lock: a concurrent provisioner may have replaced S_old with a fresh
+	// confirmed S_new after the caller's rejected fetch.
+	current, _ := LoadNotifySecret(baseDir, lg)
+	if current == "" {
+		return false, nil // already cleared by another path; nothing to do
+	}
+	if subtle.ConstantTimeCompare([]byte(current), []byte(rejected)) != 1 {
+		logDebug(lg, "Identity: RemoveNotifySecretIfMatches: on-disk secret changed since rejection; keeping it")
+		return false, nil
+	}
+	if rmErr := RemoveNotifySecret(baseDir, lg); rmErr != nil {
+		return false, rmErr
+	}
+	return true, nil
 }
 
 // Info contains server identity information.

--- a/internal/identity/notify_secret_test.go
+++ b/internal/identity/notify_secret_test.go
@@ -140,7 +140,7 @@ func TestRemoveNotifySecret(t *testing.T) {
 
 func TestPersistNotifySecretRejectsTooShort(t *testing.T) {
 	baseDir := t.TempDir()
-	// A single lowercase char passes notifySecretFormat but is below notifySecretMinLen (6):
+	// A single lowercase char passes notifySecretFormat but is below NotifySecretMinLen (6):
 	// it would be UNMASKABLE in logs (redact.go secretMinRegister), so persist must refuse it.
 	if err := PersistNotifySecret(context.Background(), baseDir, "a", nil); err == nil {
 		t.Fatalf("PersistNotifySecret() expected an error for a sub-threshold secret")

--- a/internal/identity/notify_secret_test.go
+++ b/internal/identity/notify_secret_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNotifySecretPath(t *testing.T) {
@@ -113,5 +114,154 @@ func TestPersistNotifySecretRejectsMalformed(t *testing.T) {
 	}
 	if _, err := os.Stat(NotifySecretPath(baseDir)); !os.IsNotExist(err) {
 		t.Fatalf("expected no notify secret file written, stat err = %v", err)
+	}
+}
+
+func TestRemoveNotifySecret(t *testing.T) {
+	baseDir := t.TempDir()
+	const secret = "3h64-dyi8-q3d6-wcm5"
+	if err := PersistNotifySecret(context.Background(), baseDir, secret, nil); err != nil {
+		t.Fatalf("PersistNotifySecret() error = %v", err)
+	}
+	if err := RemoveNotifySecret(baseDir); err != nil {
+		t.Fatalf("RemoveNotifySecret() error = %v", err)
+	}
+	if _, err := os.Stat(NotifySecretPath(baseDir)); !os.IsNotExist(err) {
+		t.Fatalf("secret file must be gone after remove, stat err = %v", err)
+	}
+	if got, _ := LoadNotifySecret(baseDir); got != "" {
+		t.Fatalf("LoadNotifySecret after remove = %q, want empty", got)
+	}
+	// Idempotent: removing an already-absent secret is a no-op.
+	if err := RemoveNotifySecret(baseDir); err != nil {
+		t.Fatalf("RemoveNotifySecret() (idempotent) error = %v", err)
+	}
+}
+
+func TestPersistNotifySecretRejectsTooShort(t *testing.T) {
+	baseDir := t.TempDir()
+	// A single lowercase char passes notifySecretFormat but is below notifySecretMinLen (6):
+	// it would be UNMASKABLE in logs (redact.go secretMinRegister), so persist must refuse it.
+	if err := PersistNotifySecret(context.Background(), baseDir, "a", nil); err == nil {
+		t.Fatalf("PersistNotifySecret() expected an error for a sub-threshold secret")
+	}
+	if _, err := os.Stat(NotifySecretPath(baseDir)); !os.IsNotExist(err) {
+		t.Fatalf("expected no notify secret file written, stat err = %v", err)
+	}
+	// A 5-rune (still < 6) format-valid value is also refused; a 6-rune one is accepted.
+	if err := PersistNotifySecret(context.Background(), baseDir, "abcde", nil); err == nil {
+		t.Fatalf("PersistNotifySecret() expected an error for a 5-rune secret")
+	}
+	if err := PersistNotifySecret(context.Background(), baseDir, "abcdef", nil); err != nil {
+		t.Fatalf("PersistNotifySecret() rejected a 6-rune secret: %v", err)
+	}
+}
+
+func TestRemoveNotifySecretIfMatchesRemovesOnMatch(t *testing.T) {
+	baseDir := t.TempDir()
+	const secret = "3h64-dyi8-q3d6-wcm5"
+	if err := PersistNotifySecret(context.Background(), baseDir, secret, nil); err != nil {
+		t.Fatalf("PersistNotifySecret() error = %v", err)
+	}
+	removed, err := RemoveNotifySecretIfMatches(baseDir, secret)
+	if err != nil {
+		t.Fatalf("RemoveNotifySecretIfMatches() error = %v", err)
+	}
+	if !removed {
+		t.Fatalf("RemoveNotifySecretIfMatches() removed = false, want true on an exact match")
+	}
+	if got, _ := LoadNotifySecret(baseDir); got != "" {
+		t.Fatalf("LoadNotifySecret after guarded remove = %q, want empty", got)
+	}
+}
+
+func TestRemoveNotifySecretIfMatchesKeepsOnMismatch(t *testing.T) {
+	baseDir := t.TempDir()
+	// Emulate the TOCTOU the guard defends against: a concurrent provisioner replaced the
+	// rejected S_old with a fresh confirmed S_new before the ErrHCAuth remediation ran. The
+	// guard must leave S_new in place (comparand is S_old).
+	const sNew = "cccc-dddd"
+	const sOld = "aaaa-bbbb"
+	if err := PersistNotifySecret(context.Background(), baseDir, sNew, nil); err != nil {
+		t.Fatalf("PersistNotifySecret() error = %v", err)
+	}
+	removed, err := RemoveNotifySecretIfMatches(baseDir, sOld)
+	if err != nil {
+		t.Fatalf("RemoveNotifySecretIfMatches() error = %v", err)
+	}
+	if removed {
+		t.Fatalf("RemoveNotifySecretIfMatches() removed a concurrently-provisioned secret")
+	}
+	if got, _ := LoadNotifySecret(baseDir); got != sNew {
+		t.Fatalf("LoadNotifySecret after mismatch = %q, want the fresh secret %q", got, sNew)
+	}
+}
+
+func TestRemoveNotifySecretIfMatchesEmptyRejectedKeeps(t *testing.T) {
+	baseDir := t.TempDir()
+	const secret = "3h64-dyi8-q3d6-wcm5"
+	if err := PersistNotifySecret(context.Background(), baseDir, secret, nil); err != nil {
+		t.Fatalf("PersistNotifySecret() error = %v", err)
+	}
+	// An empty comparand must never delete blindly (regression this guard replaces).
+	removed, err := RemoveNotifySecretIfMatches(baseDir, "   ")
+	if err != nil {
+		t.Fatalf("RemoveNotifySecretIfMatches() error = %v", err)
+	}
+	if removed {
+		t.Fatalf("RemoveNotifySecretIfMatches() removed with an empty comparand")
+	}
+	if got, _ := LoadNotifySecret(baseDir); got != secret {
+		t.Fatalf("LoadNotifySecret after empty-comparand call = %q, want %q", got, secret)
+	}
+}
+
+func TestRemoveNotifySecretAbsentDirIsNoOp(t *testing.T) {
+	// No identity directory created yet: remove must be a silent no-op.
+	if err := RemoveNotifySecret(t.TempDir()); err != nil {
+		t.Fatalf("RemoveNotifySecret() on absent dir error = %v", err)
+	}
+	if err := RemoveNotifySecret(""); err != nil {
+		t.Fatalf("RemoveNotifySecret() on empty baseDir error = %v", err)
+	}
+}
+
+func TestLockNotifySecretSerializes(t *testing.T) {
+	baseDir := t.TempDir()
+	unlock, err := LockNotifySecret(baseDir)
+	if err != nil {
+		t.Fatalf("LockNotifySecret() error = %v", err)
+	}
+	// A second acquisition (separate open file description) must BLOCK until the first
+	// releases, so exactly one provisioner runs at a time.
+	acquired := make(chan struct{})
+	go func() {
+		u2, lerr := LockNotifySecret(baseDir)
+		if lerr != nil {
+			t.Errorf("second LockNotifySecret() error = %v", lerr)
+			close(acquired)
+			return
+		}
+		u2()
+		close(acquired)
+	}()
+	select {
+	case <-acquired:
+		t.Fatalf("second lock acquired while the first was still held")
+	case <-time.After(150 * time.Millisecond):
+		// expected: the second acquisition is blocked.
+	}
+	unlock()
+	select {
+	case <-acquired:
+		// expected: the second acquisition proceeds once the first releases.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("second lock did not acquire after release")
+	}
+}
+
+func TestLockNotifySecretEmptyBaseDir(t *testing.T) {
+	if _, err := LockNotifySecret(""); err == nil {
+		t.Fatalf("LockNotifySecret(\"\") expected an error")
 	}
 }

--- a/internal/identity/notify_secret_test.go
+++ b/internal/identity/notify_secret_test.go
@@ -265,3 +265,21 @@ func TestLockNotifySecretEmptyBaseDir(t *testing.T) {
 		t.Fatalf("LockNotifySecret(\"\") expected an error")
 	}
 }
+
+func TestRemoveNotifySecretIfMatchesEmptyBaseDir(t *testing.T) {
+	removed, err := RemoveNotifySecretIfMatches("", "3h64-dyi8-q3d6-wcm5")
+	if removed || err != nil {
+		t.Fatalf("RemoveNotifySecretIfMatches(\"\", ...) = (%v, %v), want (false, nil)", removed, err)
+	}
+}
+
+func TestRemoveNotifySecretIfMatchesAbsentFileIsNoOp(t *testing.T) {
+	// No secret on disk but a non-empty comparand: the guard re-reads under the lock, finds
+	// nothing (another path already cleared it), and reports removed=false without error.
+	// A nil logger is passed to exercise the variadic-logger branch.
+	baseDir := t.TempDir()
+	removed, err := RemoveNotifySecretIfMatches(baseDir, "3h64-dyi8-q3d6-wcm5", nil)
+	if removed || err != nil {
+		t.Fatalf("RemoveNotifySecretIfMatches(absent) = (%v, %v), want (false, nil)", removed, err)
+	}
+}

--- a/internal/notify/relay_provision.go
+++ b/internal/notify/relay_provision.go
@@ -49,8 +49,13 @@ func ProvisionRelaySecret(ctx context.Context, serverAPIHost, serverID, baseDir 
 	defer unlock()
 	// Re-check UNDER the lock: if a concurrent minter already persisted a secret, adopt it
 	// instead of minting a competing one. Returns (false, nil) - nothing to provision - so
-	// the caller reads the winner's secret from disk on its next fetch.
-	if s, _ := identity.LoadNotifySecret(baseDir); strings.TrimSpace(s) != "" {
+	// the caller reads the winner's secret from disk on its next fetch. A real read error
+	// (the file exists but could not be read) is surfaced rather than swallowed: proceeding
+	// would mint a fresh secret OVER a value we failed to read. Missing/empty/malformed still
+	// yields ("", nil) per the loader contract, so we fall through and provision.
+	if s, err := identity.LoadNotifySecret(baseDir); err != nil {
+		return false, fmt.Errorf("relay provision: re-check load: %w", err)
+	} else if strings.TrimSpace(s) != "" {
 		logTelegramRegistrationDebug(logger, "relay provision: secret already present under lock (adopting; nothing to provision)")
 		return false, nil
 	}

--- a/internal/notify/relay_provision.go
+++ b/internal/notify/relay_provision.go
@@ -1,0 +1,95 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/tis24dev/proxsave/internal/identity"
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+// minRelaySecretLen is the shortest relay secret ProvisionRelaySecret will persist. It
+// mirrors logging's secretMinRegister (6): a secret shorter than this is NOT masked in
+// logs (redact.go skips it), so refusing to persist one keeps a too-short, unmaskable
+// value from ever reaching disk (and later a log line). The server format is 19 chars, so
+// this never rejects a real secret; it is a defensive floor.
+const minRelaySecretLen = 6
+
+// ProvisionRelaySecret performs the get-chat-id handshake WITH provision intent and, on a
+// 200 that issues a notify_secret, persists it (immutable identity file) and confirms it
+// back to the server so the centralized healthcheck fetch can authenticate WITHOUT any
+// Telegram pairing. Now that the server issues the relay secret for a chat-less known
+// ServerID, this is the generic, Telegram-independent provisioning entry point used by the
+// healthcheck self-heal hooks.
+//
+// It reuses the exact three bricks the Telegram path uses -
+// checkTelegramRegistrationWithSecret(provision=true), identity.PersistNotifySecret, and
+// confirmTelegramRelaySecret - so both paths share one wire contract and one log-masking
+// path. The issued secret is registered with the logger's masker inside
+// checkTelegramRegistrationWithSecret BEFORE any body preview is logged.
+//
+// Returns provisioned=true once the secret is on disk (a confirm failure is NON-FATAL: the
+// hash the server stored on issuance already authenticates the fetch, and the server
+// re-confirms on the next run). Every other outcome returns (false, err-or-nil):
+//   - a non-200 handshake            -> (false, err)
+//   - a 200 that issued no secret    -> (false, nil)   [nothing to adopt]
+//   - an empty baseDir               -> (false, err)
+//   - an issued secret < minRelaySecretLen runes -> (false, err)  [defensive floor]
+//   - a persist failure              -> (false, err)
+//
+// Callers MUST treat a non-nil err as "retry later" and NEVER block on it.
+func ProvisionRelaySecret(ctx context.Context, serverAPIHost, serverID, baseDir string, logger *logging.Logger) (bool, error) {
+	if strings.TrimSpace(baseDir) == "" {
+		return false, fmt.Errorf("relay provision: empty baseDir, cannot persist relay secret")
+	}
+	// Serialize the entire issue -> persist -> confirm across processes. Hook a (installer)
+	// and hook b (an enable-now daemon) can run concurrently against the same server_id;
+	// two DISTINCT minted secrets would strand the host (last-write-wins on disk vs the
+	// server's confirm-locks-reissue). An exclusive advisory lock on the identity dir makes
+	// exactly one minter win; the loser adopts the winner's on-disk secret below.
+	unlock, err := identity.LockNotifySecret(baseDir)
+	if err != nil {
+		return false, fmt.Errorf("relay provision: lock: %w", err)
+	}
+	defer unlock()
+	// Re-check UNDER the lock: if a concurrent minter already persisted a secret, adopt it
+	// instead of minting a competing one. Returns (false, nil) - nothing to provision - so
+	// the caller reads the winner's secret from disk on its next fetch.
+	if s, _ := identity.LoadNotifySecret(baseDir); strings.TrimSpace(s) != "" {
+		logTelegramRegistrationDebug(logger, "relay provision: secret already present under lock (adopting; nothing to provision)")
+		return false, nil
+	}
+
+	status, secret := checkTelegramRegistrationWithSecret(ctx, serverAPIHost, serverID, true, logger)
+	if status.Code != 200 {
+		// Do NOT wrap the raw server body (status.Error) into the returned error: it is
+		// untrusted text. The status code alone is enough for the caller to degrade/retry.
+		return false, fmt.Errorf("relay provision: get-chat-id returned status %d", status.Code)
+	}
+	if secret == "" {
+		// Linked/known but the server issued no (new) token - e.g. the secret is already
+		// confirmed server-side. Nothing to adopt; not an error.
+		logTelegramRegistrationDebug(logger, "relay provision: 200 without token (nothing to provision)")
+		return false, nil
+	}
+	// Defensive length floor: an issued secret shorter than minRelaySecretLen is not masked
+	// in logs, so refuse it rather than write an unmaskable value to disk. (Server format is
+	// 19 chars, so a real secret never trips this.)
+	if len([]rune(secret)) < minRelaySecretLen {
+		return false, fmt.Errorf("relay provision: issued secret too short (<%d runes); refusing to persist", minRelaySecretLen)
+	}
+	if err := identity.PersistNotifySecret(ctx, baseDir, secret, logger); err != nil {
+		return false, fmt.Errorf("relay provision: persist failed: %w", err)
+	}
+	if err := confirmTelegramRelaySecret(ctx, http.DefaultClient, serverAPIHost, serverID, secret, logger); err != nil {
+		// Non-fatal: the secret IS persisted and the issuance hash already authenticates the
+		// fetch; the server re-confirms on the next run. confirmTelegramRelaySecret already
+		// redacts the secret from its error text.
+		logTelegramRegistrationDebug(logger, "relay provision: confirm failed (non-fatal, secret persisted): %v", err)
+		return true, nil
+	}
+	logTelegramRegistrationDebug(logger, "relay provision: secret persisted and confirmed")
+	return true, nil
+}

--- a/internal/notify/relay_provision.go
+++ b/internal/notify/relay_provision.go
@@ -10,13 +10,6 @@ import (
 	"github.com/tis24dev/proxsave/internal/logging"
 )
 
-// minRelaySecretLen is the shortest relay secret ProvisionRelaySecret will persist. It
-// mirrors logging's secretMinRegister (6): a secret shorter than this is NOT masked in
-// logs (redact.go skips it), so refusing to persist one keeps a too-short, unmaskable
-// value from ever reaching disk (and later a log line). The server format is 19 chars, so
-// this never rejects a real secret; it is a defensive floor.
-const minRelaySecretLen = 6
-
 // ProvisionRelaySecret performs the get-chat-id handshake WITH provision intent and, on a
 // 200 that issues a notify_secret, persists it (immutable identity file) and confirms it
 // back to the server so the centralized healthcheck fetch can authenticate WITHOUT any
@@ -36,7 +29,7 @@ const minRelaySecretLen = 6
 //   - a non-200 handshake            -> (false, err)
 //   - a 200 that issued no secret    -> (false, nil)   [nothing to adopt]
 //   - an empty baseDir               -> (false, err)
-//   - an issued secret < minRelaySecretLen runes -> (false, err)  [defensive floor]
+//   - an issued secret < identity.NotifySecretMinLen runes -> (false, err)  [defensive floor]
 //   - a persist failure              -> (false, err)
 //
 // Callers MUST treat a non-nil err as "retry later" and NEVER block on it.
@@ -74,11 +67,12 @@ func ProvisionRelaySecret(ctx context.Context, serverAPIHost, serverID, baseDir 
 		logTelegramRegistrationDebug(logger, "relay provision: 200 without token (nothing to provision)")
 		return false, nil
 	}
-	// Defensive length floor: an issued secret shorter than minRelaySecretLen is not masked
-	// in logs, so refuse it rather than write an unmaskable value to disk. (Server format is
-	// 19 chars, so a real secret never trips this.)
-	if len([]rune(secret)) < minRelaySecretLen {
-		return false, fmt.Errorf("relay provision: issued secret too short (<%d runes); refusing to persist", minRelaySecretLen)
+	// Defensive length floor (shared with the persistence sink): an issued secret shorter
+	// than identity.NotifySecretMinLen is not masked in logs, so refuse it rather than write
+	// an unmaskable value to disk. (Server format is 19 chars, so a real secret never trips
+	// this.)
+	if len([]rune(secret)) < identity.NotifySecretMinLen {
+		return false, fmt.Errorf("relay provision: issued secret too short (<%d runes); refusing to persist", identity.NotifySecretMinLen)
 	}
 	if err := identity.PersistNotifySecret(ctx, baseDir, secret, logger); err != nil {
 		return false, fmt.Errorf("relay provision: persist failed: %w", err)

--- a/internal/notify/relay_provision_test.go
+++ b/internal/notify/relay_provision_test.go
@@ -1,0 +1,182 @@
+package notify
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/identity"
+)
+
+// These tests reuse routingSecretServer, provisionCapture, provisionTestSecret and
+// newProvisionTestLogger from telegram_registration_provision_test.go (same package).
+
+func TestProvisionRelaySecretHappyPath(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
+	baseDir := t.TempDir()
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
+	defer server.Close()
+
+	provisioned, err := ProvisionRelaySecret(context.Background(), server.URL, "server-123", baseDir, logger)
+	if err != nil || !provisioned {
+		t.Fatalf("provisioned=%v err=%v, want true/nil", provisioned, err)
+	}
+	if loaded, _ := identity.LoadNotifySecret(baseDir); loaded != provisionTestSecret {
+		t.Fatalf("persisted secret = %q, want %q", loaded, provisionTestSecret)
+	}
+	if capture.provisionHeader != "1" {
+		t.Fatalf("X-Proxsave-Provision = %q, want 1", capture.provisionHeader)
+	}
+	if capture.confirmHits != 1 {
+		t.Fatalf("confirm hits = %d, want 1", capture.confirmHits)
+	}
+	if capture.confirmAuth != provisionTestSecret {
+		t.Fatalf("confirm X-Server-Auth = %q, want %q", capture.confirmAuth, provisionTestSecret)
+	}
+	if strings.Contains(buf.String(), provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into logs:\n%s", buf.String())
+	}
+}
+
+func TestProvisionRelaySecretConfirmFailureIsNonFatal(t *testing.T) {
+	logger, buf := newProvisionTestLogger()
+	baseDir := t.TempDir()
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusForbidden, &capture)
+	defer server.Close()
+
+	provisioned, err := ProvisionRelaySecret(context.Background(), server.URL, "server-123", baseDir, logger)
+	if err != nil || !provisioned {
+		t.Fatalf("confirm 403 must stay provisioned: provisioned=%v err=%v", provisioned, err)
+	}
+	if loaded, _ := identity.LoadNotifySecret(baseDir); loaded != provisionTestSecret {
+		t.Fatalf("secret must persist despite confirm failure, got %q", loaded)
+	}
+	if capture.confirmHits != 1 {
+		t.Fatalf("confirm hits = %d, want 1", capture.confirmHits)
+	}
+	if strings.Contains(buf.String(), provisionTestSecret) {
+		t.Fatalf("plaintext secret leaked into logs:\n%s", buf.String())
+	}
+}
+
+func TestProvisionRelaySecretNoTokenNoPersist(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+	baseDir := t.TempDir()
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"status":200}`, http.StatusOK, &capture)
+	defer server.Close()
+
+	provisioned, err := ProvisionRelaySecret(context.Background(), server.URL, "server-123", baseDir, logger)
+	if provisioned || err != nil {
+		t.Fatalf("no token: want (false,nil), got (%v,%v)", provisioned, err)
+	}
+	if loaded, _ := identity.LoadNotifySecret(baseDir); loaded != "" {
+		t.Fatalf("nothing must be persisted, got %q", loaded)
+	}
+	if capture.confirmHits != 0 {
+		t.Fatalf("no token -> no confirm, got %d", capture.confirmHits)
+	}
+}
+
+func TestProvisionRelaySecretShortSecretRefused(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+	baseDir := t.TempDir()
+	var capture provisionCapture
+	// "abc" is 3 runes (< minRelaySecretLen) and would NOT be masked in logs.
+	server := routingSecretServer(t, `{"notify_secret":"abc","status":200}`, http.StatusOK, &capture)
+	defer server.Close()
+
+	provisioned, err := ProvisionRelaySecret(context.Background(), server.URL, "server-123", baseDir, logger)
+	if provisioned || err == nil {
+		t.Fatalf("short secret must be refused: got (%v,%v)", provisioned, err)
+	}
+	if loaded, _ := identity.LoadNotifySecret(baseDir); loaded != "" {
+		t.Fatalf("short secret must NOT be persisted, got %q", loaded)
+	}
+	if _, statErr := os.Stat(identity.NotifySecretPath(baseDir)); !os.IsNotExist(statErr) {
+		t.Fatalf("secret file must be absent, got err=%v", statErr)
+	}
+	if capture.confirmHits != 0 {
+		t.Fatalf("short secret -> no confirm, got %d", capture.confirmHits)
+	}
+}
+
+func TestProvisionRelaySecretEmptyBaseDir(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+	var capture provisionCapture
+	server := routingSecretServer(t, `{"notify_secret":"`+provisionTestSecret+`","status":200}`, http.StatusOK, &capture)
+	defer server.Close()
+
+	provisioned, err := ProvisionRelaySecret(context.Background(), server.URL, "server-123", "", logger)
+	if provisioned || err == nil {
+		t.Fatalf("empty baseDir must fail: got (%v,%v)", provisioned, err)
+	}
+	if capture.confirmHits != 0 {
+		t.Fatalf("empty baseDir -> no confirm, got %d", capture.confirmHits)
+	}
+}
+
+func TestProvisionRelaySecretAdoptsExistingSecretUnderLock(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+	baseDir := t.TempDir()
+	// A secret is already on disk (e.g. a concurrent minter won the race). The provisioner
+	// must adopt it under the lock and NOT contact the server nor mint a competing secret.
+	if err := identity.PersistNotifySecret(context.Background(), baseDir, provisionTestSecret, nil); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+	hits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		t.Errorf("server must not be contacted when a secret is already present: %s", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	provisioned, err := ProvisionRelaySecret(context.Background(), server.URL, "server-123", baseDir, logger)
+	if provisioned || err != nil {
+		t.Fatalf("adopt path must return (false,nil), got (%v,%v)", provisioned, err)
+	}
+	if hits != 0 {
+		t.Fatalf("server must not be hit under the adopt path, got %d", hits)
+	}
+	if loaded, _ := identity.LoadNotifySecret(baseDir); loaded != provisionTestSecret {
+		t.Fatalf("existing secret must be left untouched, got %q", loaded)
+	}
+}
+
+func TestProvisionRelaySecretNon200(t *testing.T) {
+	logger, _ := newProvisionTestLogger()
+	baseDir := t.TempDir()
+	confirmHits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/get-chat-id":
+			w.WriteHeader(http.StatusConflict) // 409: no relay secret issued (chat-less + server pre-change)
+			_, _ = w.Write([]byte("SERVER_NON_ASSOCIATO"))
+		case "/api/confirm-secret":
+			confirmHits++
+			t.Errorf("confirm must not be hit on a non-200 handshake")
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	provisioned, err := ProvisionRelaySecret(context.Background(), server.URL, "server-123", baseDir, logger)
+	if provisioned || err == nil {
+		t.Fatalf("409 must fail: got (%v,%v)", provisioned, err)
+	}
+	if loaded, _ := identity.LoadNotifySecret(baseDir); loaded != "" {
+		t.Fatalf("nothing persisted on 409, got %q", loaded)
+	}
+	if confirmHits != 0 {
+		t.Fatalf("no confirm on 409, got %d", confirmHits)
+	}
+}

--- a/internal/notify/relay_provision_test.go
+++ b/internal/notify/relay_provision_test.go
@@ -87,7 +87,7 @@ func TestProvisionRelaySecretShortSecretRefused(t *testing.T) {
 	logger, _ := newProvisionTestLogger()
 	baseDir := t.TempDir()
 	var capture provisionCapture
-	// "abc" is 3 runes (< minRelaySecretLen) and would NOT be masked in logs.
+	// "abc" is 3 runes (< identity.NotifySecretMinLen) and would NOT be masked in logs.
 	server := routingSecretServer(t, `{"notify_secret":"abc","status":200}`, http.StatusOK, &capture)
 	defer server.Close()
 

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -149,7 +149,16 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 		logTelegramRegistrationDebug(logger, "Telegram registration: 200 body parsed (notifySecretPresent=%v len=%d)", secret != "", len(secret))
 	}
 
-	logTelegramRegistrationDebug(logger, "Telegram registration: response status=%d bodyBytes=%d bodyPreview=%q", resp.Status, len(body), truncateTelegramRegistrationBody(body, 200))
+	// SECRET-IN-LOG GUARD (defense-in-depth): a secret shorter than the mask threshold is
+	// NOT registered by the masker (logging's secretMinRegister skips it), so it would leak
+	// verbatim into the body preview below. The real server never issues one (19-char
+	// format), but redact the whole preview in that case rather than emit an unmaskable
+	// value. The floor itself is still enforced at persist time in ProvisionRelaySecret.
+	preview := truncateTelegramRegistrationBody(body, 200)
+	if resp.Status == http.StatusOK && secret != "" && len([]rune(secret)) < minRelaySecretLen {
+		preview = "(redacted: response carried an unmaskable short secret)"
+	}
+	logTelegramRegistrationDebug(logger, "Telegram registration: response status=%d bodyBytes=%d bodyPreview=%q", resp.Status, len(body), preview)
 
 	switch resp.Status {
 	case 200:

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -155,7 +155,7 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 	// format), but redact the whole preview in that case rather than emit an unmaskable
 	// value. The floor itself is still enforced at persist time in ProvisionRelaySecret.
 	preview := truncateTelegramRegistrationBody(body, 200)
-	if resp.Status == http.StatusOK && secret != "" && len([]rune(secret)) < minRelaySecretLen {
+	if resp.Status == http.StatusOK && secret != "" && len([]rune(secret)) < identity.NotifySecretMinLen {
 		preview = "(redacted: response carried an unmaskable short secret)"
 	}
 	logTelegramRegistrationDebug(logger, "Telegram registration: response status=%d bodyBytes=%d bodyPreview=%q", resp.Status, len(body), preview)

--- a/internal/orchestrator/healthcheck_setup_bootstrap.go
+++ b/internal/orchestrator/healthcheck_setup_bootstrap.go
@@ -1,11 +1,13 @@
 package orchestrator
 
 import (
+	"context"
 	"strings"
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/identity"
+	"github.com/tis24dev/proxsave/internal/notify"
 )
 
 // HealthcheckSetupMaxVerificationAttempts bounds how many connection checks the
@@ -64,16 +66,26 @@ var (
 		s, _ := identity.LoadNotifySecret(baseDir)
 		return s
 	}
+	// healthcheckSetupProvisionSecret is the eligibility self-heal (hook c): when the
+	// ServerID is resolved but no relay secret is on disk, attempt one Telegram-independent
+	// provisioning. Best-effort - the seam swallows the error and returns whether a secret
+	// was persisted, so the caller preserves its never-error / never-block contract.
+	healthcheckSetupProvisionSecret = func(ctx context.Context, serverAPIHost, serverID, baseDir string) bool {
+		provisioned, _ := notify.ProvisionRelaySecret(ctx, serverAPIHost, serverID, baseDir, nil)
+		return provisioned
+	}
 )
 
 // BuildHealthcheckSetupBootstrap re-reads the just-written config (the same
 // single-source-of-truth approach Telegram uses) and decides whether the
 // centralized healthchecks setup screen should appear. Eligible requires: the
 // daemon engine was chosen (HEALTHCHECK_ENABLED=true), centralized mode, a resolved
-// ServerID, and a relay secret on disk (from Telegram pairing, needed for the
-// authenticated fetch). All skip paths return (state, nil) - never an error - so
-// the step is fully non-blocking.
-func BuildHealthcheckSetupBootstrap(configPath, baseDir string) (HealthcheckSetupBootstrap, error) {
+// ServerID, and a relay secret on disk (needed for the authenticated fetch). When
+// the secret is absent it is provisioned on demand from the server keyed on the
+// ServerID (no Telegram pairing required); only if that still fails does the step
+// skip. All skip paths return (state, nil) - never an error - so the step is fully
+// non-blocking.
+func BuildHealthcheckSetupBootstrap(ctx context.Context, configPath, baseDir string) (HealthcheckSetupBootstrap, error) {
 	state := HealthcheckSetupBootstrap{}
 
 	cfg, err := healthcheckSetupLoadConfig(configPath, baseDir)
@@ -123,6 +135,17 @@ func BuildHealthcheckSetupBootstrap(configPath, baseDir string) (HealthcheckSetu
 	}
 
 	state.HasSecret = strings.TrimSpace(healthcheckSetupLoadSecret(baseDir)) != ""
+	if !state.HasSecret {
+		// Self-heal (hook c): the ServerID is resolved but no relay secret is on disk.
+		// Attempt one Telegram-independent provisioning (the server now issues the relay
+		// secret for a chat-less known ServerID), gated STRICTLY on the secret being absent.
+		// The seam never returns an error and the network call is bounded (5s handshake +
+		// 5s confirm), so this preserves the "never returns an error, never blocks" contract:
+		// on any failure we fall through to SkipIdentityUnavailable exactly as before.
+		if healthcheckSetupProvisionSecret(ctx, state.ServerAPIHost, state.ServerID, baseDir) {
+			state.HasSecret = strings.TrimSpace(healthcheckSetupLoadSecret(baseDir)) != ""
+		}
+	}
 	if !state.HasSecret {
 		state.Eligibility = HealthcheckSetupSkipIdentityUnavailable
 		return state, nil

--- a/internal/orchestrator/healthcheck_setup_bootstrap.go
+++ b/internal/orchestrator/healthcheck_setup_bootstrap.go
@@ -142,9 +142,12 @@ func BuildHealthcheckSetupBootstrap(ctx context.Context, configPath, baseDir str
 		// The seam never returns an error and the network call is bounded (5s handshake +
 		// 5s confirm), so this preserves the "never returns an error, never blocks" contract:
 		// on any failure we fall through to SkipIdentityUnavailable exactly as before.
-		if healthcheckSetupProvisionSecret(ctx, state.ServerAPIHost, state.ServerID, baseDir) {
-			state.HasSecret = strings.TrimSpace(healthcheckSetupLoadSecret(baseDir)) != ""
-		}
+		// Reload UNCONDITIONALLY, regardless of the return value: ProvisionRelaySecret
+		// returns false when it adopts a secret a concurrent provisioner persisted under
+		// the cross-process lock, so gating the reload on a true return would miss a
+		// usable credential that is already on disk and wrongly report SkipIdentityUnavailable.
+		_ = healthcheckSetupProvisionSecret(ctx, state.ServerAPIHost, state.ServerID, baseDir)
+		state.HasSecret = strings.TrimSpace(healthcheckSetupLoadSecret(baseDir)) != ""
 	}
 	if !state.HasSecret {
 		state.Eligibility = HealthcheckSetupSkipIdentityUnavailable

--- a/internal/orchestrator/healthcheck_setup_classify.go
+++ b/internal/orchestrator/healthcheck_setup_classify.go
@@ -54,11 +54,11 @@ func ClassifyHealthcheckSetupResult(res HealthcheckCheckResult) HealthcheckSetup
 	switch {
 	case errors.Is(res.Err, health.ErrHCAuth):
 		st.Fatal, st.Level, st.Keyword = true, HealthcheckSetupLevelError, "REJECTED"
-		st.Message = "The monitoring server rejected this host's credentials. Complete Telegram pairing, then reinstall to retry."
+		st.Message = "The monitoring server rejected this host's credentials. The relay credential is re-provisioned automatically on the next daemon run; if this persists the server may have reset this host's registration."
 		return st
 	case errors.Is(res.Err, health.ErrHCUnknown):
 		st.Fatal, st.Level, st.Keyword = true, HealthcheckSetupLevelError, "NOT REGISTERED"
-		st.Message = "This host is not registered on the server yet. Complete Telegram pairing first."
+		st.Message = "This host is not registered on the server yet. It is registered automatically on the next daemon run (no Telegram pairing needed); if this persists the monitoring server is unreachable from this host."
 		return st
 	case errors.Is(res.Err, health.ErrHCDisabled):
 		st.Fatal, st.Level, st.Keyword = true, HealthcheckSetupLevelError, "DISABLED"
@@ -180,6 +180,51 @@ func applyHealthcheckDaemonState(st HealthcheckSetupState, d health.Diagnosis) H
 	default:
 		st.Level, st.Keyword = HealthcheckSetupLevelWarn, "UNKNOWN"
 		st.Message = "The monitoring daemon state could not be determined."
+	}
+	return st
+}
+
+// ClassifyHealthcheckSetupSkip maps a NON-eligible HealthcheckSetupBootstrap (a skip
+// verdict, i.e. the setup screen has nothing to check) to display copy, so the CLI and
+// dashboard can tell the user WHY distinctly instead of one generic "not enabled" line.
+// It is the mirror of ClassifyHealthcheckSetupResult (which classifies the eligible check
+// outcome) and the single source of truth for that copy, so both front-ends read
+// identically. Only Keyword/Level/Message are set (a skip has no login URL or daemon
+// state). The centralized missing-secret state is Option-A aware: the relay credential is
+// provisioned automatically on the next daemon run (NO Telegram pairing is required); a
+// persistent missing secret means the monitoring server is unreachable from this host.
+func ClassifyHealthcheckSetupSkip(res HealthcheckSetupBootstrap) HealthcheckSetupState {
+	st := HealthcheckSetupState{Level: HealthcheckSetupLevelWarn}
+	switch res.Eligibility {
+	case HealthcheckSetupSkipDisabled:
+		st.Keyword = "NOT ENABLED"
+		st.Message = "Backup monitoring is not enabled on this host. Switch to the daemon scheduler with monitoring enabled to use it."
+	case HealthcheckSetupSkipConfigError:
+		st.Level, st.Keyword = HealthcheckSetupLevelError, "CONFIG ERROR"
+		st.Message = "The configuration could not be loaded, so backup monitoring could not be checked. Re-run the installer to repair it."
+	case HealthcheckSetupSkipSelfMode:
+		st.Keyword = "NOT CONFIGURED"
+		st.Message = "Self-mode monitoring is selected but no service-alive ping URL is configured yet. Enter the healthchecks parameters to finish setup."
+	case HealthcheckSetupSkipIdentityUnavailable:
+		// Two distinct causes collapse into this eligibility upstream: no ServerID at all,
+		// or a ServerID with no relay secret on disk yet. res.ServerID splits them (a
+		// ServerID-less host never has HasSecret set).
+		if res.ServerID == "" {
+			st.Keyword = "NO IDENTITY"
+			st.Message = "No server identity was found on this host, so centralized monitoring cannot be provisioned. Re-run the installer or regenerate the identity file."
+			return st
+		}
+		// ServerID present, relay secret still absent: A-aware. Provisioning is automatic on
+		// the next daemon run and needs NO Telegram pairing; a persistent gap means the
+		// monitoring server is unreachable from this host.
+		st.Keyword = "PROVISIONING"
+		st.Message = "Centralized monitoring is enabled; the relay credential is provisioned automatically on the next daemon run. If this state persists, the monitoring server is unreachable from this host."
+	default:
+		// EligibilityUnknown (zero value) or an eligible verdict reaching the skip path
+		// defensively -- never happens from the dashboard, which only calls this when the
+		// screen was not shown.
+		st.Keyword = "NOT CONFIGURED"
+		st.Message = "Backup monitoring is not configured on this host."
 	}
 	return st
 }

--- a/internal/orchestrator/healthcheck_setup_classify_daemon_test.go
+++ b/internal/orchestrator/healthcheck_setup_classify_daemon_test.go
@@ -1,0 +1,53 @@
+package orchestrator
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/health"
+)
+
+// TestApplyHealthcheckDaemonStateKeywords pins the headline keyword for every daemon
+// transmission state, including the defensive default, so the check screen distinguishes
+// "reachable" from "actually monitoring" for each state.
+func TestApplyHealthcheckDaemonStateKeywords(t *testing.T) {
+	cases := []struct {
+		state health.TxState
+		want  string
+	}{
+		{health.TxTransmitting, "WORKING"},
+		{health.TxNotInstalled, "NOT INSTALLED"},
+		{health.TxNotActive, "NOT RUNNING"},
+		{health.TxRunningNoReport, "RUNNING, NOT REPORTING"},
+		{health.TxNoHeartbeat, "NOT RUNNING"},
+		{health.TxStale, "STALE"},
+		{health.TxNotProvisioned, "NOT PROVISIONED"},
+		{health.TxUnreachable, "MONITOR UNREACHABLE"},
+		{health.TxTransmitFailed, "TRANSMIT FAILED"},
+		{health.TxState("bogus"), "UNKNOWN"},
+	}
+	for _, tt := range cases {
+		st := applyHealthcheckDaemonState(HealthcheckSetupState{}, health.Diagnosis{State: tt.state})
+		if st.Keyword != tt.want {
+			t.Fatalf("state %q: Keyword=%q, want %q", tt.state, st.Keyword, tt.want)
+		}
+		if st.Message == "" {
+			t.Fatalf("state %q: message must not be empty", tt.state)
+		}
+	}
+}
+
+// TestClassifyHealthcheckSelfResultUnreachable covers the two self-mode failure branches
+// (a transport error, and a non-error but not-reachable result), both of which render
+// UNREACHABLE.
+func TestClassifyHealthcheckSelfResultUnreachable(t *testing.T) {
+	st := ClassifyHealthcheckSelfResult(HealthcheckCheckResult{Err: errors.New("dial timeout")})
+	if st.Keyword != "UNREACHABLE" {
+		t.Fatalf("error case: Keyword=%q, want UNREACHABLE", st.Keyword)
+	}
+
+	st = ClassifyHealthcheckSelfResult(HealthcheckCheckResult{Reachable: false})
+	if st.Keyword != "UNREACHABLE" {
+		t.Fatalf("not-reachable case: Keyword=%q, want UNREACHABLE", st.Keyword)
+	}
+}

--- a/internal/orchestrator/healthcheck_setup_self_test.go
+++ b/internal/orchestrator/healthcheck_setup_self_test.go
@@ -41,7 +41,7 @@ func TestBuildHealthcheckSetupBootstrapSelf(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			stubHealthcheckBootstrap(t, tc.cfg, nil, tc.serverID, tc.secret)
-			state, err := BuildHealthcheckSetupBootstrap("/cfg", "/base")
+			state, err := BuildHealthcheckSetupBootstrap(context.Background(), "/cfg", "/base")
 			if err != nil {
 				t.Fatalf("bootstrap returned error: %v", err)
 			}

--- a/internal/orchestrator/healthcheck_setup_skip_test.go
+++ b/internal/orchestrator/healthcheck_setup_skip_test.go
@@ -21,6 +21,7 @@ func TestClassifyHealthcheckSetupSkip(t *testing.T) {
 		{"self-no-url", HealthcheckSetupBootstrap{Eligibility: HealthcheckSetupSkipSelfMode}, "NOT CONFIGURED", HealthcheckSetupLevelWarn, "ping URL"},
 		{"no-identity", HealthcheckSetupBootstrap{Eligibility: HealthcheckSetupSkipIdentityUnavailable, ServerID: ""}, "NO IDENTITY", HealthcheckSetupLevelWarn, "No server identity"},
 		{"provisioning-missing-secret", HealthcheckSetupBootstrap{Eligibility: HealthcheckSetupSkipIdentityUnavailable, ServerID: "abcd1234", HasSecret: false}, "PROVISIONING", HealthcheckSetupLevelWarn, "provisioned automatically"},
+		{"unknown-default", HealthcheckSetupBootstrap{}, "NOT CONFIGURED", HealthcheckSetupLevelWarn, "not configured"},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/orchestrator/healthcheck_setup_skip_test.go
+++ b/internal/orchestrator/healthcheck_setup_skip_test.go
@@ -1,0 +1,87 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestClassifyHealthcheckSetupSkip pins DISTINCT user-facing copy for every skip verdict,
+// so the dashboard/CLI no longer collapse them into one generic line. The centralized
+// missing-secret state is A-aware.
+func TestClassifyHealthcheckSetupSkip(t *testing.T) {
+	cases := []struct {
+		name        string
+		res         HealthcheckSetupBootstrap
+		wantKeyword string
+		wantLevel   HealthcheckSetupLevel
+		wantSubstr  string
+	}{
+		{"disabled", HealthcheckSetupBootstrap{Eligibility: HealthcheckSetupSkipDisabled}, "NOT ENABLED", HealthcheckSetupLevelWarn, "not enabled"},
+		{"config-error", HealthcheckSetupBootstrap{Eligibility: HealthcheckSetupSkipConfigError, ConfigError: "boom"}, "CONFIG ERROR", HealthcheckSetupLevelError, "configuration could not be loaded"},
+		{"self-no-url", HealthcheckSetupBootstrap{Eligibility: HealthcheckSetupSkipSelfMode}, "NOT CONFIGURED", HealthcheckSetupLevelWarn, "ping URL"},
+		{"no-identity", HealthcheckSetupBootstrap{Eligibility: HealthcheckSetupSkipIdentityUnavailable, ServerID: ""}, "NO IDENTITY", HealthcheckSetupLevelWarn, "No server identity"},
+		{"provisioning-missing-secret", HealthcheckSetupBootstrap{Eligibility: HealthcheckSetupSkipIdentityUnavailable, ServerID: "abcd1234", HasSecret: false}, "PROVISIONING", HealthcheckSetupLevelWarn, "provisioned automatically"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			st := ClassifyHealthcheckSetupSkip(tt.res)
+			if st.Keyword != tt.wantKeyword {
+				t.Fatalf("Keyword=%q, want %q", st.Keyword, tt.wantKeyword)
+			}
+			if st.Level != tt.wantLevel {
+				t.Fatalf("Level=%d, want %d", st.Level, tt.wantLevel)
+			}
+			if !strings.Contains(st.Message, tt.wantSubstr) {
+				t.Fatalf("Message=%q, want substring %q", st.Message, tt.wantSubstr)
+			}
+			if st.Message == "" {
+				t.Fatal("Message must not be empty")
+			}
+		})
+	}
+}
+
+// TestClassifyHealthcheckSetupSkip_MissingSecretIsAAware guards the Option-A copy: the
+// centralized missing-secret state must NEVER tell the user to pair Telegram, and must
+// promise automatic provisioning plus the "monitor unreachable if it persists" hint.
+func TestClassifyHealthcheckSetupSkip_MissingSecretIsAAware(t *testing.T) {
+	st := ClassifyHealthcheckSetupSkip(HealthcheckSetupBootstrap{
+		Eligibility: HealthcheckSetupSkipIdentityUnavailable,
+		ServerID:    "abcd1234",
+	})
+	low := strings.ToLower(st.Message)
+	if strings.Contains(low, "telegram") || strings.Contains(low, "pair") {
+		t.Fatalf("missing-secret copy must be A-aware (no Telegram/pairing), got %q", st.Message)
+	}
+	if !strings.Contains(low, "provisioned automatically") {
+		t.Fatalf("missing-secret copy must promise auto provisioning, got %q", st.Message)
+	}
+	if !strings.Contains(low, "unreachable") {
+		t.Fatalf("missing-secret copy must hint at monitor unreachability, got %q", st.Message)
+	}
+}
+
+// TestClassifyHealthcheckSetupSkip_Distinct locks that no two skip verdicts render the
+// same headline or copy (the whole point of the differentiation).
+func TestClassifyHealthcheckSetupSkip_Distinct(t *testing.T) {
+	states := []HealthcheckSetupBootstrap{
+		{Eligibility: HealthcheckSetupSkipDisabled},
+		{Eligibility: HealthcheckSetupSkipConfigError},
+		{Eligibility: HealthcheckSetupSkipSelfMode},
+		{Eligibility: HealthcheckSetupSkipIdentityUnavailable, ServerID: ""},
+		{Eligibility: HealthcheckSetupSkipIdentityUnavailable, ServerID: "abcd1234"},
+	}
+	kw := map[string]bool{}
+	msg := map[string]bool{}
+	for _, s := range states {
+		st := ClassifyHealthcheckSetupSkip(s)
+		if kw[st.Keyword] {
+			t.Fatalf("duplicate skip keyword: %q", st.Keyword)
+		}
+		kw[st.Keyword] = true
+		if msg[st.Message] {
+			t.Fatalf("duplicate skip message: %q", st.Message)
+		}
+		msg[st.Message] = true
+	}
+}

--- a/internal/orchestrator/healthcheck_setup_test.go
+++ b/internal/orchestrator/healthcheck_setup_test.go
@@ -18,17 +18,20 @@ import (
 
 func stubHealthcheckBootstrap(t *testing.T, cfg *config.Config, cfgErr error, serverID string, secret string) {
 	t.Helper()
-	oc, oi, os := healthcheckSetupLoadConfig, healthcheckSetupIdentityDetect, healthcheckSetupLoadSecret
+	oc, oi, osec, op := healthcheckSetupLoadConfig, healthcheckSetupIdentityDetect, healthcheckSetupLoadSecret, healthcheckSetupProvisionSecret
 	t.Cleanup(func() {
 		healthcheckSetupLoadConfig = oc
 		healthcheckSetupIdentityDetect = oi
-		healthcheckSetupLoadSecret = os
+		healthcheckSetupLoadSecret = osec
+		healthcheckSetupProvisionSecret = op
 	})
 	healthcheckSetupLoadConfig = func(configPath, baseDir string) (*config.Config, error) { return cfg, cfgErr }
 	healthcheckSetupIdentityDetect = func(baseDir string, logger *logging.Logger) (*identity.Info, error) {
 		return &identity.Info{ServerID: serverID}, nil
 	}
 	healthcheckSetupLoadSecret = func(baseDir string) string { return secret }
+	// Default: provisioning is a no-op (no network), so a missing secret stays a skip.
+	healthcheckSetupProvisionSecret = func(ctx context.Context, serverAPIHost, serverID, baseDir string) bool { return false }
 }
 
 func TestBuildHealthcheckSetupBootstrap(t *testing.T) {
@@ -53,7 +56,7 @@ func TestBuildHealthcheckSetupBootstrap(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			stubHealthcheckBootstrap(t, tc.cfg, tc.cfgErr, tc.serverID, tc.secret)
-			state, err := BuildHealthcheckSetupBootstrap("/cfg", "/base")
+			state, err := BuildHealthcheckSetupBootstrap(context.Background(), "/cfg", "/base")
 			if err != nil {
 				t.Fatalf("bootstrap returned error (must be non-blocking): %v", err)
 			}
@@ -67,6 +70,72 @@ func TestBuildHealthcheckSetupBootstrap(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildHealthcheckSetupBootstrapProvisionsMissingSecret pins hook c: a centralized host
+// with a resolved ServerID but NO secret on disk attempts provisioning; when it succeeds
+// (a secret then appears on disk) the verdict flips from SkipIdentityUnavailable to
+// EligibleCentralized, and the provision seam is called with the resolved host + ServerID.
+// A failed attempt keeps the skip verdict.
+func TestBuildHealthcheckSetupBootstrapProvisionsMissingSecret(t *testing.T) {
+	oc, oi, osl, op := healthcheckSetupLoadConfig, healthcheckSetupIdentityDetect, healthcheckSetupLoadSecret, healthcheckSetupProvisionSecret
+	t.Cleanup(func() {
+		healthcheckSetupLoadConfig = oc
+		healthcheckSetupIdentityDetect = oi
+		healthcheckSetupLoadSecret = osl
+		healthcheckSetupProvisionSecret = op
+	})
+	cfg := &config.Config{HealthcheckEnabled: true, HealthcheckMode: "centralized", ServerAPIHost: "https://h"}
+	healthcheckSetupLoadConfig = func(configPath, baseDir string) (*config.Config, error) { return cfg, nil }
+	healthcheckSetupIdentityDetect = func(baseDir string, logger *logging.Logger) (*identity.Info, error) {
+		return &identity.Info{ServerID: "123456789012"}, nil
+	}
+	secret := "" // absent at first
+	healthcheckSetupLoadSecret = func(baseDir string) string { return secret }
+
+	t.Run("provision success -> eligible", func(t *testing.T) {
+		secret = ""
+		called := false
+		var gotHost, gotID string
+		healthcheckSetupProvisionSecret = func(ctx context.Context, host, id, baseDir string) bool {
+			called = true
+			gotHost, gotID = host, id
+			secret = "3h64-dyi8-q3d6-wcm5" // provisioning made a secret appear on disk
+			return true
+		}
+		state, err := BuildHealthcheckSetupBootstrap(context.Background(), "/cfg", "/base")
+		if err != nil {
+			t.Fatalf("bootstrap must never error: %v", err)
+		}
+		if !called {
+			t.Fatal("provision seam must be called when the secret is absent")
+		}
+		if gotHost != "https://h" || gotID != "123456789012" {
+			t.Fatalf("provision seam args = (%q,%q), want (https://h,123456789012)", gotHost, gotID)
+		}
+		if state.Eligibility != HealthcheckSetupEligibleCentralized || !state.HasSecret {
+			t.Fatalf("after provisioning want EligibleCentralized+HasSecret, got %+v", state)
+		}
+	})
+
+	t.Run("provision failure -> skip, still non-blocking", func(t *testing.T) {
+		secret = ""
+		called := false
+		healthcheckSetupProvisionSecret = func(ctx context.Context, host, id, baseDir string) bool {
+			called = true
+			return false // e.g. server change not landed yet / host unknown
+		}
+		state, err := BuildHealthcheckSetupBootstrap(context.Background(), "/cfg", "/base")
+		if err != nil {
+			t.Fatalf("bootstrap must never error even on provision failure: %v", err)
+		}
+		if !called {
+			t.Fatal("provision seam must still be attempted")
+		}
+		if state.Eligibility != HealthcheckSetupSkipIdentityUnavailable || state.HasSecret {
+			t.Fatalf("failed provisioning must stay SkipIdentityUnavailable, got %+v", state)
+		}
+	})
 }
 
 func TestClassifyHealthcheckSetupResult(t *testing.T) {

--- a/internal/orchestrator/telegram_setup_classify.go
+++ b/internal/orchestrator/telegram_setup_classify.go
@@ -76,3 +76,39 @@ func ClassifyTelegramSetupResult(res notify.TelegramRegistrationResult) Telegram
 			Message: SanitizeTelegramSetupStatusMessage(res.Status.Message)}
 	}
 }
+
+// ClassifyTelegramSetupSkip maps a NON-eligible TelegramSetupBootstrap (a skip verdict) to
+// display copy, so the dashboard can tell the user WHY pairing was not offered distinctly.
+// It mirrors ClassifyHealthcheckSetupSkip and returns the SAME shared HealthcheckSetupState
+// so the dashboard renders both twins through one path (showDaemonResultScreen). This fixes
+// the twin message-collapse bug: "disabled", "personal mode", "config error", and the two
+// identity causes no longer all read as one generic "not enabled" line. Only
+// Keyword/Level/Message are set.
+func ClassifyTelegramSetupSkip(res TelegramSetupBootstrap) HealthcheckSetupState {
+	st := HealthcheckSetupState{Level: HealthcheckSetupLevelWarn}
+	switch res.Eligibility {
+	case TelegramSetupSkipDisabled:
+		st.Keyword = "NOT ENABLED"
+		st.Message = "Telegram notifications are not enabled on this host."
+	case TelegramSetupSkipConfigError:
+		st.Level, st.Keyword = HealthcheckSetupLevelError, "CONFIG ERROR"
+		st.Message = "The configuration could not be loaded, so Telegram notifications could not be checked. Re-run the installer to repair it."
+	case TelegramSetupSkipPersonalMode:
+		st.Keyword = "PERSONAL MODE"
+		st.Message = "Telegram is set to personal-bot mode, which uses your own bot token and needs no centralized pairing check."
+	case TelegramSetupSkipIdentityUnavailable:
+		// Two distinct causes collapse here upstream: identity detection FAILED
+		// (IdentityDetectError set), or it succeeded but yielded no ServerID.
+		if res.IdentityDetectError != "" {
+			st.Keyword = "IDENTITY ERROR"
+			st.Message = "The server identity could not be read, so Telegram pairing could not be checked. Re-run the installer or regenerate the identity file."
+			return st
+		}
+		st.Keyword = "NO IDENTITY"
+		st.Message = "No server identity was found on this host, so Telegram pairing cannot be checked. Re-run the installer or regenerate the identity file."
+	default:
+		st.Keyword = "NOT CONFIGURED"
+		st.Message = "Telegram notifications are not configured on this host."
+	}
+	return st
+}

--- a/internal/orchestrator/telegram_setup_skip_test.go
+++ b/internal/orchestrator/telegram_setup_skip_test.go
@@ -1,0 +1,58 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestClassifyTelegramSetupSkip pins DISTINCT copy per Telegram skip verdict, fixing the
+// dashboard TWIN bug where every non-eligible state collapsed to one generic line.
+func TestClassifyTelegramSetupSkip(t *testing.T) {
+	cases := []struct {
+		name        string
+		res         TelegramSetupBootstrap
+		wantKeyword string
+		wantLevel   HealthcheckSetupLevel
+		wantSubstr  string
+	}{
+		{"disabled", TelegramSetupBootstrap{Eligibility: TelegramSetupSkipDisabled}, "NOT ENABLED", HealthcheckSetupLevelWarn, "not enabled"},
+		{"config-error", TelegramSetupBootstrap{Eligibility: TelegramSetupSkipConfigError, ConfigError: "boom"}, "CONFIG ERROR", HealthcheckSetupLevelError, "configuration could not be loaded"},
+		{"personal-mode", TelegramSetupBootstrap{Eligibility: TelegramSetupSkipPersonalMode}, "PERSONAL MODE", HealthcheckSetupLevelWarn, "personal-bot mode"},
+		{"identity-error", TelegramSetupBootstrap{Eligibility: TelegramSetupSkipIdentityUnavailable, IdentityDetectError: "read failed"}, "IDENTITY ERROR", HealthcheckSetupLevelWarn, "could not be read"},
+		{"no-identity", TelegramSetupBootstrap{Eligibility: TelegramSetupSkipIdentityUnavailable}, "NO IDENTITY", HealthcheckSetupLevelWarn, "No server identity"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			st := ClassifyTelegramSetupSkip(tt.res)
+			if st.Keyword != tt.wantKeyword {
+				t.Fatalf("Keyword=%q, want %q", st.Keyword, tt.wantKeyword)
+			}
+			if st.Level != tt.wantLevel {
+				t.Fatalf("Level=%d, want %d", st.Level, tt.wantLevel)
+			}
+			if !strings.Contains(st.Message, tt.wantSubstr) {
+				t.Fatalf("Message=%q, want substring %q", st.Message, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestClassifyTelegramSetupSkip_Distinct locks that the two identity causes (detect error
+// vs no ServerID) and the mode/config verdicts never render identically.
+func TestClassifyTelegramSetupSkip_Distinct(t *testing.T) {
+	states := []TelegramSetupBootstrap{
+		{Eligibility: TelegramSetupSkipDisabled},
+		{Eligibility: TelegramSetupSkipConfigError},
+		{Eligibility: TelegramSetupSkipPersonalMode},
+		{Eligibility: TelegramSetupSkipIdentityUnavailable, IdentityDetectError: "x"},
+		{Eligibility: TelegramSetupSkipIdentityUnavailable},
+	}
+	seen := map[string]bool{}
+	for _, s := range states {
+		m := ClassifyTelegramSetupSkip(s).Message
+		if seen[m] {
+			t.Fatalf("duplicate skip message: %q", m)
+		}
+		seen[m] = true
+	}
+}

--- a/internal/orchestrator/telegram_setup_skip_test.go
+++ b/internal/orchestrator/telegram_setup_skip_test.go
@@ -20,6 +20,7 @@ func TestClassifyTelegramSetupSkip(t *testing.T) {
 		{"personal-mode", TelegramSetupBootstrap{Eligibility: TelegramSetupSkipPersonalMode}, "PERSONAL MODE", HealthcheckSetupLevelWarn, "personal-bot mode"},
 		{"identity-error", TelegramSetupBootstrap{Eligibility: TelegramSetupSkipIdentityUnavailable, IdentityDetectError: "read failed"}, "IDENTITY ERROR", HealthcheckSetupLevelWarn, "could not be read"},
 		{"no-identity", TelegramSetupBootstrap{Eligibility: TelegramSetupSkipIdentityUnavailable}, "NO IDENTITY", HealthcheckSetupLevelWarn, "No server identity"},
+		{"unknown-default", TelegramSetupBootstrap{}, "NOT CONFIGURED", HealthcheckSetupLevelWarn, "not configured"},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/ui/flows/install/healthcheck.go
+++ b/internal/ui/flows/install/healthcheck.go
@@ -38,9 +38,20 @@ const (
 // daemon engine with centralized monitoring was chosen and the identity/secret
 // exist (decided by BuildHealthcheckSetupBootstrap re-reading the written config).
 func RunHealthcheckSetup(ctx context.Context, session *shell.Session, baseDir, configPath string, backToMenu bool) (installer.HealthcheckSetupResult, error) {
-	state, err := healthcheckBuildBootstrap(configPath, baseDir)
-	if err != nil {
-		return installer.HealthcheckSetupResult{}, err
+	// BuildHealthcheckSetupBootstrap can run an up-to-10s relay-secret provisioning handshake
+	// (hook c) when this centralized host has a resolved ServerID but no secret on disk yet.
+	// Run it under the SAME spinner the connection check uses so the screen shows progress
+	// instead of appearing frozen; an already-provisioned host returns instantly.
+	var state orchestrator.HealthcheckSetupBootstrap
+	var bootErr error
+	if runErr := components.RunTask(ctx, session, "Checking monitoring setup", "Reading configuration...", func(taskCtx context.Context, report func(string)) error {
+		state, bootErr = healthcheckBuildBootstrap(taskCtx, configPath, baseDir)
+		return nil
+	}); runErr != nil {
+		return installer.HealthcheckSetupResult{}, runErr
+	}
+	if bootErr != nil {
+		return installer.HealthcheckSetupResult{}, bootErr
 	}
 	result := installer.HealthcheckSetupResult{
 		HealthcheckSetupBootstrap: state,

--- a/internal/ui/flows/install/healthcheck_selfparams_test.go
+++ b/internal/ui/flows/install/healthcheck_selfparams_test.go
@@ -118,7 +118,7 @@ func TestRunHealthcheckSetupSelfBranch(t *testing.T) {
 		healthcheckSelfCheck = origSelf
 	})
 
-	healthcheckBuildBootstrap = func(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+	healthcheckBuildBootstrap = func(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 		return orchestrator.HealthcheckSetupBootstrap{
 			Eligibility:         orchestrator.HealthcheckSetupEligibleSelf,
 			HealthcheckMode:     "self",

--- a/internal/ui/flows/install/healthcheck_test.go
+++ b/internal/ui/flows/install/healthcheck_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tis24dev/proxsave/internal/uitest"
 )
 
-func healthcheckEligibleBootstrap(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+func healthcheckEligibleBootstrap(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 	return orchestrator.HealthcheckSetupBootstrap{
 		Eligibility:   orchestrator.HealthcheckSetupEligibleCentralized,
 		ServerID:      "12345678",
@@ -146,7 +146,7 @@ func TestRunHealthcheckSetup(t *testing.T) {
 		healthcheckCheck = origCheck
 	})
 
-	healthcheckBuildBootstrap = func(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+	healthcheckBuildBootstrap = func(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 		return orchestrator.HealthcheckSetupBootstrap{
 			Eligibility:   orchestrator.HealthcheckSetupEligibleCentralized,
 			ServerID:      "12345678",
@@ -213,7 +213,7 @@ func TestRunHealthcheckSetup(t *testing.T) {
 	}
 
 	// Not eligible: no screen, Shown=false.
-	healthcheckBuildBootstrap = func(configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
+	healthcheckBuildBootstrap = func(ctx context.Context, configPath, baseDir string) (orchestrator.HealthcheckSetupBootstrap, error) {
 		return orchestrator.HealthcheckSetupBootstrap{Eligibility: orchestrator.HealthcheckSetupSkipDisabled}, nil
 	}
 	notShown, err := RunHealthcheckSetup(context.Background(), d.session, t.TempDir(), "/tmp/backup.env", false)


### PR DESCRIPTION
Automated release PR for `v0.30.0-beta4`.

<!-- release-tag: v0.30.0-beta4 -->

## Summary by Sourcery

Enable automatic, Telegram-independent provisioning and self-healing of the centralized relay secret, with stronger concurrency, safety, and user messaging around monitoring and Telegram setup states.

New Features:
- Add relay secret provisioning logic used by daemon and healthcheck setup to obtain centralized monitoring credentials without Telegram pairing.
- Introduce advisory locking and guarded removal for the relay secret to coordinate concurrent provisioners and avoid deleting newly confirmed secrets.
- Expose new healthcheck and Telegram skip classifiers so CLI and dashboard can show distinct reasons when setup screens are not eligible.

Bug Fixes:
- Prevent leaking short, unmaskable relay secrets into logs by enforcing a minimum length at persist/provision time and redacting risky previews.
- Ensure a relay secret rejected by the server is cleared only when the on-disk value still matches the rejected one, avoiding races that could strand a host.

Enhancements:
- Throttle daemon relay-secret self-heal attempts and integrate provisioning into daemon startup and daemon-setup flow to avoid overloading the server and double-issuance races.
- Update healthcheck setup bootstrap, CLI, and installer flows to run provisioning under context-aware tasks and report more accurate, A-aware messages for centralized monitoring eligibility.
- Refine healthcheck and Telegram setup classification messages so configuration errors, disabled modes, identity issues, and provisioning states are clearly distinguished.

Tests:
- Add comprehensive tests for relay secret provisioning, locking, guarded removal, daemon self-heal throttling, and auth rejection handling.
- Extend healthcheck and Telegram setup tests to cover new bootstrap behavior, skip classifications, and UI/CLI integration paths.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Healthcheck setup can now automatically provision missing monitoring credentials.
  * Daemon startup self-heals missing/invalid monitoring credentials, with throttled re-provisioning to prevent repeated attempts.
  * Setup screens show clearer, more specific status messages for Telegram and backup monitoring.
  * Healthcheck setup displays a progress spinner while checking configuration.

* **Bug Fixes**
  * Prevented valid, newly-written credentials from being overwritten during auth failures; transient failures no longer clear existing credentials.
  * Rejects short/unsafe credentials and improves protection of sensitive response data.

* **Tests**
  * Expanded coverage for provisioning, recovery behavior, concurrency safety, throttling, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic relay-secret provisioning and recovery for centralized monitoring. The main changes are:

- Cross-process locking and guarded secret removal.
- Daemon and setup-flow credential self-healing.
- Throttled provisioning retries and auth-rejection handling.
- Clearer healthcheck and Telegram setup messages.
- Expanded provisioning, concurrency, and setup tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The setup and daemon paths now reload the secret after provisioning, including when another process wrote it first.
- Secret deletion checks the rejected value under the shared lock before removing it.
- No blocking issues remain in the changed code.



<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/healthcheck_setup_bootstrap.go | Reloads the relay secret after provisioning so setup adopts credentials written by another process. |
| cmd/proxsave/daemon.go | Adds throttled credential provisioning, guarded auth recovery, and centralized reporter self-healing. |
| internal/notify/relay_provision.go | Adds a locked issue, persist, and confirm flow for relay credentials. |
| internal/identity/identity.go | Adds secret locking, minimum-length validation, and compare-before-delete helpers. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/notify/relay_provision.go`, line 941-946 ([link](https://github.com/tis24dev/proxsave/blob/7260e504b5080faa84123bf53fe2bfdceb13d2a8/internal/notify/relay_provision.go#L941-L946)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed Confirmation Is Never Retried**

   When confirmation fails after persistence, this returns success and leaves the credential on disk. Later provisioning attempts take the existing-secret branch before calling confirmation, so an unconfirmed registration is never repaired; if the server permits another issuance for that ServerID, the retained credential can be invalidated and centralized monitoring stops authenticating.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fnotify%2Frelay_provision.go%0ALine%3A%20941-946%0A%0AComment%3A%0A**Failed%20Confirmation%20Is%20Never%20Retried**%0A%0AWhen%20confirmation%20fails%20after%20persistence%2C%20this%20returns%20success%20and%20leaves%20the%20credential%20on%20disk.%20Later%20provisioning%20attempts%20take%20the%20existing-secret%20branch%20before%20calling%20confirmation%2C%20so%20an%20unconfirmed%20registration%20is%20never%20repaired%3B%20if%20the%20server%20permits%20another%20issuance%20for%20that%20ServerID%2C%20the%20retained%20credential%20can%20be%20invalidated%20and%20centralized%20monitoring%20stops%20authenticating.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=271&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fnotify%2Frelay_provision.go%0ALine%3A%20941-946%0A%0AComment%3A%0A**Failed%20Confirmation%20Is%20Never%20Retried**%0A%0AWhen%20confirmation%20fails%20after%20persistence%2C%20this%20returns%20success%20and%20leaves%20the%20credential%20on%20disk.%20Later%20provisioning%20attempts%20take%20the%20existing-secret%20branch%20before%20calling%20confirmation%2C%20so%20an%20unconfirmed%20registration%20is%20never%20repaired%3B%20if%20the%20server%20permits%20another%20issuance%20for%20that%20ServerID%2C%20the%20retained%20credential%20can%20be%20invalidated%20and%20centralized%20monitoring%20stops%20authenticating.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=271&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Fproxsave%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fnotify%2Frelay_provision.go%0ALine%3A%20941-946%0A%0AComment%3A%0A**Failed%20Confirmation%20Is%20Never%20Retried**%0A%0AWhen%20confirmation%20fails%20after%20persistence%2C%20this%20returns%20success%20and%20leaves%20the%20credential%20on%20disk.%20Later%20provisioning%20attempts%20take%20the%20existing-secret%20branch%20before%20calling%20confirmation%2C%20so%20an%20unconfirmed%20registration%20is%20never%20repaired%3B%20if%20the%20server%20permits%20another%20issuance%20for%20that%20ServerID%2C%20the%20retained%20credential%20can%20be%20invalidated%20and%20centralized%20monitoring%20stops%20authenticating.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Fproxsave&pr=271&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["test(healthcheck): cover skip-verdict ma..."](https://github.com/tis24dev/proxsave/commit/29f6106e8d00651deda874e7efce3a640983e190) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45775429)</sub>

<!-- /greptile_comment -->