### PR TITLE
Release v0.30.0-beta5

### DIFF
--- a/cmd/proxsave/main_identity.go
+++ b/cmd/proxsave/main_identity.go
@@ -76,6 +76,15 @@ func checkTelegramServerStatus(rt *appRuntime) (string, bool) {
 		rt.cfg.TelegramEnabled = false
 		return status.Message, false
 	}
-	logging.Debug("Remote server contacted: Bot token / chat ID verified (handshake)")
+	// Error == nil means a 200: Telegram stays ENABLED. That is correct even for a
+	// relay-only (chat-less) host -- centralized monitoring works without a chat, and
+	// the relay path is ready the moment the user links one. status.Message already
+	// carries the distinct "200 - Relay provisioned (no Telegram chat)" line into the
+	// "Server Telegram: %s" boot log; add a clearer debug line for the chat-less case.
+	if status.Code == 200 && status.LinkState == notify.TelegramLinkStateRelayOnly {
+		logging.Debug("Remote server contacted: relay provisioned, no Telegram chat bound yet (monitoring works; link a chat in the bot to receive messages)")
+	} else {
+		logging.Debug("Remote server contacted: Bot token / chat ID verified (handshake)")
+	}
 	return status.Message, true
 }

--- a/cmd/proxsave/main_runtime.go
+++ b/cmd/proxsave/main_runtime.go
@@ -67,26 +67,37 @@ func redetectHostBackupEnvironment(rt *appRuntime) {
 		return
 	}
 
-	// DetectWith returns an error only when the type is unknown; that condition is
-	// handled below and its message is subsumed by the specific warning, so the
-	// error value itself is not needed here.
-	info, _ := environment.DetectWith(environment.DetectOptions{RootPrefix: prefix})
-	if info == nil || info.Type == types.ProxmoxUnknown {
-		// The type stays unknown: keep the pre-config detection and, only when the
-		// operator explicitly opted into host-backup mode, surface a single warning
-		// (a plain prefix run, e.g. chroot/snapshot/CI, must not be spammed). The
-		// generic DetectWith error is subsumed by this message, so it is not logged
-		// separately.
-		if rt.cfg.HostBackupMode {
-			rt.bootstrap.Warning("WARNING: no Proxmox host detected under SYSTEM_ROOT_PREFIX=%s; the host filesystem may not be mounted", prefix)
+	// Under a prefix the container ProxSave runs in is NOT the backup target: the
+	// target is the Proxmox host mounted under the prefix. DetectHostUnderPrefix uses
+	// ONLY the re-anchored filesystem markers (the same ones bare-metal PVE/PBS
+	// detection uses; host command probes are skipped) and never returns nil or a
+	// live-container type. Its result REPLACES envInfo unconditionally, so the
+	// pre-config live-container type can never survive a prefix run and mislabel a
+	// hollow archive as a valid backup.
+	liveType := types.ProxmoxUnknown
+	if rt.envInfo != nil {
+		liveType = rt.envInfo.Type
+	}
+	info := environment.DetectHostUnderPrefix(prefix)
+	rt.envInfo = info
+
+	if info.Type == types.ProxmoxUnknown {
+		// Fail closed: PVE/PBS collectors are skipped and the manifest records
+		// "unknown" instead of a false type over an empty tree. Warn when the
+		// operator signaled host intent: either HOST_BACKUP_MODE is set, or the live
+		// system itself IS a Proxmox (a Proxmox host/container pointed at a prefix
+		// with no Proxmox under it is a mis-mount). A plain prefix run
+		// (chroot/snapshot/CI) on a non-Proxmox live system stays quiet to avoid spam.
+		switch {
+		case rt.cfg.HostBackupMode:
+			rt.bootstrap.Warning("WARNING: no Proxmox host detected under SYSTEM_ROOT_PREFIX=%s; the host filesystem may not be mounted (archive labeled unknown)", prefix)
+		case liveType.SupportsPVE() || liveType.SupportsPBS():
+			rt.bootstrap.Warning("WARNING: %s detected on the live system but none under SYSTEM_ROOT_PREFIX=%s; the host filesystem may not be mounted (archive labeled unknown)", liveType, prefix)
+		default:
+			rt.bootstrap.Debug("no Proxmox detected under SYSTEM_ROOT_PREFIX=%s; archive labeled unknown", prefix)
 		}
 		return
 	}
-
-	// A detected type is a strict correctness improvement for any prefix run, so the
-	// envInfo is overwritten regardless of the flag. Only the framing (banner label
-	// and the pmxcfs mount-shape warning) is host-backup specific.
-	rt.envInfo = info
 	if rt.cfg.HostBackupMode {
 		rt.bootstrap.Printf("✓ Proxmox Type (host-backup mode, %s): %s", prefix, info.Type)
 	} else {

--- a/cmd/proxsave/main_runtime.go
+++ b/cmd/proxsave/main_runtime.go
@@ -50,6 +50,56 @@ func detectAndPrintEnvironment(bootstrap *logging.BootstrapLogger) *environment.
 	return envInfo
 }
 
+// redetectHostBackupEnvironment re-runs Proxmox detection under SYSTEM_ROOT_PREFIX
+// once config is loaded, so an HA-LXC backup appliance reports the mounted host
+// (issue #255) rather than the container the pre-config best-effort detection saw.
+// The corrected envInfo is what reaches the collector, backup phases, stats and the
+// archive manifest, and detection must run before collection (a ProxmoxUnknown type
+// skips all PVE/PBS collection and silently under-restores), so it is fixed here
+// before any of those consume it. A non-empty prefix alone drives this; the
+// HOST_BACKUP_MODE flag is not required for the detection correctness fix.
+func redetectHostBackupEnvironment(rt *appRuntime) {
+	prefix := strings.TrimSpace(rt.cfg.SystemRootPrefix)
+	if prefix == "" || prefix == string(filepath.Separator) {
+		if rt.cfg.HostBackupMode {
+			rt.bootstrap.Warning("WARNING: HOST_BACKUP_MODE is set but SYSTEM_ROOT_PREFIX is empty; host-backup mode has no effect")
+		}
+		return
+	}
+
+	info, err := environment.DetectWith(environment.DetectOptions{RootPrefix: prefix})
+	if err != nil {
+		rt.bootstrap.Warning("WARNING: host-backup detection under %s: %v", prefix, err)
+	}
+	if info == nil || info.Type == types.ProxmoxUnknown {
+		rt.bootstrap.Warning("WARNING: no Proxmox host detected under SYSTEM_ROOT_PREFIX=%s; the host filesystem may not be mounted", prefix)
+		warnHostBackupMountShape(rt, prefix)
+		return
+	}
+
+	rt.envInfo = info
+	rt.bootstrap.Printf("✓ Proxmox Type (host-backup mode, %s): %s", prefix, info.Type)
+	if info.Type == types.ProxmoxDual {
+		rt.bootstrap.Printf("  PVE Version: %s", info.PVEVersion)
+		rt.bootstrap.Printf("  PBS Version: %s", info.PBSVersion)
+	} else {
+		rt.bootstrap.Printf("  Version: %s", info.Version)
+	}
+	rt.bootstrap.Println("")
+	warnHostBackupMountShape(rt, prefix)
+}
+
+// warnHostBackupMountShape surfaces the most likely host-backup misconfiguration:
+// the host root is mounted (mp0) but the pmxcfs bind (mp1 /etc/pve) is not, so
+// cluster and Ceph configuration would be silently missing. It only warns; a
+// partial mount never fails the backup.
+func warnHostBackupMountShape(rt *appRuntime, prefix string) {
+	pvePath := filepath.Join(prefix, "etc", "pve")
+	if info, err := os.Stat(pvePath); err != nil || !info.IsDir() {
+		rt.bootstrap.Warning("WARNING: %s is not present; the /etc/pve bind mount may be missing (cluster and Ceph config will be incomplete)", pvePath)
+	}
+}
+
 func bootstrapRuntime(ctx context.Context, args *cli.Args, bootstrap *logging.BootstrapLogger, envInfo *environment.EnvironmentInfo, toolVersion string) (*appRuntime, int, bool) {
 	rt := &appRuntime{
 		ctx:              ctx,
@@ -66,6 +116,7 @@ func bootstrapRuntime(ctx context.Context, args *cli.Args, bootstrap *logging.Bo
 		return nil, exitCode, false
 	}
 	rt.cfg = cfg
+	redetectHostBackupEnvironment(rt)
 	rt.initialEnvBaseDir = initialEnvBaseDir
 	rt.autoBaseDirFound = autoFound
 	rt.dryRun = args.DryRun || cfg.DryRun

--- a/cmd/proxsave/main_runtime.go
+++ b/cmd/proxsave/main_runtime.go
@@ -67,18 +67,31 @@ func redetectHostBackupEnvironment(rt *appRuntime) {
 		return
 	}
 
-	info, err := environment.DetectWith(environment.DetectOptions{RootPrefix: prefix})
-	if err != nil {
-		rt.bootstrap.Warning("WARNING: host-backup detection under %s: %v", prefix, err)
-	}
+	// DetectWith returns an error only when the type is unknown; that condition is
+	// handled below and its message is subsumed by the specific warning, so the
+	// error value itself is not needed here.
+	info, _ := environment.DetectWith(environment.DetectOptions{RootPrefix: prefix})
 	if info == nil || info.Type == types.ProxmoxUnknown {
-		rt.bootstrap.Warning("WARNING: no Proxmox host detected under SYSTEM_ROOT_PREFIX=%s; the host filesystem may not be mounted", prefix)
-		warnHostBackupMountShape(rt, prefix)
+		// The type stays unknown: keep the pre-config detection and, only when the
+		// operator explicitly opted into host-backup mode, surface a single warning
+		// (a plain prefix run, e.g. chroot/snapshot/CI, must not be spammed). The
+		// generic DetectWith error is subsumed by this message, so it is not logged
+		// separately.
+		if rt.cfg.HostBackupMode {
+			rt.bootstrap.Warning("WARNING: no Proxmox host detected under SYSTEM_ROOT_PREFIX=%s; the host filesystem may not be mounted", prefix)
+		}
 		return
 	}
 
+	// A detected type is a strict correctness improvement for any prefix run, so the
+	// envInfo is overwritten regardless of the flag. Only the framing (banner label
+	// and the pmxcfs mount-shape warning) is host-backup specific.
 	rt.envInfo = info
-	rt.bootstrap.Printf("✓ Proxmox Type (host-backup mode, %s): %s", prefix, info.Type)
+	if rt.cfg.HostBackupMode {
+		rt.bootstrap.Printf("✓ Proxmox Type (host-backup mode, %s): %s", prefix, info.Type)
+	} else {
+		rt.bootstrap.Printf("✓ Proxmox Type (prefix %s): %s", prefix, info.Type)
+	}
 	if info.Type == types.ProxmoxDual {
 		rt.bootstrap.Printf("  PVE Version: %s", info.PVEVersion)
 		rt.bootstrap.Printf("  PBS Version: %s", info.PBSVersion)
@@ -86,14 +99,22 @@ func redetectHostBackupEnvironment(rt *appRuntime) {
 		rt.bootstrap.Printf("  Version: %s", info.Version)
 	}
 	rt.bootstrap.Println("")
-	warnHostBackupMountShape(rt, prefix)
+	warnHostBackupMountShape(rt, prefix, info.Type)
 }
 
 // warnHostBackupMountShape surfaces the most likely host-backup misconfiguration:
 // the host root is mounted (mp0) but the pmxcfs bind (mp1 /etc/pve) is not, so
 // cluster and Ceph configuration would be silently missing. It only warns; a
-// partial mount never fails the backup.
-func warnHostBackupMountShape(rt *appRuntime, prefix string) {
+// partial mount never fails the backup. It applies only to host-backup mode on a
+// PVE or dual host: PBS has no /etc/pve, and a plain prefix (snapshot/chroot) has
+// no bind mount to be missing, so neither is warned about.
+func warnHostBackupMountShape(rt *appRuntime, prefix string, detected types.ProxmoxType) {
+	if !rt.cfg.HostBackupMode {
+		return
+	}
+	if detected != types.ProxmoxVE && detected != types.ProxmoxDual {
+		return
+	}
 	pvePath := filepath.Join(prefix, "etc", "pve")
 	if info, err := os.Stat(pvePath); err != nil || !info.IsDir() {
 		rt.bootstrap.Warning("WARNING: %s is not present; the /etc/pve bind mount may be missing (cluster and Ceph config will be incomplete)", pvePath)

--- a/cmd/proxsave/main_runtime_hostbackup_test.go
+++ b/cmd/proxsave/main_runtime_hostbackup_test.go
@@ -48,10 +48,10 @@ func writeHBFile(t *testing.T, path, content string) {
 // but still gets the corrected detection type (issue #255 backward compatibility).
 func TestRedetectPlainPrefixNeutralFraming(t *testing.T) {
 	root := t.TempDir()
+	// PVE is detected from the version file; /etc/pve is intentionally NOT created,
+	// so this also pins the warnHostBackupMountShape HostBackupMode guard: a plain
+	// prefix with a missing /etc/pve must still produce no bind-mount warning.
 	writeHBFile(t, filepath.Join(root, "etc/pve-manager/version"), "8.2.2\n")
-	if err := os.MkdirAll(filepath.Join(root, "etc/pve"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	out, info := runRedetect(t, root, false)
 	if info.Type != types.ProxmoxVE {

--- a/cmd/proxsave/main_runtime_hostbackup_test.go
+++ b/cmd/proxsave/main_runtime_hostbackup_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/tis24dev/proxsave/internal/types"
 )
 
-// runRedetect drives redetectHostBackupEnvironment with a mirrored bootstrap
-// logger and returns everything it printed plus the resulting envInfo.
-func runRedetect(t *testing.T, prefix string, hostBackup bool) (string, *environment.EnvironmentInfo) {
+// runRedetectWithLive drives redetectHostBackupEnvironment with a mirrored
+// bootstrap logger, seeding the pre-config live-container type, and returns
+// everything it printed plus the resulting envInfo. Seeding a non-Unknown live type
+// is what exposes the retain-live-type leak: a prefix run must overwrite it.
+func runRedetectWithLive(t *testing.T, prefix string, hostBackup bool, liveType types.ProxmoxType) (string, *environment.EnvironmentInfo) {
 	t.Helper()
 	boot := logging.NewBootstrapLogger()
 	boot.SetConsoleQuiet(true)
@@ -27,10 +29,17 @@ func runRedetect(t *testing.T, prefix string, hostBackup bool) (string, *environ
 	rt := &appRuntime{
 		bootstrap: boot,
 		cfg:       &config.Config{SystemRootPrefix: prefix, HostBackupMode: hostBackup},
-		envInfo:   &environment.EnvironmentInfo{Type: types.ProxmoxUnknown},
+		envInfo:   &environment.EnvironmentInfo{Type: liveType},
 	}
 	redetectHostBackupEnvironment(rt)
 	return buf.String(), rt.envInfo
+}
+
+// runRedetect is the common case: the live type is unknown (no Proxmox seen in the
+// container) and only the prefix detection matters.
+func runRedetect(t *testing.T, prefix string, hostBackup bool) (string, *environment.EnvironmentInfo) {
+	t.Helper()
+	return runRedetectWithLive(t, prefix, hostBackup, types.ProxmoxUnknown)
 }
 
 func writeHBFile(t *testing.T, path, content string) {
@@ -114,5 +123,70 @@ func TestRedetectHostBackupWithoutPrefixWarns(t *testing.T) {
 	out, _ := runRedetect(t, "", true)
 	if !strings.Contains(out, "SYSTEM_ROOT_PREFIX is empty") {
 		t.Fatalf("expected an empty-prefix warning, got:\n%s", out)
+	}
+}
+
+// TestRedetectFailedPrefixNeverRetainsLivePVE is the greptile-P1 regression: a live
+// PVE system whose prefix has no Proxmox markers must NOT keep the live PVE type
+// (which would ship a hollow archive labeled valid PVE). It must fail closed to
+// Unknown, and since the live system is a Proxmox this is a mis-mount, so it warns
+// even without HOST_BACKUP_MODE.
+func TestRedetectFailedPrefixNeverRetainsLivePVE(t *testing.T) {
+	root := t.TempDir() // empty: no Proxmox markers under the prefix
+
+	out, info := runRedetectWithLive(t, root, false, types.ProxmoxVE)
+	if info.Type != types.ProxmoxUnknown {
+		t.Fatalf("envInfo.Type = %v, want ProxmoxUnknown (must not retain the live PVE type)", info.Type)
+	}
+	if !strings.Contains(strings.ToUpper(out), "WARNING") || !strings.Contains(out, "detected on the live system") {
+		t.Fatalf("expected a mis-mount warning without HOST_BACKUP_MODE, got:\n%s", out)
+	}
+}
+
+// TestRedetectFailedPrefixHostBackupFailsClosedAndWarns: host-backup mode with a
+// prefix that has no host mounted fails closed to Unknown and warns, with no PVE
+// banner.
+func TestRedetectFailedPrefixHostBackupFailsClosedAndWarns(t *testing.T) {
+	root := t.TempDir()
+
+	out, info := runRedetectWithLive(t, root, true, types.ProxmoxVE)
+	if info.Type != types.ProxmoxUnknown {
+		t.Fatalf("envInfo.Type = %v, want ProxmoxUnknown", info.Type)
+	}
+	if !strings.Contains(out, "host filesystem may not be mounted") {
+		t.Fatalf("expected the not-mounted warning, got:\n%s", out)
+	}
+	if strings.Contains(out, "✓ Proxmox Type") {
+		t.Fatalf("failed detection must not print a type banner, got:\n%s", out)
+	}
+}
+
+// TestRedetectFailedPrefixPlainStaysQuiet is the no-spam contract: a non-Proxmox
+// live system (plain chroot/snapshot/CI) with an empty prefix and no
+// HOST_BACKUP_MODE fails closed to Unknown quietly, emitting neither warning
+// message (asserted on the message fragments rather than the "WARNING" level tag,
+// since the interpolated prefix path echoes the test name).
+func TestRedetectFailedPrefixPlainStaysQuiet(t *testing.T) {
+	root := t.TempDir()
+
+	out, info := runRedetectWithLive(t, root, false, types.ProxmoxUnknown)
+	if info.Type != types.ProxmoxUnknown {
+		t.Fatalf("envInfo.Type = %v, want ProxmoxUnknown", info.Type)
+	}
+	if strings.Contains(out, "may not be mounted") || strings.Contains(out, "detected on the live system") {
+		t.Fatalf("a plain prefix on a non-Proxmox host must not warn, got:\n%s", out)
+	}
+}
+
+// TestRedetectFailedPrefixNeverRetainsLivePBS mirrors the PVE regression for PBS.
+func TestRedetectFailedPrefixNeverRetainsLivePBS(t *testing.T) {
+	root := t.TempDir()
+
+	out, info := runRedetectWithLive(t, root, false, types.ProxmoxBS)
+	if info.Type != types.ProxmoxUnknown {
+		t.Fatalf("envInfo.Type = %v, want ProxmoxUnknown (must not retain the live PBS type)", info.Type)
+	}
+	if !strings.Contains(strings.ToUpper(out), "WARNING") || !strings.Contains(out, "detected on the live system") {
+		t.Fatalf("expected a mis-mount warning, got:\n%s", out)
 	}
 }

--- a/cmd/proxsave/main_runtime_hostbackup_test.go
+++ b/cmd/proxsave/main_runtime_hostbackup_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/environment"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// runRedetect drives redetectHostBackupEnvironment with a mirrored bootstrap
+// logger and returns everything it printed plus the resulting envInfo.
+func runRedetect(t *testing.T, prefix string, hostBackup bool) (string, *environment.EnvironmentInfo) {
+	t.Helper()
+	boot := logging.NewBootstrapLogger()
+	boot.SetConsoleQuiet(true)
+	buf := &bytes.Buffer{}
+	mirror := logging.New(types.LogLevelDebug, false)
+	mirror.SetOutput(buf)
+	boot.SetMirrorLogger(mirror)
+
+	rt := &appRuntime{
+		bootstrap: boot,
+		cfg:       &config.Config{SystemRootPrefix: prefix, HostBackupMode: hostBackup},
+		envInfo:   &environment.EnvironmentInfo{Type: types.ProxmoxUnknown},
+	}
+	redetectHostBackupEnvironment(rt)
+	return buf.String(), rt.envInfo
+}
+
+func writeHBFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRedetectPlainPrefixNeutralFraming: an existing SYSTEM_ROOT_PREFIX user with
+// no HOST_BACKUP_MODE gets a neutral banner, no host-backup framing, no warning,
+// but still gets the corrected detection type (issue #255 backward compatibility).
+func TestRedetectPlainPrefixNeutralFraming(t *testing.T) {
+	root := t.TempDir()
+	writeHBFile(t, filepath.Join(root, "etc/pve-manager/version"), "8.2.2\n")
+	if err := os.MkdirAll(filepath.Join(root, "etc/pve"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out, info := runRedetect(t, root, false)
+	if info.Type != types.ProxmoxVE {
+		t.Fatalf("envInfo.Type = %v, want ProxmoxVE (detection must still be corrected)", info.Type)
+	}
+	if !strings.Contains(out, "(prefix ") {
+		t.Fatalf("expected a neutral 'prefix' banner, got:\n%s", out)
+	}
+	if strings.Contains(out, "host-backup mode") {
+		t.Fatalf("plain prefix must not be framed as host-backup mode, got:\n%s", out)
+	}
+	if strings.Contains(strings.ToUpper(out), "WARNING") {
+		t.Fatalf("plain prefix must not warn, got:\n%s", out)
+	}
+}
+
+// TestRedetectPBSHostBackupNoPveWarning: a PBS host in host-backup mode gets the
+// host-backup banner but no /etc/pve mount-shape warning (PBS has no /etc/pve).
+func TestRedetectPBSHostBackupNoPveWarning(t *testing.T) {
+	root := t.TempDir()
+	writeHBFile(t, filepath.Join(root, "etc/proxmox-backup/version"), "3.2.1\n")
+
+	out, info := runRedetect(t, root, true)
+	if info.Type != types.ProxmoxBS {
+		t.Fatalf("envInfo.Type = %v, want ProxmoxBS", info.Type)
+	}
+	if !strings.Contains(out, "host-backup mode") {
+		t.Fatalf("expected host-backup framing, got:\n%s", out)
+	}
+	if strings.Contains(out, "/etc/pve") {
+		t.Fatalf("PBS host must not get an /etc/pve warning, got:\n%s", out)
+	}
+}
+
+// TestRedetectVEHostBackupMissingPveWarnsOnce: a VE host in host-backup mode whose
+// /etc/pve bind is missing gets exactly one mount-shape warning.
+func TestRedetectVEHostBackupMissingPveWarnsOnce(t *testing.T) {
+	root := t.TempDir()
+	// PVE detected via the version file; the /etc/pve directory is intentionally absent.
+	writeHBFile(t, filepath.Join(root, "etc/pve-manager/version"), "8.2.2\n")
+
+	out, info := runRedetect(t, root, true)
+	if info.Type != types.ProxmoxVE {
+		t.Fatalf("envInfo.Type = %v, want ProxmoxVE", info.Type)
+	}
+	if !strings.Contains(out, "host-backup mode") {
+		t.Fatalf("expected host-backup framing, got:\n%s", out)
+	}
+	if !strings.Contains(out, "/etc/pve") || !strings.Contains(out, "bind mount") {
+		t.Fatalf("expected the /etc/pve bind-mount warning, got:\n%s", out)
+	}
+	if got := strings.Count(out, "bind mount may be missing"); got != 1 {
+		t.Fatalf("expected exactly one mount-shape warning, got %d:\n%s", got, out)
+	}
+}
+
+// TestRedetectHostBackupWithoutPrefixWarns: HOST_BACKUP_MODE with no prefix warns
+// that it has no effect.
+func TestRedetectHostBackupWithoutPrefixWarns(t *testing.T) {
+	out, _ := runRedetect(t, "", true)
+	if !strings.Contains(out, "SYSTEM_ROOT_PREFIX is empty") {
+		t.Fatalf("expected an empty-prefix warning, got:\n%s", out)
+	}
+}

--- a/cmd/proxsave/testdata/install_characterization/edit_noop.env
+++ b/cmd/proxsave/testdata/install_characterization/edit_noop.env
@@ -386,6 +386,7 @@ BACKUP_ROOT_HOME=true
 BACKUP_SCRIPT_REPOSITORY=false
 BACKUP_CONFIG_FILE=true        # Include this backup.env configuration file in the backup
 SYSTEM_ROOT_PREFIX=            # Optional: override system root (e.g. chroot/test fixture). Empty or "/" = real root.
+HOST_BACKUP_MODE=false         # HA-LXC appliance backing up a host mounted read-only at SYSTEM_ROOT_PREFIX (issue #255). No effect without a prefix.
 
 # ----------------------------------------------------------------------
 # Custom paths / blacklist

--- a/cmd/proxsave/testdata/install_characterization/fresh_decline_all.env
+++ b/cmd/proxsave/testdata/install_characterization/fresh_decline_all.env
@@ -386,6 +386,7 @@ BACKUP_ROOT_HOME=true
 BACKUP_SCRIPT_REPOSITORY=false
 BACKUP_CONFIG_FILE=true        # Include this backup.env configuration file in the backup
 SYSTEM_ROOT_PREFIX=            # Optional: override system root (e.g. chroot/test fixture). Empty or "/" = real root.
+HOST_BACKUP_MODE=false         # HA-LXC appliance backing up a host mounted read-only at SYSTEM_ROOT_PREFIX (issue #255). No effect without a prefix.
 
 # ----------------------------------------------------------------------
 # Custom paths / blacklist

--- a/cmd/proxsave/testdata/install_characterization/fresh_enable_all.env
+++ b/cmd/proxsave/testdata/install_characterization/fresh_enable_all.env
@@ -386,6 +386,7 @@ BACKUP_ROOT_HOME=true
 BACKUP_SCRIPT_REPOSITORY=false
 BACKUP_CONFIG_FILE=true        # Include this backup.env configuration file in the backup
 SYSTEM_ROOT_PREFIX=            # Optional: override system root (e.g. chroot/test fixture). Empty or "/" = real root.
+HOST_BACKUP_MODE=false         # HA-LXC appliance backing up a host mounted read-only at SYSTEM_ROOT_PREFIX (issue #255). No effect without a prefix.
 
 # ----------------------------------------------------------------------
 # Custom paths / blacklist

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1204,11 +1204,16 @@ PBS_DATASTORE_PATH=                # e.g., "/mnt/pbs1,/mnt/pbs2"
 # System root override (testing/chroot)
 SYSTEM_ROOT_PREFIX=                # Optional alternate root for system collection. Empty or "/" = real root.
 # Use this to point the collector at a chroot/test fixture without touching the host FS.
+
+# HA-LXC host-backup mode (issue #255)
+HOST_BACKUP_MODE=false             # Appliance backing up a host mounted read-only at SYSTEM_ROOT_PREFIX. No effect without a prefix.
 ```
 
 **Note**: `${PVE_CONFIG_PATH}` (and other `${VAR}` references) are resolved from the same `backup.env` file too, so you do not need to `export` them.
 
 **Use case**: Working with mounted snapshots or mirrors at non-standard paths.
+
+**HA-LXC appliance (`HOST_BACKUP_MODE`)**: run ProxSave inside a privileged LXC that backs up the Proxmox host bind-mounted read-only. A non-empty `SYSTEM_ROOT_PREFIX` already makes Proxmox detection and absolute-symlink resolution prefix-aware. `HOST_BACKUP_MODE=true` additionally frames the run as a host-backup appliance and enables the ZFS inventory, which reports the host pools accurately because a privileged LXC shares the host kernel. Namespace-scoped and cluster-daemon commands (udevadm, ethtool, pvesh, ceph) stay skipped under a prefix because they would describe the container, not the host; their data is collected from the host files instead. Symlink targets are stored verbatim, so a backup taken this way restores onto a real host unchanged.
 
 ### System Collectors
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1215,6 +1215,8 @@ HOST_BACKUP_MODE=false             # Appliance backing up a host mounted read-on
 
 **HA-LXC appliance (`HOST_BACKUP_MODE`)**: run ProxSave inside a privileged LXC that backs up the Proxmox host bind-mounted read-only. A non-empty `SYSTEM_ROOT_PREFIX` already makes Proxmox detection and absolute-symlink resolution prefix-aware. `HOST_BACKUP_MODE=true` additionally frames the run as a host-backup appliance and enables the ZFS inventory, which reports the host pools accurately because a privileged LXC shares the host kernel. Namespace-scoped and cluster-daemon commands (udevadm, ethtool, pvesh, ceph) stay skipped under a prefix because they would describe the container, not the host; their data is collected from the host files instead. Symlink targets are stored verbatim, so a backup taken this way restores onto a real host unchanged.
 
+Set `HOST_BACKUP_MODE=true` only in a privileged LXC that shares the host `/dev/zfs` and owns no independent ZFS pools of its own, otherwise the ZFS inventory could record the container's pools as the host's. The host network inventory relies on the host `/sys/class/net`, so it is only complete if the host sysfs is carried under the prefix (a plain non-recursive bind of `/` does not carry it); when it is absent ProxSave logs that the host sysfs is not available rather than reporting container interfaces.
+
 ### System Collectors
 
 ```bash

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -903,6 +903,40 @@ SYSTEM_ROOT_PREFIX=/mnt/snapshot-root proxsave
 
 ---
 
+## HA-LXC Backup Appliance (`HOST_BACKUP_MODE`)
+
+**Scenario**: Run ProxSave inside a privileged LXC that backs up the Proxmox host, with the host filesystem bind-mounted read-only into the container (issue #255).
+
+**Use case**:
+- A dedicated, restartable backup appliance for a Proxmox VE or PBS host
+- Keeping ProxSave and its dependencies out of the host root
+
+### Setup Steps
+
+```bash
+# 1) On the Proxmox host, bind-mount the host root and pmxcfs read-only into the CT
+pct set <CTID> -mp0 /,mp=/host,ro=1
+pct set <CTID> -mp1 /etc/pve,mp=/host/etc/pve,ro=1
+
+# 2) In the container's configs/backup.env
+SYSTEM_ROOT_PREFIX=/host
+HOST_BACKUP_MODE=true
+BACKUP_ENABLED=true
+
+# 3) Dry-run, then run
+proxsave --dry-run
+proxsave
+```
+
+### Expected Results
+- Proxmox type is detected from the mounted host (`/host/etc/pve`, `/host/etc/proxmox-backup`), not the container.
+- Absolute symlinks such as `/etc/ceph/ceph.conf -> /etc/pve/ceph.conf` resolve under the prefix, so Ceph configuration is collected.
+- ZFS pool state is collected (shared kernel); namespace-scoped and cluster-daemon commands (udevadm, ethtool, pvesh, ceph) are skipped and their data comes from the host files.
+- Symlink targets are stored verbatim, so the archive restores onto a real host unchanged.
+- No writes to the host filesystem.
+
+---
+
 ## Example 10: Dual PVE+PBS Host
 
 **Scenario**: A single node runs both Proxmox VE and Proxmox Backup Server.

--- a/install.sh
+++ b/install.sh
@@ -217,6 +217,24 @@ mv proxsave "${TARGET_BIN}"
 chmod 755 "${TARGET_BIN}"
 
 ###############################################
+# 12b) HA-LXC host-backup hint (issue #255)
+###############################################
+# When the Proxmox host root is bind-mounted read-only into this container, offer
+# the SYSTEM_ROOT_PREFIX + HOST_BACKUP_MODE configuration. Informational only: it
+# never writes config, so it is safe and idempotent.
+if grep -qE '[[:space:]]/host[[:space:]]' /proc/mounts 2>/dev/null; then
+  echo "--------------------------------------------"
+  echo "Detected a /host mount: this looks like an HA-LXC backup appliance."
+  echo "To back up the Proxmox host, set in backup.env:"
+  echo "  SYSTEM_ROOT_PREFIX=/host"
+  echo "  HOST_BACKUP_MODE=true"
+  echo "The host is expected to be mounted read-only, for example:"
+  echo "  pct set <CTID> -mp0 /,mp=/host,ro=1"
+  echo "  pct set <CTID> -mp1 /etc/pve,mp=/host/etc/pve,ro=1"
+  echo "--------------------------------------------"
+fi
+
+###############################################
 # 13) Run internal installer (--install or --new-install)
 ###############################################
 cd "${TARGET_DIR}"

--- a/internal/backup/collector.go
+++ b/internal/backup/collector.go
@@ -235,6 +235,7 @@ type CollectorConfig struct {
 	BackupScriptRepository  bool
 	BackupConfigFile        bool
 	SystemRootPrefix        string
+	HostBackupMode          bool
 
 	// PXAR scanning tuning
 	PxarDatastoreConcurrency int

--- a/internal/backup/collector_host_command_gate_test.go
+++ b/internal/backup/collector_host_command_gate_test.go
@@ -1,0 +1,52 @@
+package backup
+
+import "testing"
+
+func TestShouldRunHostCommandsUnderPrefix(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		want   bool
+	}{
+		{"real root empty", "", true},
+		{"real root slash", "/", true},
+		{"host prefix", "/host", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Collector{config: &CollectorConfig{SystemRootPrefix: tc.prefix}}
+			if got := c.shouldRunHostCommands(); got != tc.want {
+				t.Fatalf("shouldRunHostCommands(%q) = %v, want %v", tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldRunKernelSharedCommands: ZFS is global kernel state, so it runs on a
+// real root always, and under a prefix only when HOST_BACKUP_MODE is set. The
+// namespace-scoped gate (shouldRunHostCommands) stays off under any prefix.
+func TestShouldRunKernelSharedCommands(t *testing.T) {
+	cases := []struct {
+		name       string
+		prefix     string
+		hostBackup bool
+		want       bool
+	}{
+		{"real root", "", false, true},
+		{"prefix without flag", "/host", false, false},
+		{"prefix with flag", "/host", true, true},
+		{"flag without prefix", "", true, true}, // real root already returns true
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Collector{config: &CollectorConfig{SystemRootPrefix: tc.prefix, HostBackupMode: tc.hostBackup}}
+			if got := c.shouldRunKernelSharedCommands(); got != tc.want {
+				t.Fatalf("shouldRunKernelSharedCommands = %v, want %v", got, tc.want)
+			}
+			// The namespace-scoped gate must never be flipped on by the flag.
+			if tc.prefix != "" && tc.prefix != "/" && c.shouldRunHostCommands() {
+				t.Fatal("shouldRunHostCommands must stay false under a prefix")
+			}
+		})
+	}
+}

--- a/internal/backup/collector_network_inventory.go
+++ b/internal/backup/collector_network_inventory.go
@@ -46,7 +46,15 @@ func (c *Collector) collectNetworkInventory(ctx context.Context, commandsDir, in
 	sysNet := c.systemPath("/sys/class/net")
 	entries, err := os.ReadDir(sysNet)
 	if err != nil {
-		c.logger.Debug("Network inventory skipped: unable to read %s: %v", sysNet, err)
+		// Under a prefix this is the common case when the host root bind mount does
+		// not carry sysfs (a non-recursive bind of / leaves PREFIX/sys empty). Surface
+		// it as a bare fact so the missing inventory reads as "host sysfs not carried",
+		// not "collection broke". Never fails the backup.
+		if c.hostRootPrefixActive() {
+			c.logger.Info("Network inventory unavailable: %s is not readable; the host sysfs is not carried by the bind mount", sysNet)
+		} else {
+			c.logger.Debug("Network inventory skipped: unable to read %s: %v", sysNet, err)
+		}
 		return nil
 	}
 
@@ -57,13 +65,14 @@ func (c *Collector) collectNetworkInventory(ctx context.Context, commandsDir, in
 		inv.Hostname = host
 	}
 	if !c.shouldRunHostCommands() {
-		// Interface facts come from the host sysfs under the prefix (accurate), but
-		// udevadm/ethtool query the running network namespace, which is the
-		// container's, so their per-interface fields (udev properties, permanent MAC)
-		// are intentionally absent rather than container data mislabeled as host data.
+		// Interface facts are read from sysfs under the prefix (which reflects the host
+		// only when the host sysfs is carried under the prefix), but udevadm/ethtool
+		// query the running network namespace, which is the container's, so their
+		// per-interface fields (udev properties, permanent MAC) are intentionally absent
+		// rather than container data mislabeled as host data.
 		inv.HostCommandsSkipped = true
 		inv.HostCommandsReason = "system root prefix set; namespace-scoped commands (udevadm/ethtool) describe the container, not the host"
-		c.logger.Info("Network inventory: host commands skipped under system root prefix; interface data collected from host sysfs")
+		c.logger.Info("Network inventory: host commands skipped under system root prefix; interface data read from sysfs under the prefix")
 	}
 
 	for _, entry := range entries {

--- a/internal/backup/collector_network_inventory.go
+++ b/internal/backup/collector_network_inventory.go
@@ -14,9 +14,11 @@ import (
 )
 
 type networkInventory struct {
-	GeneratedAt string                    `json:"generated_at"`
-	Hostname    string                    `json:"hostname"`
-	Interfaces  []networkInterfaceProfile `json:"interfaces"`
+	GeneratedAt         string                    `json:"generated_at"`
+	Hostname            string                    `json:"hostname"`
+	HostCommandsSkipped bool                      `json:"host_commands_skipped,omitempty"`
+	HostCommandsReason  string                    `json:"host_commands_skipped_reason,omitempty"`
+	Interfaces          []networkInterfaceProfile `json:"interfaces"`
 }
 
 type networkInterfaceProfile struct {
@@ -53,6 +55,15 @@ func (c *Collector) collectNetworkInventory(ctx context.Context, commandsDir, in
 	}
 	if host, err := os.Hostname(); err == nil {
 		inv.Hostname = host
+	}
+	if !c.shouldRunHostCommands() {
+		// Interface facts come from the host sysfs under the prefix (accurate), but
+		// udevadm/ethtool query the running network namespace, which is the
+		// container's, so their per-interface fields (udev properties, permanent MAC)
+		// are intentionally absent rather than container data mislabeled as host data.
+		inv.HostCommandsSkipped = true
+		inv.HostCommandsReason = "system root prefix set; namespace-scoped commands (udevadm/ethtool) describe the container, not the host"
+		c.logger.Info("Network inventory: host commands skipped under system root prefix; interface data collected from host sysfs")
 	}
 
 	for _, entry := range entries {
@@ -129,9 +140,41 @@ func (c *Collector) collectNetworkInventory(ctx context.Context, commandsDir, in
 	return nil
 }
 
+// shouldRunHostCommands reports whether host-scoped commands may run against the
+// live system. It stays false whenever a SYSTEM_ROOT_PREFIX is set, because the
+// commands it gates (udevadm, ethtool, and the PBS block-device inventory:
+// blkid/lsblk/findmnt/dmsetup/lvm/mdadm/multipath/iscsi) query the running
+// network, mount and device namespaces. In an HA-LXC backup appliance those are
+// the container's namespaces, not the mounted host's, so running them under a
+// prefix would record container state mislabeled as host state. Under a prefix the
+// file-derived inventory (host sysfs, /etc, fstab, crypttab) is used instead, and
+// the ZFS subset is handled separately by shouldRunKernelSharedCommands (issue
+// #255).
 func (c *Collector) shouldRunHostCommands() bool {
 	root := strings.TrimSpace(c.config.SystemRootPrefix)
 	return root == "" || root == string(filepath.Separator)
+}
+
+// hostRootPrefixActive reports whether a non-trivial SYSTEM_ROOT_PREFIX is set, so
+// the appliance is collecting from a mounted host root rather than its own root.
+func (c *Collector) hostRootPrefixActive() bool {
+	root := strings.TrimSpace(c.config.SystemRootPrefix)
+	return root != "" && root != string(filepath.Separator)
+}
+
+// shouldRunKernelSharedCommands reports whether commands that read GLOBAL kernel
+// state may run. Unlike the namespace/device-scoped commands gated by
+// shouldRunHostCommands, ZFS state lives in the shared kernel (/dev/zfs), so a
+// privileged LXC reports the host pools accurately even when only the host
+// filesystem is bind-mounted. It returns true on a real root (like
+// shouldRunHostCommands) and, additionally, under HOST_BACKUP_MODE with a
+// SYSTEM_ROOT_PREFIX set (issue #255).
+func (c *Collector) shouldRunKernelSharedCommands() bool {
+	if c.shouldRunHostCommands() {
+		return true
+	}
+	root := strings.TrimSpace(c.config.SystemRootPrefix)
+	return c.config.HostBackupMode && root != "" && root != string(filepath.Separator)
 }
 
 func (c *Collector) readUdevProperties(ctx context.Context, netPath string) (map[string]string, error) {

--- a/internal/backup/collector_network_inventory.go
+++ b/internal/backup/collector_network_inventory.go
@@ -46,12 +46,14 @@ func (c *Collector) collectNetworkInventory(ctx context.Context, commandsDir, in
 	sysNet := c.systemPath("/sys/class/net")
 	entries, err := os.ReadDir(sysNet)
 	if err != nil {
-		// Under a prefix this is the common case when the host root bind mount does
-		// not carry sysfs (a non-recursive bind of / leaves PREFIX/sys empty). Surface
-		// it as a bare fact so the missing inventory reads as "host sysfs not carried",
-		// not "collection broke". Never fails the backup.
-		if c.hostRootPrefixActive() {
-			c.logger.Info("Network inventory unavailable: %s is not readable; the host sysfs is not carried by the bind mount", sysNet)
+		// In host-backup mode this is the common case when the host root bind mount
+		// does not carry sysfs (a non-recursive bind of / leaves PREFIX/sys empty).
+		// Surface it as a bare fact so the missing inventory reads as "host sysfs not
+		// carried", not "collection broke". A plain prefix (chroot/snapshot/CI) keeps
+		// the neutral debug line with the real error, since there is no bind mount to
+		// blame. Never fails the backup either way.
+		if c.config.HostBackupMode && c.hostRootPrefixActive() {
+			c.logger.Info("Network inventory unavailable: %s is not readable; the host sysfs may not be carried by the host mount", sysNet)
 		} else {
 			c.logger.Debug("Network inventory skipped: unable to read %s: %v", sysNet, err)
 		}

--- a/internal/backup/collector_network_inventory_hostbackup_test.go
+++ b/internal/backup/collector_network_inventory_hostbackup_test.go
@@ -1,0 +1,53 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// TestNetworkInventoryHostSysfsMarkerGating pins the round-2 fix: an unreadable
+// /sys/class/net under a prefix emits the honest "host sysfs may not be carried"
+// Info ONLY under HOST_BACKUP_MODE; a plain prefix keeps the neutral debug line
+// (issue #255), so a chroot/snapshot/CI run is not told about a nonexistent bind
+// mount.
+func TestNetworkInventoryHostSysfsMarkerGating(t *testing.T) {
+	cases := []struct {
+		name       string
+		hostBackup bool
+		wantMarker bool
+	}{
+		{"host-backup mode marks host sysfs", true, true},
+		{"plain prefix stays neutral", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A prefix whose /sys/class/net does not exist forces the ReadDir error path.
+			root := t.TempDir()
+			buf := &bytes.Buffer{}
+			logger := logging.New(types.LogLevelDebug, false)
+			logger.SetOutput(buf)
+
+			c := &Collector{
+				logger: logger,
+				config: &CollectorConfig{SystemRootPrefix: root, HostBackupMode: tc.hostBackup},
+			}
+			if err := c.collectNetworkInventory(context.Background(), t.TempDir(), t.TempDir()); err != nil {
+				t.Fatalf("collectNetworkInventory: %v", err)
+			}
+
+			out := buf.String()
+			hasMarker := strings.Contains(out, "host sysfs may not be carried")
+			if hasMarker != tc.wantMarker {
+				t.Fatalf("host-sysfs marker present=%v want %v; output:\n%s", hasMarker, tc.wantMarker, out)
+			}
+			if !tc.hostBackup && strings.Contains(out, "host sysfs") {
+				t.Fatalf("plain prefix must not mention host sysfs; output:\n%s", out)
+			}
+		})
+	}
+}

--- a/internal/backup/collector_pbs_datastore_inventory.go
+++ b/internal/backup/collector_pbs_datastore_inventory.go
@@ -97,6 +97,7 @@ type pbsInventoryState struct {
 	mergedDatastores    []pbsDatastoreDefinition
 	referencedFiles     []string
 	hostCommandsEnabled bool
+	kernelSharedEnabled bool
 }
 
 func (c *Collector) initPBSDatastoreInventoryState(ctx context.Context, cliDatastores []pbsDatastore) (*pbsInventoryState, error) {
@@ -132,6 +133,7 @@ func (c *Collector) initPBSDatastoreInventoryState(ctx context.Context, cliDatas
 		mergedDatastores:    mergePBSDatastoreDefinitions(cliDatastores, configDatastores),
 		referencedFiles:     uniqueSortedStrings(append(extractCrypttabKeyFiles(report.Files["crypttab"].Content), extractFstabReferencedFiles(report.Files["fstab"].Content)...)),
 		hostCommandsEnabled: report.HostCommands,
+		kernelSharedEnabled: c.shouldRunKernelSharedCommands(),
 	}, nil
 }
 
@@ -354,7 +356,12 @@ func (c *Collector) populatePBSInventoryHostCommandsZFS(ctx context.Context, inv
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if !inventory.hostCommandsEnabled {
+	// ZFS is global kernel state (/dev/zfs), not namespace-scoped, so a privileged
+	// LXC sharing the host kernel reports the host pools accurately even when only
+	// the host filesystem is bind-mounted. Enable it under HOST_BACKUP_MODE (issue
+	// #255) while the device-visibility-dependent commands (dmsetup/lvm/mdadm/
+	// multipath/iscsi) stay gated by hostCommandsEnabled.
+	if !inventory.kernelSharedEnabled {
 		return nil
 	}
 	report := &inventory.report

--- a/internal/backup/collector_pbs_datastore_inventory.go
+++ b/internal/backup/collector_pbs_datastore_inventory.go
@@ -279,10 +279,17 @@ func (c *Collector) populatePBSInventoryHostCommandsCore(ctx context.Context, in
 		return nil
 	}
 
+	reason := "system_root_prefix is not host root; skipping host-only commands"
+	if inventory.kernelSharedEnabled {
+		// Under HOST_BACKUP_MODE the shared-kernel ZFS commands still run (see
+		// populatePBSInventoryHostCommandsZFS), so the marker must not claim all
+		// host commands were skipped.
+		reason = "system_root_prefix is host root (host-backup mode); namespace and device-scoped commands skipped, shared-kernel ZFS commands collected"
+	}
 	report.Commands["host_commands_skipped"] = inventoryCommandSnapshot{
 		Command: "host_commands",
 		Skipped: true,
-		Reason:  "system_root_prefix is not host root; skipping host-only commands",
+		Reason:  reason,
 	}
 	return nil
 }

--- a/internal/backup/collector_pve.go
+++ b/internal/backup/collector_pve.go
@@ -2519,7 +2519,14 @@ func (c *Collector) cephConfigPaths() []string {
 	if c.config.CephConfigPath != "" {
 		add(c.config.CephConfigPath)
 	}
-	add(filepath.Join(c.effectivePVEConfigPath(), "ceph"))
+	// add() applies systemPath itself, so feed it the UN-prefixed pve config path;
+	// effectivePVEConfigPath() is already prefixed and would double-prefix to
+	// PREFIX/PREFIX/etc/pve/ceph.
+	pveConfigRoot := strings.TrimSpace(c.config.PVEConfigPath)
+	if pveConfigRoot == "" {
+		pveConfigRoot = "/etc/pve"
+	}
+	add(filepath.Join(pveConfigRoot, "ceph"))
 	add("/etc/ceph")
 	return paths
 }

--- a/internal/backup/collector_pve.go
+++ b/internal/backup/collector_pve.go
@@ -2547,28 +2547,30 @@ func (c *Collector) cephHasClusterConfig(path string) bool {
 }
 
 // readSystemFileFollowingSymlinks reads a system file that may be reached through
-// an absolute symlink into another subtree. On a real root it is a plain
-// os.ReadFile. Under a SYSTEM_ROOT_PREFIX it resolves the file through
-// safefs.ReadFileInRoot, which re-anchors an absolute symlink target under the
-// prefix (so /etc/ceph/ceph.conf -> /etc/pve/ceph.conf reads
-// PREFIX/etc/pve/ceph.conf instead of escaping to the container root) and stays
-// confined at the syscall level. Read-only; never writes under the prefix. This is
-// the read side of the fix; copySymlinkFile keeps storing link targets verbatim so
-// a restore onto a real host recreates the link correctly (issue #255).
+// an absolute symlink into another subtree. Both the real-root and the
+// SYSTEM_ROOT_PREFIX cases resolve through safefs.ReadFileInRoot, which re-anchors
+// an absolute symlink target under the root (so /etc/ceph/ceph.conf ->
+// /etc/pve/ceph.conf reads ROOT/etc/pve/ceph.conf instead of escaping) and stays
+// confined at the syscall level via os.Root. On a real root the confinement root is
+// "/", so re-anchoring is a no-op that resolves to the same absolute file a plain
+// os.ReadFile would, while keeping the read out of a raw variable sink (structural
+// gosec G304 remedy, not a suppression). Read-only; never writes under the root.
+// This is the read side of the fix; copySymlinkFile keeps storing link targets
+// verbatim so a restore onto a real host recreates the link correctly (issue #255).
 func (c *Collector) readSystemFileFollowingSymlinks(path string) ([]byte, error) {
-	prefix := strings.TrimSpace(c.config.SystemRootPrefix)
-	if prefix == "" || prefix == string(filepath.Separator) {
-		return os.ReadFile(path)
+	root := strings.TrimSpace(c.config.SystemRootPrefix)
+	if root == "" {
+		root = string(filepath.Separator)
 	}
-	cleanPrefix := filepath.Clean(prefix)
+	cleanRoot := filepath.Clean(root)
 	rel := path
 	switch {
-	case path == cleanPrefix:
+	case path == cleanRoot:
 		rel = "/"
-	case strings.HasPrefix(path, cleanPrefix+string(filepath.Separator)):
-		rel = strings.TrimPrefix(path, cleanPrefix)
+	case strings.HasPrefix(path, cleanRoot+string(filepath.Separator)):
+		rel = strings.TrimPrefix(path, cleanRoot)
 	}
-	return safefs.ReadFileInRoot(cleanPrefix, rel)
+	return safefs.ReadFileInRoot(cleanRoot, rel)
 }
 
 func cephHasKeyring(path string) bool {

--- a/internal/backup/collector_pve.go
+++ b/internal/backup/collector_pve.go
@@ -1789,6 +1789,16 @@ func (c *Collector) collectPVECephRuntime(ctx context.Context) error {
 		return fmt.Errorf("failed to create ceph directory: %w", err)
 	}
 
+	if c.config.HostBackupMode && c.hostRootPrefixActive() {
+		// The Ceph CLI talks to the live cluster over the pmxcfs socket, which is not
+		// reachable from the appliance container, so ceph -s would fail and write
+		// nothing. Emit a positive marker so the missing runtime files read as "not
+		// applicable in host-backup mode", not "collection broke"; the Ceph
+		// configuration itself is captured from the file tree (issue #255).
+		c.logger.Info("Ceph runtime status unavailable in host-backup mode (cluster socket not reachable from the appliance); Ceph configuration captured from %s", c.effectivePVEConfigPath())
+		return nil
+	}
+
 	if _, err := c.depLookPath("ceph"); err != nil {
 		c.logger.Debug("Ceph CLI not available, skipping Ceph command outputs")
 		return nil
@@ -2467,7 +2477,7 @@ func (c *Collector) isServiceActive(ctx context.Context, service string) bool {
 
 func (c *Collector) isCephConfigured(ctx context.Context) bool {
 	for _, path := range c.cephConfigPaths() {
-		if cephHasClusterConfig(path) || cephHasKeyring(path) {
+		if c.cephHasClusterConfig(path) || cephHasKeyring(path) {
 			return true
 		}
 	}
@@ -2514,9 +2524,9 @@ func (c *Collector) cephConfigPaths() []string {
 	return paths
 }
 
-func cephHasClusterConfig(path string) bool {
+func (c *Collector) cephHasClusterConfig(path string) bool {
 	confPath := filepath.Join(path, "ceph.conf")
-	data, err := os.ReadFile(confPath)
+	data, err := c.readSystemFileFollowingSymlinks(confPath)
 	if err != nil {
 		return false
 	}
@@ -2527,6 +2537,31 @@ func cephHasClusterConfig(path string) bool {
 		}
 	}
 	return false
+}
+
+// readSystemFileFollowingSymlinks reads a system file that may be reached through
+// an absolute symlink into another subtree. On a real root it is a plain
+// os.ReadFile. Under a SYSTEM_ROOT_PREFIX it resolves the file through
+// safefs.ReadFileInRoot, which re-anchors an absolute symlink target under the
+// prefix (so /etc/ceph/ceph.conf -> /etc/pve/ceph.conf reads
+// PREFIX/etc/pve/ceph.conf instead of escaping to the container root) and stays
+// confined at the syscall level. Read-only; never writes under the prefix. This is
+// the read side of the fix; copySymlinkFile keeps storing link targets verbatim so
+// a restore onto a real host recreates the link correctly (issue #255).
+func (c *Collector) readSystemFileFollowingSymlinks(path string) ([]byte, error) {
+	prefix := strings.TrimSpace(c.config.SystemRootPrefix)
+	if prefix == "" || prefix == string(filepath.Separator) {
+		return os.ReadFile(path)
+	}
+	cleanPrefix := filepath.Clean(prefix)
+	rel := path
+	switch {
+	case path == cleanPrefix:
+		rel = "/"
+	case strings.HasPrefix(path, cleanPrefix+string(filepath.Separator)):
+		rel = strings.TrimPrefix(path, cleanPrefix)
+	}
+	return safefs.ReadFileInRoot(cleanPrefix, rel)
 }
 
 func cephHasKeyring(path string) bool {

--- a/internal/backup/collector_pve_ceph_prefix_test.go
+++ b/internal/backup/collector_pve_ceph_prefix_test.go
@@ -35,8 +35,10 @@ func TestCephHasClusterConfigFollowsAbsoluteSymlinkUnderPrefix(t *testing.T) {
 	}
 }
 
-// TestReadSystemFileFollowingSymlinksNoPrefix keeps the real-root path a plain
-// os.ReadFile (backward compatibility).
+// TestReadSystemFileFollowingSymlinksNoPrefix pins the real-root contract: a plain
+// regular file reads back byte-for-byte. With no prefix the read is confined to
+// root "/" via os.Root (structural G304 remedy), which resolves to the same file a
+// plain os.ReadFile would.
 func TestReadSystemFileFollowingSymlinksNoPrefix(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "file.txt")
@@ -50,5 +52,29 @@ func TestReadSystemFileFollowingSymlinksNoPrefix(t *testing.T) {
 	}
 	if string(got) != "data" {
 		t.Fatalf("got %q want data", got)
+	}
+}
+
+// TestReadSystemFileFollowingSymlinksNoPrefixFollowsSymlink proves the real-root
+// read still follows a symlink to its target (the os.Root confinement must not
+// break symlink resolution the way a bare os.OpenRoot(dir).Open would refuse an
+// escaping final component). The link and target sit in the same directory.
+func TestReadSystemFileFollowingSymlinksNoPrefixFollowsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("linked-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.conf")
+	if err := os.Symlink("target.txt", link); err != nil {
+		t.Fatal(err)
+	}
+	c := &Collector{config: &CollectorConfig{}}
+	got, err := c.readSystemFileFollowingSymlinks(link)
+	if err != nil {
+		t.Fatalf("readSystemFileFollowingSymlinks: %v", err)
+	}
+	if string(got) != "linked-data" {
+		t.Fatalf("got %q want linked-data", got)
 	}
 }

--- a/internal/backup/collector_pve_ceph_prefix_test.go
+++ b/internal/backup/collector_pve_ceph_prefix_test.go
@@ -1,0 +1,54 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCephHasClusterConfigFollowsAbsoluteSymlinkUnderPrefix is the issue #255
+// gap #3 regression. On a Proxmox host /etc/ceph/ceph.conf is an absolute symlink
+// to /etc/pve/ceph.conf. Under a SYSTEM_ROOT_PREFIX the old os.ReadFile followed
+// the absolute target against the container root (ENOENT) and the whole Ceph
+// category was silently skipped. The prefix-aware read must re-anchor the target
+// under the prefix and find the config.
+func TestCephHasClusterConfigFollowsAbsoluteSymlinkUnderPrefix(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc/pve"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "etc/ceph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "etc/pve/ceph.conf"), []byte("[global]\nfsid = 1234\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/pve/ceph.conf", filepath.Join(root, "etc/ceph/ceph.conf")); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Collector{config: &CollectorConfig{SystemRootPrefix: root}}
+
+	// systemPath("/etc/ceph") is what cephConfigPaths feeds cephHasClusterConfig.
+	if !c.cephHasClusterConfig(c.systemPath("/etc/ceph")) {
+		t.Fatal("cephHasClusterConfig should resolve the absolute symlink under the prefix and find the config")
+	}
+}
+
+// TestReadSystemFileFollowingSymlinksNoPrefix keeps the real-root path a plain
+// os.ReadFile (backward compatibility).
+func TestReadSystemFileFollowingSymlinksNoPrefix(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(p, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := &Collector{config: &CollectorConfig{}}
+	got, err := c.readSystemFileFollowingSymlinks(p)
+	if err != nil {
+		t.Fatalf("readSystemFileFollowingSymlinks: %v", err)
+	}
+	if string(got) != "data" {
+		t.Fatalf("got %q want data", got)
+	}
+}

--- a/internal/backup/collector_pve_util_test.go
+++ b/internal/backup/collector_pve_util_test.go
@@ -195,6 +195,9 @@ func TestCopyIfExists(t *testing.T) {
 // TestCephHasClusterConfig tests Ceph cluster configuration detection
 func TestCephHasClusterConfig(t *testing.T) {
 	tmpDir := t.TempDir()
+	// Zero-prefix collector: readSystemFileFollowingSymlinks falls back to os.ReadFile,
+	// so this preserves the original free-function behavior.
+	c := &Collector{config: &CollectorConfig{}}
 
 	tests := []struct {
 		name     string
@@ -249,7 +252,7 @@ some_other_key = value`,
 				}
 			}
 
-			result := cephHasClusterConfig(testDir)
+			result := c.cephHasClusterConfig(testDir)
 			if result != tt.expected {
 				t.Errorf("cephHasClusterConfig() = %v, want %v", result, tt.expected)
 			}
@@ -258,7 +261,7 @@ some_other_key = value`,
 
 	// Test nonexistent directory
 	t.Run("nonexistent directory", func(t *testing.T) {
-		result := cephHasClusterConfig(filepath.Join(tmpDir, "nonexistent"))
+		result := c.cephHasClusterConfig(filepath.Join(tmpDir, "nonexistent"))
 		if result {
 			t.Error("cephHasClusterConfig() should return false for nonexistent directory")
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -337,6 +337,7 @@ type Config struct {
 	BackupScriptRepository  bool
 	BackupConfigFile        bool
 	SystemRootPrefix        string
+	HostBackupMode          bool
 	PVEConfigPath           string
 	PBSConfigPath           string
 	PVEClusterPath          string
@@ -988,6 +989,11 @@ func (c *Config) parseSystemSettings() {
 	// Optional system-root override (chroot/test fixture). Empty or "/" means real
 	// root; CollectorConfig.Validate rejects a non-absolute value.
 	c.SystemRootPrefix = strings.TrimSpace(c.getString("SYSTEM_ROOT_PREFIX", ""))
+	// HA-LXC host-backup mode (issue #255). SYSTEM_ROOT_PREFIX alone already drives
+	// prefix-aware detection and symlink resolution; this flag additionally frames
+	// the run as an appliance backing up a mounted host and gates the host-command
+	// handling. It is meaningful only together with a SYSTEM_ROOT_PREFIX.
+	c.HostBackupMode = c.getBool("HOST_BACKUP_MODE", false)
 	c.PBSDatastorePaths = normalizeList(c.getStringSlice("PBS_DATASTORE_PATH", nil))
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1497,6 +1497,23 @@ func TestParseSystemSettingsSystemRootPrefix(t *testing.T) {
 	})
 }
 
+func TestParseSystemSettingsHostBackupMode(t *testing.T) {
+	t.Run("parses truthy value", func(t *testing.T) {
+		cfg := &Config{raw: map[string]string{"HOST_BACKUP_MODE": "true"}}
+		cfg.parseSystemSettings()
+		if !cfg.HostBackupMode {
+			t.Fatal("HostBackupMode should be true")
+		}
+	})
+	t.Run("defaults to false when unset", func(t *testing.T) {
+		cfg := &Config{raw: map[string]string{}}
+		cfg.parseSystemSettings()
+		if cfg.HostBackupMode {
+			t.Fatal("HostBackupMode should default to false")
+		}
+	})
+}
+
 func TestParseSystemSettingsScriptRepositoryDefaultsFalse(t *testing.T) {
 	// A config missing the key must default to false, matching the shipped template
 	// (#69), so it does not silently snapshot /opt/proxsave.

--- a/internal/config/templates/backup.env
+++ b/internal/config/templates/backup.env
@@ -386,6 +386,7 @@ BACKUP_ROOT_HOME=true
 BACKUP_SCRIPT_REPOSITORY=false
 BACKUP_CONFIG_FILE=true        # Include this backup.env configuration file in the backup
 SYSTEM_ROOT_PREFIX=            # Optional: override system root (e.g. chroot/test fixture). Empty or "/" = real root.
+HOST_BACKUP_MODE=false         # HA-LXC appliance backing up a host mounted read-only at SYSTEM_ROOT_PREFIX (issue #255). No effect without a prefix.
 
 # ----------------------------------------------------------------------
 # Custom paths / blacklist

--- a/internal/environment/detect.go
+++ b/internal/environment/detect.go
@@ -26,6 +26,32 @@ var (
 	pveLegacyFile  = defaultPVELegacyFile
 	pbsVersionFile = defaultPBSVersionFile
 
+	// dpkgStatusFile is the Debian package database. Under a mounted host prefix it
+	// is the persistent, authoritative record of what is installed AND its version,
+	// unlike the pmxcfs-backed version files which vanish when the /etc/pve bind is
+	// not mounted. It is the reliable offline version source for both PVE and PBS.
+	dpkgStatusFile = "/var/lib/dpkg/status"
+
+	// pveClusterDB is the pmxcfs SQLite backing store. It exists on every PVE host
+	// (clustered or standalone), lives on the persistent root filesystem, and
+	// survives with no pmxcfs FUSE bind, so it identifies a mounted PVE host even
+	// when /etc/pve is an empty mountpoint. Nothing but PVE creates it.
+	pveClusterDB = "/var/lib/pve-cluster/config.db"
+
+	// pveBinaryCandidates and pbsBinaryCandidates are product-specific binaries
+	// installed under /usr, present whenever the mount carries /usr even if /etc and
+	// /var are excluded. They are only stat-probed, never executed (executing a host
+	// binary from inside the backup appliance would answer for the appliance).
+	pveBinaryCandidates = []string{"/usr/bin/pmxcfs", "/usr/bin/pveversion", "/usr/bin/pvesh", "/usr/sbin/qm", "/usr/sbin/pct"}
+	// PBS server binaries only (proxmox-backup-proxy/manager); the client
+	// (proxmox-backup-client) ships on PVE hosts too, so it is excluded to avoid a
+	// false PBS positive on a PVE-only host.
+	pbsBinaryCandidates = []string{"/usr/sbin/proxmox-backup-proxy", "/usr/bin/proxmox-backup-manager", "/usr/sbin/proxmox-backup-manager"}
+
+	// Package data directories, on-disk and product-specific.
+	pveShareDir = "/usr/share/pve-manager"
+	pbsShareDir = "/usr/share/proxmox-backup"
+
 	additionalPaths = []string{"/usr/bin", "/usr/sbin", "/bin", "/sbin"}
 
 	pveDirCandidates = []string{
@@ -233,6 +259,25 @@ func detectPVE() (string, bool) {
 		return version, true
 	}
 
+	// dpkg is version-bearing and reliable offline, so it precedes the version-less
+	// markers below and recovers the real version even when the pmxcfs version files
+	// are absent.
+	if version, ok := dpkgPackageInstalled("pve-manager"); ok {
+		return version, true
+	}
+
+	if fileExists(pveClusterDB) {
+		return "unknown", true
+	}
+
+	if fileExistsAny(pveBinaryCandidates) {
+		return "unknown", true
+	}
+
+	if dirExists(pveShareDir) {
+		return "unknown", true
+	}
+
 	if ok := detectPVEViaSources(); ok {
 		return "unknown", true
 	}
@@ -255,6 +300,18 @@ func detectPBS() (string, bool) {
 		return version, true
 	}
 
+	if version, ok := dpkgPackageInstalled("proxmox-backup-server"); ok {
+		return version, true
+	}
+
+	if fileExistsAny(pbsBinaryCandidates) {
+		return "unknown", true
+	}
+
+	if dirExists(pbsShareDir) {
+		return "unknown", true
+	}
+
 	if ok := detectPBSViaSources(); ok {
 		return "unknown", true
 	}
@@ -264,6 +321,55 @@ func detectPBS() (string, bool) {
 	}
 
 	return "", false
+}
+
+// fileExistsAny reports whether any candidate resolves to a regular file under the
+// active prefix (fileExists applies resolveUnderPrefix).
+func fileExistsAny(paths []string) bool {
+	for _, p := range paths {
+		if fileExists(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// dpkgPackageInstalled reports whether the dpkg status database under the active
+// prefix records pkg as installed, returning its Version. It matches an anchored
+// "Package:" field plus a "Status: ... installed" line so a Depends: mention in
+// another stanza, or a residual "deinstall ok config-files" entry, never counts as
+// installed. Stanzas are blank-line separated.
+func dpkgPackageInstalled(pkg string) (string, bool) {
+	data, err := readFileFunc(resolveUnderPrefix(dpkgStatusFile))
+	if err != nil {
+		return "", false
+	}
+	for _, stanza := range strings.Split(string(data), "\n\n") {
+		if dpkgStanzaField(stanza, "Package") != pkg {
+			continue
+		}
+		if !strings.HasSuffix(dpkgStanzaField(stanza, "Status"), " installed") {
+			return "", false
+		}
+		version := dpkgStanzaField(stanza, "Version")
+		if version == "" {
+			version = "unknown"
+		}
+		return version, true
+	}
+	return "", false
+}
+
+// dpkgStanzaField returns the trimmed value of the first "Key: value" line in a
+// stanza, anchored at column 0 so an indented continuation line never matches.
+func dpkgStanzaField(stanza, key string) string {
+	prefix := key + ":"
+	for _, line := range strings.Split(stanza, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(line[len(prefix):])
+		}
+	}
+	return ""
 }
 
 func detectPVEViaCommand() (string, bool) {
@@ -516,6 +622,22 @@ func writeDetectionDebug() string {
 	builder.WriteString("=== APT source files check ===\n")
 	for _, source := range append(pveSourceFiles, pbsSourceFiles...) {
 		fmt.Fprintf(&builder, "%s exists: %s\n", source, boolToYes(fileExists(source)))
+	}
+	builder.WriteString("\n")
+
+	builder.WriteString("=== Offline host markers check ===\n")
+	fmt.Fprintf(&builder, "%s exists: %s\n", pveClusterDB, boolToYes(fileExists(pveClusterDB)))
+	for _, bin := range append(append([]string{}, pveBinaryCandidates...), pbsBinaryCandidates...) {
+		fmt.Fprintf(&builder, "%s exists: %s\n", bin, boolToYes(fileExists(bin)))
+	}
+	fmt.Fprintf(&builder, "%s exists: %s\n", pveShareDir, boolToYes(dirExists(pveShareDir)))
+	fmt.Fprintf(&builder, "%s exists: %s\n", pbsShareDir, boolToYes(dirExists(pbsShareDir)))
+	fmt.Fprintf(&builder, "%s exists: %s\n", dpkgStatusFile, boolToYes(fileExists(dpkgStatusFile)))
+	if _, ok := dpkgPackageInstalled("pve-manager"); ok {
+		builder.WriteString("dpkg pve-manager: installed\n")
+	}
+	if _, ok := dpkgPackageInstalled("proxmox-backup-server"); ok {
+		builder.WriteString("dpkg proxmox-backup-server: installed\n")
 	}
 	builder.WriteString("\n")
 

--- a/internal/environment/detect.go
+++ b/internal/environment/detect.go
@@ -62,6 +62,13 @@ var (
 	debugBaseDir   = "/tmp"
 
 	runCommandFunc = runCommand
+
+	// rootPrefix re-anchors the hardcoded detection paths under a mounted host
+	// filesystem (SYSTEM_ROOT_PREFIX). Empty means detect against the real root,
+	// the historical behavior. It is a package-level seam, like statFunc and
+	// readFileFunc above, set only by DetectWith for the duration of a single
+	// bootstrap detection, which runs before any concurrent goroutine exists.
+	rootPrefix string
 )
 
 // DetectProxmoxType detects whether the system is running Proxmox VE or Proxmox Backup Server
@@ -109,6 +116,28 @@ type EnvironmentInfo struct {
 
 // Detect detects the Proxmox environment and returns detailed information
 func Detect() (*EnvironmentInfo, error) {
+	return DetectWith(DetectOptions{})
+}
+
+// DetectOptions tunes detection. RootPrefix, when set, points detection at a
+// Proxmox host filesystem mounted read-only under that prefix (SYSTEM_ROOT_PREFIX),
+// so ProxSave running inside an HA-LXC backup appliance detects the host rather
+// than the container it runs in (issue #255).
+type DetectOptions struct {
+	RootPrefix string
+}
+
+// DetectWith detects the Proxmox environment under the given options. With an
+// empty RootPrefix it is identical to the historical Detect(): detection reads the
+// real root and probes host commands. With a RootPrefix it re-anchors the
+// detection paths under the prefix and skips the host command probes, because
+// pveversion/proxmox-backup-manager executed inside the container answer for the
+// container, not for the mounted host.
+func DetectWith(opts DetectOptions) (*EnvironmentInfo, error) {
+	prev := rootPrefix
+	rootPrefix = strings.TrimSpace(opts.RootPrefix)
+	defer func() { rootPrefix = prev }()
+
 	info, err := detectEnvironmentInfo()
 	if info.Type == types.ProxmoxUnknown {
 		if err != nil {
@@ -117,6 +146,22 @@ func Detect() (*EnvironmentInfo, error) {
 		return info, fmt.Errorf("unable to detect Proxmox environment")
 	}
 	return info, err
+}
+
+// hostRooted reports whether detection is re-anchored under a host prefix.
+func hostRooted() bool {
+	return rootPrefix != "" && rootPrefix != string(filepath.Separator)
+}
+
+// resolveUnderPrefix re-anchors an absolute detection path under rootPrefix. The
+// detection paths are fixed literals (never attacker-controlled), so a plain join
+// mirroring collector.systemPath is sufficient and matches how the rest of
+// collection resolves system paths under the prefix.
+func resolveUnderPrefix(path string) string {
+	if !hostRooted() {
+		return path
+	}
+	return filepath.Join(rootPrefix, strings.TrimPrefix(path, string(filepath.Separator)))
 }
 
 func detectEnvironmentInfo() (*EnvironmentInfo, error) {
@@ -178,8 +223,10 @@ func combineVersions(pveVersion, pbsVersion string) string {
 }
 
 func detectPVE() (string, bool) {
-	if version, ok := detectPVEViaCommand(); ok {
-		return version, true
+	if !hostRooted() {
+		if version, ok := detectPVEViaCommand(); ok {
+			return version, true
+		}
 	}
 
 	if version, ok := detectPVEViaVersionFiles(); ok {
@@ -198,8 +245,10 @@ func detectPVE() (string, bool) {
 }
 
 func detectPBS() (string, bool) {
-	if version, ok := detectPBSViaCommand(); ok {
-		return version, true
+	if !hostRooted() {
+		if version, ok := detectPBSViaCommand(); ok {
+			return version, true
+		}
 	}
 
 	if version, ok := detectPBSViaVersionFile(); ok {
@@ -368,7 +417,7 @@ func extractPBSVersion(output string) string {
 }
 
 func containsAny(path string, tokens []string) bool {
-	data, err := readFileFunc(path)
+	data, err := readFileFunc(resolveUnderPrefix(path))
 	if err != nil {
 		return false
 	}
@@ -382,7 +431,7 @@ func containsAny(path string, tokens []string) bool {
 }
 
 func readAndTrim(path string) string {
-	data, err := readFileFunc(path)
+	data, err := readFileFunc(resolveUnderPrefix(path))
 	if err != nil {
 		return ""
 	}
@@ -391,7 +440,7 @@ func readAndTrim(path string) string {
 
 // fileExists checks if a file exists
 func fileExists(path string) bool {
-	info, err := statFunc(path)
+	info, err := statFunc(resolveUnderPrefix(path))
 	if err != nil {
 		return false
 	}
@@ -399,7 +448,7 @@ func fileExists(path string) bool {
 }
 
 func dirExists(path string) bool {
-	info, err := statFunc(path)
+	info, err := statFunc(resolveUnderPrefix(path))
 	if err != nil {
 		return false
 	}

--- a/internal/environment/detect.go
+++ b/internal/environment/detect.go
@@ -174,6 +174,23 @@ func DetectWith(opts DetectOptions) (*EnvironmentInfo, error) {
 	return info, err
 }
 
+// DetectHostUnderPrefix detects a Proxmox host whose filesystem is mounted under
+// prefix (SYSTEM_ROOT_PREFIX, issue #255). It uses ONLY the re-anchored filesystem
+// markers that bare-metal PVE/PBS detection uses; it never runs the host command
+// probes, which answer for the appliance container rather than the mounted host. It
+// NEVER returns nil and NEVER returns a live-container type: when no host markers
+// are present under the prefix it returns a ProxmoxUnknown EnvironmentInfo (fail
+// closed), so a caller cannot inherit the container type and label a hollow archive
+// as a valid PVE/PBS backup. The caller is responsible for screening an empty or
+// root prefix before calling.
+func DetectHostUnderPrefix(prefix string) *EnvironmentInfo {
+	info, _ := DetectWith(DetectOptions{RootPrefix: prefix})
+	if info == nil { // defensive; detectEnvironmentInfo never yields nil today
+		return &EnvironmentInfo{Type: types.ProxmoxUnknown, Version: "unknown"}
+	}
+	return info
+}
+
 // hostRooted reports whether detection is re-anchored under a host prefix.
 func hostRooted() bool {
 	return rootPrefix != "" && rootPrefix != string(filepath.Separator)

--- a/internal/environment/detect_deterministic_test.go
+++ b/internal/environment/detect_deterministic_test.go
@@ -269,6 +269,12 @@ func TestDetectPVE_FallbackOrder(t *testing.T) {
 	setValue(t, &additionalPaths, []string{})
 	setValue(t, &pveSourceFiles, []string{})
 	setValue(t, &pveDirCandidates, []string{})
+	// Null the offline-marker seams so the fallback-order subtests do not consult the
+	// build host's real /var/lib/dpkg/status, config.db, /usr binaries or share dir.
+	setValue(t, &dpkgStatusFile, filepath.Join(tmpDir, "missing-dpkg-status"))
+	setValue(t, &pveClusterDB, filepath.Join(tmpDir, "missing-config-db"))
+	setValue(t, &pveBinaryCandidates, []string{})
+	setValue(t, &pveShareDir, filepath.Join(tmpDir, "missing-pve-share"))
 
 	t.Run("via command", func(t *testing.T) {
 		setValue(t, &lookPathFunc, func(string) (string, error) { return "/fake/pveversion", nil })
@@ -352,6 +358,11 @@ func TestDetectPBS_FallbackOrder(t *testing.T) {
 	setValue(t, &additionalPaths, []string{})
 	setValue(t, &pbsSourceFiles, []string{})
 	setValue(t, &pbsDirCandidates, []string{})
+	// Null the offline-marker seams so the fallback-order subtests do not consult the
+	// build host's real /var/lib/dpkg/status, /usr binaries or share dir.
+	setValue(t, &dpkgStatusFile, filepath.Join(tmpDir, "missing-dpkg-status"))
+	setValue(t, &pbsBinaryCandidates, []string{})
+	setValue(t, &pbsShareDir, filepath.Join(tmpDir, "missing-pbs-share"))
 
 	t.Run("via command", func(t *testing.T) {
 		setValue(t, &lookPathFunc, func(string) (string, error) { return "/fake/proxmox-backup-manager", nil })

--- a/internal/environment/detect_deterministic_test.go
+++ b/internal/environment/detect_deterministic_test.go
@@ -20,6 +20,30 @@ func setValue[T any](t *testing.T, target *T, value T) {
 	t.Cleanup(func() { *target = original })
 }
 
+// nullFilesystemMarkerSeams points every filesystem-marker detection seam at absent
+// paths or empty lists so an unprefixed detection test cannot consult the build
+// host's real markers. The suite is run with `make test` on a PVE host, where the
+// real dpkg status, config.db, /usr binaries and share dirs would otherwise flip a
+// test that expects a non-Proxmox verdict. It does NOT touch the command seams
+// (lookPathFunc/runCommandFunc); callers set those. A subtest may override any seam
+// afterward (setValue restores per-subtest).
+func nullFilesystemMarkerSeams(t *testing.T, tmpDir string) {
+	t.Helper()
+	setValue(t, &pveVersionFile, filepath.Join(tmpDir, "missing-pve-version"))
+	setValue(t, &pveLegacyFile, filepath.Join(tmpDir, "missing-pve-legacy"))
+	setValue(t, &pbsVersionFile, filepath.Join(tmpDir, "missing-pbs-version"))
+	setValue(t, &pveSourceFiles, []string{})
+	setValue(t, &pbsSourceFiles, []string{})
+	setValue(t, &pveDirCandidates, []string{})
+	setValue(t, &pbsDirCandidates, []string{})
+	setValue(t, &dpkgStatusFile, filepath.Join(tmpDir, "missing-dpkg-status"))
+	setValue(t, &pveClusterDB, filepath.Join(tmpDir, "missing-config-db"))
+	setValue(t, &pveBinaryCandidates, []string{})
+	setValue(t, &pbsBinaryCandidates, []string{})
+	setValue(t, &pveShareDir, filepath.Join(tmpDir, "missing-pve-share"))
+	setValue(t, &pbsShareDir, filepath.Join(tmpDir, "missing-pbs-share"))
+}
+
 func TestExtendPath_EmptyPATH(t *testing.T) {
 	separator := string(os.PathListSeparator)
 	setValue(t, &additionalPaths, []string{"/custom/bin", "/custom/sbin"})
@@ -267,14 +291,7 @@ func TestDetectViaSources_Branches(t *testing.T) {
 func TestDetectPVE_FallbackOrder(t *testing.T) {
 	tmpDir := t.TempDir()
 	setValue(t, &additionalPaths, []string{})
-	setValue(t, &pveSourceFiles, []string{})
-	setValue(t, &pveDirCandidates, []string{})
-	// Null the offline-marker seams so the fallback-order subtests do not consult the
-	// build host's real /var/lib/dpkg/status, config.db, /usr binaries or share dir.
-	setValue(t, &dpkgStatusFile, filepath.Join(tmpDir, "missing-dpkg-status"))
-	setValue(t, &pveClusterDB, filepath.Join(tmpDir, "missing-config-db"))
-	setValue(t, &pveBinaryCandidates, []string{})
-	setValue(t, &pveShareDir, filepath.Join(tmpDir, "missing-pve-share"))
+	nullFilesystemMarkerSeams(t, tmpDir)
 
 	t.Run("via command", func(t *testing.T) {
 		setValue(t, &lookPathFunc, func(string) (string, error) { return "/fake/pveversion", nil })
@@ -356,13 +373,7 @@ func TestDetectPVE_FallbackOrder(t *testing.T) {
 func TestDetectPBS_FallbackOrder(t *testing.T) {
 	tmpDir := t.TempDir()
 	setValue(t, &additionalPaths, []string{})
-	setValue(t, &pbsSourceFiles, []string{})
-	setValue(t, &pbsDirCandidates, []string{})
-	// Null the offline-marker seams so the fallback-order subtests do not consult the
-	// build host's real /var/lib/dpkg/status, /usr binaries or share dir.
-	setValue(t, &dpkgStatusFile, filepath.Join(tmpDir, "missing-dpkg-status"))
-	setValue(t, &pbsBinaryCandidates, []string{})
-	setValue(t, &pbsShareDir, filepath.Join(tmpDir, "missing-pbs-share"))
+	nullFilesystemMarkerSeams(t, tmpDir)
 
 	t.Run("via command", func(t *testing.T) {
 		setValue(t, &lookPathFunc, func(string) (string, error) { return "/fake/proxmox-backup-manager", nil })
@@ -441,13 +452,7 @@ func TestDetectProxmox_Branches(t *testing.T) {
 	tmpDir := t.TempDir()
 	setValue(t, &additionalPaths, []string{})
 	setValue(t, &debugBaseDir, tmpDir)
-	setValue(t, &pveSourceFiles, []string{})
-	setValue(t, &pbsSourceFiles, []string{})
-	setValue(t, &pveDirCandidates, []string{})
-	setValue(t, &pbsDirCandidates, []string{})
-	setValue(t, &pveVersionFile, filepath.Join(tmpDir, "missing-pve-version"))
-	setValue(t, &pveLegacyFile, filepath.Join(tmpDir, "missing-pve-legacy"))
-	setValue(t, &pbsVersionFile, filepath.Join(tmpDir, "missing-pbs-version"))
+	nullFilesystemMarkerSeams(t, tmpDir)
 
 	t.Run("pve", func(t *testing.T) {
 		setValue(t, &lookPathFunc, func(binary string) (string, error) {
@@ -513,13 +518,7 @@ func TestDetect_Branches(t *testing.T) {
 	tmpDir := t.TempDir()
 	setValue(t, &additionalPaths, []string{})
 	setValue(t, &debugBaseDir, tmpDir)
-	setValue(t, &pveSourceFiles, []string{})
-	setValue(t, &pbsSourceFiles, []string{})
-	setValue(t, &pveDirCandidates, []string{})
-	setValue(t, &pbsDirCandidates, []string{})
-	setValue(t, &pveVersionFile, filepath.Join(tmpDir, "missing-pve-version"))
-	setValue(t, &pveLegacyFile, filepath.Join(tmpDir, "missing-pve-legacy"))
-	setValue(t, &pbsVersionFile, filepath.Join(tmpDir, "missing-pbs-version"))
+	nullFilesystemMarkerSeams(t, tmpDir)
 
 	t.Run("unknown", func(t *testing.T) {
 		setValue(t, &lookPathFunc, func(string) (string, error) { return "", errors.New("not found") })
@@ -560,13 +559,7 @@ func TestDetect_Branches(t *testing.T) {
 func TestGetVersion_Branches(t *testing.T) {
 	tmpDir := t.TempDir()
 	setValue(t, &additionalPaths, []string{})
-	setValue(t, &pveSourceFiles, []string{})
-	setValue(t, &pbsSourceFiles, []string{})
-	setValue(t, &pveDirCandidates, []string{})
-	setValue(t, &pbsDirCandidates, []string{})
-	setValue(t, &pveVersionFile, filepath.Join(tmpDir, "missing-pve-version"))
-	setValue(t, &pveLegacyFile, filepath.Join(tmpDir, "missing-pve-legacy"))
-	setValue(t, &pbsVersionFile, filepath.Join(tmpDir, "missing-pbs-version"))
+	nullFilesystemMarkerSeams(t, tmpDir)
 
 	t.Run("pve success", func(t *testing.T) {
 		setValue(t, &lookPathFunc, func(binary string) (string, error) {

--- a/internal/environment/detect_hybrid_bug_test.go
+++ b/internal/environment/detect_hybrid_bug_test.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"errors"
-	"path/filepath"
 	"testing"
 
 	"github.com/tis24dev/proxsave/internal/types"
@@ -10,16 +9,8 @@ import (
 
 func isolateDetectionFallbacks(t *testing.T) {
 	t.Helper()
-	tmpDir := t.TempDir()
-
 	setValue(t, &additionalPaths, []string{})
-	setValue(t, &pveSourceFiles, []string{})
-	setValue(t, &pbsSourceFiles, []string{})
-	setValue(t, &pveDirCandidates, []string{})
-	setValue(t, &pbsDirCandidates, []string{})
-	setValue(t, &pveVersionFile, filepath.Join(tmpDir, "missing-pve-version"))
-	setValue(t, &pveLegacyFile, filepath.Join(tmpDir, "missing-pve-legacy"))
-	setValue(t, &pbsVersionFile, filepath.Join(tmpDir, "missing-pbs-version"))
+	nullFilesystemMarkerSeams(t, t.TempDir())
 }
 
 func TestDetectHybridInstallationDual(t *testing.T) {

--- a/internal/environment/detect_prefix_test.go
+++ b/internal/environment/detect_prefix_test.go
@@ -1,0 +1,117 @@
+package environment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// writeFile is a small fixture helper for building a host tree under a prefix.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDetectWithPrefixPVE is the issue #255 detection regression: a plain
+// container root with only a mounted host tree under the prefix must detect the
+// host as Proxmox VE, where the historical container-root detection returned
+// ProxmoxUnknown.
+func TestDetectWithPrefixPVE(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "etc/pve-manager/version"), "8.2.2\n")
+	if err := os.MkdirAll(filepath.Join(root, "etc/pve"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxVE {
+		t.Fatalf("Type = %v, want ProxmoxVE", info.Type)
+	}
+	if info.PVEVersion != "8.2.2" {
+		t.Fatalf("PVEVersion = %q, want 8.2.2", info.PVEVersion)
+	}
+}
+
+func TestDetectWithPrefixPBS(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "etc/proxmox-backup/version"), "3.2.1\n")
+	if err := os.MkdirAll(filepath.Join(root, "etc/proxmox-backup"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxBS {
+		t.Fatalf("Type = %v, want ProxmoxBS", info.Type)
+	}
+}
+
+func TestDetectWithPrefixDual(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "etc/pve-manager/version"), "8.2.2\n")
+	writeFile(t, filepath.Join(root, "etc/proxmox-backup/version"), "3.2.1\n")
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxDual {
+		t.Fatalf("Type = %v, want ProxmoxDual", info.Type)
+	}
+}
+
+// TestDetectWithPrefixSkipsCommandProbes proves that under a prefix the host
+// command probes are not consulted: pveversion/proxmox-backup-manager run inside
+// the container answer for the container, not the mounted host, so detection must
+// rely on the re-anchored files only.
+func TestDetectWithPrefixSkipsCommandProbes(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "etc/pve-manager/version"), "8.2.2\n")
+
+	setValue(t, &lookPathFunc, func(string) (string, error) {
+		t.Fatal("lookPathFunc must not be called under a root prefix")
+		return "", nil
+	})
+	setValue(t, &runCommandFunc, func(string, ...string) (string, error) {
+		t.Fatal("runCommandFunc must not be called under a root prefix")
+		return "", nil
+	})
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxVE {
+		t.Fatalf("Type = %v, want ProxmoxVE", info.Type)
+	}
+}
+
+// TestDetectWithEmptyPrefixUnchanged guards backward compatibility: with no prefix
+// DetectWith is the historical Detect() and still probes commands.
+func TestDetectWithEmptyPrefixUnchanged(t *testing.T) {
+	probed := false
+	setValue(t, &lookPathFunc, func(string) (string, error) {
+		probed = true
+		return "", os.ErrNotExist
+	})
+	// A tree that would only be seen if the prefix were honored must be ignored.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "etc/pve-manager/version"), "8.2.2\n")
+
+	_, _ = DetectWith(DetectOptions{})
+	if !probed {
+		t.Fatal("command probes must run when no prefix is set")
+	}
+}

--- a/internal/environment/detect_prefix_test.go
+++ b/internal/environment/detect_prefix_test.go
@@ -98,6 +98,134 @@ func TestDetectWithPrefixSkipsCommandProbes(t *testing.T) {
 	}
 }
 
+// TestDetectWithPrefixPVEViaClusterDB locks the golden offline marker: a mounted
+// host whose /etc/pve pmxcfs bind is absent (only the persistent
+// /var/lib/pve-cluster/config.db present) must still detect as PVE. This is the
+// exact mp1-missing mount shape the host-backup mount-shape warning targets.
+func TestDetectWithPrefixPVEViaClusterDB(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "var/lib/pve-cluster/config.db"), "SQLite format 3\x00")
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxVE {
+		t.Fatalf("Type = %v, want ProxmoxVE", info.Type)
+	}
+}
+
+// TestDetectWithPrefixPVEViaBinaryOnly covers a /usr-only mount: no /etc or /var,
+// only the pmxcfs binary. It must detect PVE.
+func TestDetectWithPrefixPVEViaBinaryOnly(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "usr/bin/pmxcfs"), "\x7fELF")
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxVE {
+		t.Fatalf("Type = %v, want ProxmoxVE", info.Type)
+	}
+}
+
+// TestDetectWithPrefixPVEViaDpkgStatus proves the dpkg database recovers the real
+// offline version when the pmxcfs version files are absent.
+func TestDetectWithPrefixPVEViaDpkgStatus(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "var/lib/dpkg/status"),
+		"Package: bash\nStatus: install ok installed\nVersion: 5.2\n\n"+
+			"Package: pve-manager\nStatus: install ok installed\nVersion: 8.2.2-1\n")
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxVE {
+		t.Fatalf("Type = %v, want ProxmoxVE", info.Type)
+	}
+	if info.PVEVersion != "8.2.2-1" {
+		t.Fatalf("PVEVersion = %q, want 8.2.2-1", info.PVEVersion)
+	}
+}
+
+// TestDetectWithPrefixDpkgResidualNotInstalled locks the residual-config guard: a
+// pve-manager entry left as "deinstall ok config-files" is NOT installed and must
+// not detect PVE.
+func TestDetectWithPrefixDpkgResidualNotInstalled(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "var/lib/dpkg/status"),
+		"Package: pve-manager\nStatus: deinstall ok config-files\nVersion: 8.2.2-1\n")
+
+	if _, err := DetectWith(DetectOptions{RootPrefix: root}); err == nil {
+		t.Fatal("residual config-files entry must not detect Proxmox")
+	}
+}
+
+// TestDetectWithPrefixDpkgDependsMentionOnly locks stanza anchoring: pve-manager
+// appearing only inside another package's Depends: line must not detect PVE.
+func TestDetectWithPrefixDpkgDependsMentionOnly(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "var/lib/dpkg/status"),
+		"Package: some-tool\nStatus: install ok installed\nVersion: 1.0\nDepends: pve-manager\n")
+
+	if _, err := DetectWith(DetectOptions{RootPrefix: root}); err == nil {
+		t.Fatal("a Depends: pve-manager mention must not detect Proxmox")
+	}
+}
+
+// TestDetectWithPrefixPBSViaBinaryOnly covers a /usr-only PBS mount.
+func TestDetectWithPrefixPBSViaBinaryOnly(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "usr/sbin/proxmox-backup-proxy"), "\x7fELF")
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxBS {
+		t.Fatalf("Type = %v, want ProxmoxBS", info.Type)
+	}
+}
+
+// TestDetectWithPrefixDualViaDpkg: both server packages installed -> Dual.
+func TestDetectWithPrefixDualViaDpkg(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "var/lib/dpkg/status"),
+		"Package: pve-manager\nStatus: install ok installed\nVersion: 8.2.2-1\n\n"+
+			"Package: proxmox-backup-server\nStatus: install ok installed\nVersion: 3.2.1\n")
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err != nil {
+		t.Fatalf("DetectWith: %v", err)
+	}
+	if info.Type != types.ProxmoxDual {
+		t.Fatalf("Type = %v, want ProxmoxDual", info.Type)
+	}
+}
+
+// TestDetectWithPrefixPlainDebianNoFalsePositive is the no-spam contract: a generic
+// Debian tree with no Proxmox markers under the prefix must stay Unknown so the
+// caller can fail closed without a false PVE/PBS label. The pbsBinaryCandidates
+// client entry is intentionally excluded upstream so a proxmox-backup-client-only
+// host does not read as PBS.
+func TestDetectWithPrefixPlainDebianNoFalsePositive(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "etc/os-release"), "ID=debian\n")
+	writeFile(t, filepath.Join(root, "var/lib/dpkg/status"),
+		"Package: bash\nStatus: install ok installed\nVersion: 5.2\n\n"+
+			"Package: coreutils\nStatus: install ok installed\nVersion: 9.1\n")
+
+	info, err := DetectWith(DetectOptions{RootPrefix: root})
+	if err == nil {
+		t.Fatalf("plain Debian tree must not detect Proxmox, got Type=%v", info.Type)
+	}
+	if info.Type != types.ProxmoxUnknown {
+		t.Fatalf("Type = %v, want ProxmoxUnknown", info.Type)
+	}
+}
+
 // TestDetectWithEmptyPrefixUnchanged guards backward compatibility: with no prefix
 // DetectWith is the historical Detect() and still probes commands.
 func TestDetectWithEmptyPrefixUnchanged(t *testing.T) {

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -318,7 +318,7 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 		// link_state "relay_only"; provisioning below still fires on 200 +
 		// notify_secret regardless of chat_id, so this line is purely diagnostic but
 		// now reports the two meanings distinctly.
-		relayOnly := strings.TrimSpace(response.ChatID) == "" || strings.EqualFold(strings.TrimSpace(response.LinkState), "relay_only")
+		relayOnly := linkStateFromFields(response.LinkState, response.ChatID) == TelegramLinkStateRelayOnly
 		t.logger.Debug("Telegram: get-chat-id 200 (notifySecretPresent=%v botTokenPresent=%v chatIDPresent=%v linkState=%q relayOnly=%v)",
 			response.NotifySecret != "", response.BotToken != "", response.ChatID != "", response.LinkState, relayOnly)
 

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -77,6 +77,7 @@ type telegramCentralizedResponse struct {
 	Status       int    `json:"status"`
 	Message      string `json:"message,omitempty"`
 	NotifySecret string `json:"notify_secret"` // TOFU one-time provisioning
+	LinkState    string `json:"link_state"`    // "linked" | "relay_only"; additive, order-independent, ignored by old servers/clients
 }
 
 // Token and ChatID validation regex patterns
@@ -313,7 +314,13 @@ func (t *TelegramNotifier) fetchCentralizedCredentials(ctx context.Context) (str
 		if err := json.Unmarshal(body, &response); err != nil {
 			return "", "", fmt.Errorf("failed to parse response: %w", err)
 		}
-		t.logger.Debug("Telegram: get-chat-id 200 (notifySecretPresent=%v botTokenPresent=%v chatIDPresent=%v)", response.NotifySecret != "", response.BotToken != "", response.ChatID != "")
+		// Chat-less (Option A) bodies carry an empty chat_id and (optionally)
+		// link_state "relay_only"; provisioning below still fires on 200 +
+		// notify_secret regardless of chat_id, so this line is purely diagnostic but
+		// now reports the two meanings distinctly.
+		relayOnly := strings.TrimSpace(response.ChatID) == "" || strings.EqualFold(strings.TrimSpace(response.LinkState), "relay_only")
+		t.logger.Debug("Telegram: get-chat-id 200 (notifySecretPresent=%v botTokenPresent=%v chatIDPresent=%v linkState=%q relayOnly=%v)",
+			response.NotifySecret != "", response.BotToken != "", response.ChatID != "", response.LinkState, relayOnly)
 
 		// Adopt-on-token-present: whenever a 200 carries a notify_secret, the
 		// server wants the client to (re)adopt it, so we OVERWRITE any existing

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -154,13 +154,25 @@ func resolveTelegramLinkState(body []byte) TelegramLinkState {
 	if err := json.Unmarshal(body, &sig); err != nil {
 		return TelegramLinkStateRelayOnly
 	}
-	if ls := strings.TrimSpace(sig.LinkState); ls != "" {
+	return linkStateFromFields(sig.LinkState, sig.ChatID)
+}
+
+// linkStateFromFields is the single source of the linked-vs-relay-only precedence,
+// applied to already-extracted link_state and chat_id values: an explicit
+// link_state wins (case-insensitive "linked" -> Linked, anything else ->
+// RelayOnly); with no link_state, a non-empty chat_id -> Linked, empty ->
+// RelayOnly. resolveTelegramLinkState feeds it the JSON-parsed signal; the
+// get-chat-id diagnostic in telegram.go feeds it the response struct, so both read
+// the same discriminator and cannot diverge on edge cases (link_state "linked"
+// with empty chat_id, or an unrecognized link_state with a chat_id present).
+func linkStateFromFields(linkState, chatID string) TelegramLinkState {
+	if ls := strings.TrimSpace(linkState); ls != "" {
 		if strings.EqualFold(ls, "linked") {
 			return TelegramLinkStateLinked
 		}
 		return TelegramLinkStateRelayOnly
 	}
-	if strings.TrimSpace(sig.ChatID) != "" {
+	if strings.TrimSpace(chatID) != "" {
 		return TelegramLinkStateLinked
 	}
 	return TelegramLinkStateRelayOnly

--- a/internal/notify/telegram_registration.go
+++ b/internal/notify/telegram_registration.go
@@ -36,7 +36,43 @@ type TelegramRegistrationStatus struct {
 	Code    int
 	Message string
 	Error   error
+
+	// LinkState is meaningful ONLY on a 200 (Code == 200). It reports whether the
+	// centralized server has a real Telegram chat bound to this ServerID
+	// (TelegramLinkStateLinked) or issued a relay-only provisioning with NO chat
+	// (TelegramLinkStateRelayOnly, Option A: centralized monitoring works without
+	// any Telegram chat). It rides ALONGSIDE Code, which stays 200 for BOTH cases
+	// so every provisioning gate (Code == 200 && secret != "") keeps firing and
+	// chat-less hosts still provision; only copy/verdict consumers read LinkState.
+	// It defaults to TelegramLinkStateUnknown -- left on every non-200 result and
+	// unread there (consumers gate on Code first, exactly as they do for Provision).
+	LinkState TelegramLinkState
 }
+
+// TelegramLinkState is the resolved chat-link verdict for a get-chat-id 200. It
+// distinguishes the TWO meanings of an HTTP 200 so copy/verdict consumers (the
+// boot log and the pairing-wizard classifier) can tell a real Telegram chat link
+// from Option A's chat-less relay. Code stays 200 for BOTH cases so every
+// provisioning gate (Code == 200 && secret != "") keeps firing and chat-less
+// hosts still provision; only copy/verdict consumers read this field.
+type TelegramLinkState int
+
+const (
+	// TelegramLinkStateUnknown is the zero value: not determined. It is left on
+	// every non-200 result and on a bare hand-built 200 stub, and consumers keep
+	// their legacy verified behavior for it (they gate on Code first). A real 200
+	// from checkTelegramRegistrationWithSecret is ALWAYS resolved to Linked or
+	// RelayOnly, never Unknown.
+	TelegramLinkStateUnknown TelegramLinkState = iota
+	// TelegramLinkStateLinked: a real Telegram chat is bound to this ServerID
+	// (server link_state == "linked", or a non-empty chat_id in the fallback).
+	TelegramLinkStateLinked
+	// TelegramLinkStateRelayOnly: Option A. Centralized monitoring is provisioned
+	// (a notify_secret is issued) but NO Telegram chat is bound, so no Telegram
+	// message will ever arrive until the user links one (server link_state ==
+	// "relay_only", or a 200 with an empty chat_id in the fallback).
+	TelegramLinkStateRelayOnly
+)
 
 // StatusCodeMissingServerID is a sentinel (non-HTTP, negative) status Code set when
 // the local server identity is missing, so the classifier can give identity-specific
@@ -90,6 +126,44 @@ func parseTelegramBotToken(body []byte) string {
 		return ""
 	}
 	return strings.TrimSpace(parsed.BotToken)
+}
+
+// telegramLinkSignal carries the two additive discriminator fields lifted from a
+// get-chat-id 200 body: the server's explicit link_state ("linked" | "relay_only")
+// when present, and chat_id used as the fallback discriminator. notify_secret is
+// deliberately NOT part of this signal: it is issued in BOTH the chat-linked and
+// the relay-only (Option A) payloads, so it can never discriminate the two.
+type telegramLinkSignal struct {
+	LinkState string `json:"link_state"`
+	ChatID    string `json:"chat_id"`
+}
+
+// resolveTelegramLinkState resolves the linked-vs-relay-only discriminator per the
+// decided contract, consulted ONLY on a 200: PREFER the additive server field
+// link_state when present (link_state == "linked" -> Linked; anything else, e.g.
+// "relay_only", -> RelayOnly); OTHERWISE fall back to chat_id presence (non-empty
+// chat_id == Linked, empty == RelayOnly). notify_secret is present in BOTH cases
+// and is intentionally excluded. Best-effort: a non-JSON body resolves to
+// RelayOnly (fail-safe: an unparseable 200 never reads as a false Linked).
+// Additive and order-independent -- encoding/json ignores every other field, so
+// an old body without link_state parses cleanly and falls back to chat_id.
+// Case-insensitive on link_state so server casing drift still resolves only the
+// explicit "linked" token as Linked; any unrecognized value resolves to RelayOnly.
+func resolveTelegramLinkState(body []byte) TelegramLinkState {
+	var sig telegramLinkSignal
+	if err := json.Unmarshal(body, &sig); err != nil {
+		return TelegramLinkStateRelayOnly
+	}
+	if ls := strings.TrimSpace(sig.LinkState); ls != "" {
+		if strings.EqualFold(ls, "linked") {
+			return TelegramLinkStateLinked
+		}
+		return TelegramLinkStateRelayOnly
+	}
+	if strings.TrimSpace(sig.ChatID) != "" {
+		return TelegramLinkStateLinked
+	}
+	return TelegramLinkStateRelayOnly
 }
 
 // checkTelegramRegistrationWithSecret is the single shared implementation of the
@@ -162,8 +236,18 @@ func checkTelegramRegistrationWithSecret(ctx context.Context, serverAPIHost, ser
 
 	switch resp.Status {
 	case 200:
-		logTelegramRegistrationDebug(logger, "Telegram registration: status 200 (active)")
-		return TelegramRegistrationStatus{Code: 200, Message: "200 - Registration active"}, secret
+		// KEEP Code = 200 for BOTH meanings so the provisioning gates keep firing and
+		// chat-less hosts still provision. The linked-vs-relay-only distinction rides
+		// on LinkState + a distinct Message, read only by copy/verdict consumers.
+		// Discriminator: prefer the server's link_state, else fall back to chat_id
+		// presence (see resolveTelegramLinkState). notify_secret is issued in BOTH
+		// cases, so it is NEVER used to discriminate here.
+		if resolveTelegramLinkState(body) == TelegramLinkStateLinked {
+			logTelegramRegistrationDebug(logger, "Telegram registration: status 200 (linked; Telegram chat active)")
+			return TelegramRegistrationStatus{Code: 200, Message: "200 - Registration active", LinkState: TelegramLinkStateLinked}, secret
+		}
+		logTelegramRegistrationDebug(logger, "Telegram registration: status 200 (relay-only; no Telegram chat, Option A)")
+		return TelegramRegistrationStatus{Code: 200, Message: "200 - Relay provisioned (no Telegram chat)", LinkState: TelegramLinkStateRelayOnly}, secret
 	case 403:
 		logTelegramRegistrationDebug(logger, "Telegram registration: status 403 (bot not started / first contact)")
 		return TelegramRegistrationStatus{Code: 403, Message: "403 - Start the bot and send the Server ID", Error: fmt.Errorf("%s", body)}, ""

--- a/internal/notify/telegram_registration_test.go
+++ b/internal/notify/telegram_registration_test.go
@@ -181,3 +181,60 @@ func TestCheckTelegramRegistrationLinkStateDiscriminator(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveTelegramLinkState exercises the parser directly, independent of HTTP
+// handling, to lock the fail-safe and case-insensitivity guarantees: an
+// unparseable body must never read as a false Linked, and only the explicit
+// "linked" token (any casing) resolves to Linked.
+func TestResolveTelegramLinkState(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want TelegramLinkState
+	}{
+		{"non-json-body-falls-back-relay-only", "not-json", TelegramLinkStateRelayOnly},
+		{"truncated-json-falls-back-relay-only", "{", TelegramLinkStateRelayOnly},
+		{"empty-body-falls-back-relay-only", "", TelegramLinkStateRelayOnly},
+		{"link-state-uppercase-linked", `{"link_state":"LINKED"}`, TelegramLinkStateLinked},
+		{"link-state-mixed-case-linked", `{"link_state":"Linked"}`, TelegramLinkStateLinked},
+		{"link-state-unknown-value-relay-only", `{"link_state":"something-else","chat_id":"123"}`, TelegramLinkStateRelayOnly},
+		{"link-state-linked-empty-chat-id", `{"link_state":"linked"}`, TelegramLinkStateLinked},
+		{"no-link-state-chat-id-linked", `{"chat_id":"123"}`, TelegramLinkStateLinked},
+		{"no-link-state-no-chat-id-relay-only", `{}`, TelegramLinkStateRelayOnly},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveTelegramLinkState([]byte(tt.body)); got != tt.want {
+				t.Fatalf("resolveTelegramLinkState(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLinkStateFromFields pins the shared precedence helper that both
+// resolveTelegramLinkState and the get-chat-id diagnostic in telegram.go consume,
+// covering the two edge cases where the old inline diagnostic diverged: an explicit
+// "linked" with empty chat_id (must be Linked), and an unrecognized link_state with
+// a chat_id present (must be RelayOnly).
+func TestLinkStateFromFields(t *testing.T) {
+	cases := []struct {
+		name      string
+		linkState string
+		chatID    string
+		want      TelegramLinkState
+	}{
+		{"linked-token-empty-chat-id", "linked", "", TelegramLinkStateLinked},
+		{"linked-token-case-insensitive", "LiNkEd", "", TelegramLinkStateLinked},
+		{"unknown-link-state-with-chat-id", "foo", "123", TelegramLinkStateRelayOnly},
+		{"relay-only-token-overrides-chat-id", "relay_only", "123", TelegramLinkStateRelayOnly},
+		{"no-link-state-chat-id-linked", "", "123", TelegramLinkStateLinked},
+		{"no-link-state-no-chat-id-relay-only", "", "", TelegramLinkStateRelayOnly},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := linkStateFromFields(tt.linkState, tt.chatID); got != tt.want {
+				t.Fatalf("linkStateFromFields(%q,%q) = %v, want %v", tt.linkState, tt.chatID, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/notify/telegram_registration_test.go
+++ b/internal/notify/telegram_registration_test.go
@@ -86,3 +86,98 @@ func TestCheckTelegramRegistrationSendsVersionHeader(t *testing.T) {
 		t.Fatalf("X-Proxsave-Provision = %q, want empty on the public status path", capturedProvision)
 	}
 }
+
+// TestCheckTelegramRegistrationLinkStateDiscriminator locks the linked-vs-relay-only
+// signal interpretation on a 200: Code stays 200 for BOTH so the provisioning gates
+// keep firing; LinkState and Message distinguish chat-linked from chat-less
+// (Option A). It covers all four contract paths: link_state present ("linked" /
+// "relay_only") takes precedence, and link_state absent falls back to chat_id. It
+// also proves notify_secret is NOT a discriminator (present in the relay-only case
+// yet LinkState stays RelayOnly, and present in a linked case yet LinkState stays
+// Linked).
+func TestCheckTelegramRegistrationLinkStateDiscriminator(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+
+	const linkedMsg = "200 - Registration active"
+	const relayMsg = "200 - Relay provisioned (no Telegram chat)"
+
+	cases := []struct {
+		name        string
+		body        string
+		wantState   TelegramLinkState
+		wantMessage string
+	}{
+		{
+			// Chat-linked: chat_id present, no link_state. notify_secret also present
+			// (linked hosts get one on provision) yet the host is still Linked -> proves
+			// notify_secret is not the discriminator.
+			name:        "linked-chat-id-no-link-state",
+			body:        `{"chat_id":"123456","notify_secret":"` + provisionTestSecret + `"}`,
+			wantState:   TelegramLinkStateLinked,
+			wantMessage: linkedMsg,
+		},
+		{
+			// Chat-less (Option A): notify_secret issued, NO chat_id, no link_state.
+			name:        "relay-only-secret-no-chat-id",
+			body:        `{"notify_secret":"` + provisionTestSecret + `"}`,
+			wantState:   TelegramLinkStateRelayOnly,
+			wantMessage: relayMsg,
+		},
+		{
+			// link_state="relay_only" wins even though a chat_id is present (precedence
+			// of the explicit server field over the chat_id fallback).
+			name:        "link-state-relay-only-overrides-chat-id",
+			body:        `{"chat_id":"123456","notify_secret":"` + provisionTestSecret + `","link_state":"relay_only"}`,
+			wantState:   TelegramLinkStateRelayOnly,
+			wantMessage: relayMsg,
+		},
+		{
+			// link_state="linked" wins even with NO chat_id (precedence, linked direction).
+			name:        "link-state-linked-overrides-missing-chat-id",
+			body:        `{"notify_secret":"` + provisionTestSecret + `","link_state":"linked"}`,
+			wantState:   TelegramLinkStateLinked,
+			wantMessage: linkedMsg,
+		},
+		{
+			// link_state absent, no chat_id -> fallback yields relay-only.
+			name:        "no-link-state-no-chat-id-falls-back-relay-only",
+			body:        `{}`,
+			wantState:   TelegramLinkStateRelayOnly,
+			wantMessage: relayMsg,
+		},
+		{
+			// link_state absent, chat_id present -> fallback yields linked.
+			name:        "no-link-state-with-chat-id-falls-back-linked",
+			body:        `{"chat_id":"987654"}`,
+			wantState:   TelegramLinkStateLinked,
+			wantMessage: linkedMsg,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			status := CheckTelegramRegistration(context.Background(), server.URL, "server-123", logger)
+
+			// Code MUST stay 200 for BOTH meanings so provisioning gates keep firing.
+			if status.Code != 200 {
+				t.Fatalf("Code = %d, want 200", status.Code)
+			}
+			if status.Error != nil {
+				t.Fatalf("unexpected error: %v", status.Error)
+			}
+			if status.LinkState != tt.wantState {
+				t.Fatalf("LinkState = %v, want %v (body=%s)", status.LinkState, tt.wantState, tt.body)
+			}
+			// Linked copy must stay byte-identical; relay-only copy is the distinct line.
+			if status.Message != tt.wantMessage {
+				t.Fatalf("Message = %q, want %q (body=%s)", status.Message, tt.wantMessage, tt.body)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1224,6 +1224,7 @@ func applyCollectorOverrides(cc *backup.CollectorConfig, cfg *config.Config) {
 	cc.BackupScriptRepository = cfg.BackupScriptRepository
 	cc.BackupConfigFile = cfg.BackupConfigFile
 	cc.SystemRootPrefix = cfg.SystemRootPrefix
+	cc.HostBackupMode = cfg.HostBackupMode
 	cc.ScriptRepositoryPath = cfg.BaseDir
 	if cfg.PxarDatastoreConcurrency > 0 {
 		cc.PxarDatastoreConcurrency = cfg.PxarDatastoreConcurrency

--- a/internal/orchestrator/telegram_setup_classify.go
+++ b/internal/orchestrator/telegram_setup_classify.go
@@ -40,6 +40,21 @@ type TelegramSetupState struct {
 func ClassifyTelegramSetupResult(res notify.TelegramRegistrationResult) TelegramSetupState {
 	switch res.Status.Code {
 	case 200:
+		// Option A (chat-less): a get-chat-id 200 has TWO meanings and the client
+		// keeps Code==200 for BOTH so the provisioning gates keep firing. But a
+		// relay-only 200 means centralized monitoring is active WITHOUT any linked
+		// Telegram chat, so it MUST NOT read as Verified/"Linked" - no message will
+		// ever arrive until the user pairs a chat. Consult the additive link-state
+		// discriminator BEFORE the provision switch, because a relay secret can be
+		// persisted/confirmed even when no chat is linked (Provision alone cannot
+		// tell the two 200 meanings apart). Distinct code, retryable, A-aware, NOT
+		// fatal (a later Check can link a chat). A bare 200 stub or an old server
+		// leaves LinkState Unknown -> unchanged verified path below, so the ~1244
+		// linked hosts stay byte-identical.
+		if res.Status.LinkState == notify.TelegramLinkStateRelayOnly {
+			return TelegramSetupState{Code: "centralized_no_telegram", Label: "No Telegram chat", Severity: TelegramSeverityAction, Verified: false,
+				Message: "Centralized monitoring is active, but no Telegram chat is linked yet. Start the bot and send the Server ID to link a chat, then press Check again."}
+		}
 		switch res.Provision {
 		case notify.TelegramProvisionPersistFailed:
 			return TelegramSetupState{Code: "linked_token_unsaved", Label: "Linked (finishing setup)", Severity: TelegramSeverityPartial, Verified: true, Partial: true,

--- a/internal/orchestrator/telegram_setup_classify_test.go
+++ b/internal/orchestrator/telegram_setup_classify_test.go
@@ -107,6 +107,20 @@ func TestClassifyTelegramSetupResult(t *testing.T) {
 			wantCode:    "unexpected_response",
 			wantMessage: "x",
 		},
+		{
+			name:         "200-relay-only-chatless",
+			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200, LinkState: notify.TelegramLinkStateRelayOnly}},
+			wantCode:     "centralized_no_telegram",
+			wantMessage:  "Centralized monitoring is active, but no Telegram chat is linked yet. Start the bot and send the Server ID to link a chat, then press Check again.",
+			wantVerified: false,
+		},
+		{
+			name:         "200-linked-explicit",
+			res:          notify.TelegramRegistrationResult{Status: notify.TelegramRegistrationStatus{Code: 200, LinkState: notify.TelegramLinkStateLinked}, Provision: notify.TelegramProvisionConfirmed},
+			wantCode:     "linked_confirmed",
+			wantMessage:  "Linked successfully.",
+			wantVerified: true,
+		},
 	}
 
 	for _, tt := range cases {
@@ -128,6 +142,70 @@ func TestClassifyTelegramSetupResult(t *testing.T) {
 				t.Fatalf("Fatal=%v, want %v", st.Fatal, tt.wantFatal)
 			}
 		})
+	}
+}
+
+// TestClassifyTelegramSetupResult_RelayOnlyNotVerified pins the Option A fix: a
+// chat-less 200 (centralized monitoring active, notify_secret issued, but NO
+// Telegram chat) classifies as a DISTINCT, non-Verified, non-Fatal, retryable
+// state, so the pairing wizard never shows green "Linked" for a host that will
+// never receive a Telegram message. The LinkState discriminator is consulted
+// BEFORE the provision switch, so it holds even when a relay secret was confirmed.
+func TestClassifyTelegramSetupResult_RelayOnlyNotVerified(t *testing.T) {
+	for _, prov := range []notify.TelegramProvisionOutcome{
+		notify.TelegramProvisionNotApplicable,
+		notify.TelegramProvisionNoToken,
+		notify.TelegramProvisionConfirmed,
+		notify.TelegramProvisionPersistFailed,
+		notify.TelegramProvisionConfirmFailed,
+		notify.TelegramProvisionClean,
+	} {
+		st := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{
+			Status:    notify.TelegramRegistrationStatus{Code: 200, LinkState: notify.TelegramLinkStateRelayOnly},
+			Provision: prov,
+		})
+		if st.Verified {
+			t.Fatalf("relay-only 200 (provision=%d) must NOT be Verified", prov)
+		}
+		if st.Fatal {
+			t.Fatalf("relay-only 200 (provision=%d) must NOT be Fatal (a later Check can link a chat)", prov)
+		}
+		if st.Partial {
+			t.Fatalf("relay-only 200 (provision=%d) must NOT be Partial", prov)
+		}
+		if st.Code != "centralized_no_telegram" {
+			t.Fatalf("relay-only 200 (provision=%d) Code=%q, want centralized_no_telegram", prov, st.Code)
+		}
+		if st.Severity != TelegramSeverityAction {
+			t.Fatalf("relay-only 200 (provision=%d) Severity=%d, want Action(%d)", prov, st.Severity, TelegramSeverityAction)
+		}
+		if st.Label == "" {
+			t.Fatalf("relay-only 200 (provision=%d) has an empty Label", prov)
+		}
+	}
+
+	// A relay-only state must be DISTINCT from the linked verdict.
+	relay := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{
+		Status: notify.TelegramRegistrationStatus{Code: 200, LinkState: notify.TelegramLinkStateRelayOnly},
+	})
+	linked := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{
+		Status:    notify.TelegramRegistrationStatus{Code: 200, LinkState: notify.TelegramLinkStateLinked},
+		Provision: notify.TelegramProvisionConfirmed,
+	})
+	if relay.Code == linked.Code {
+		t.Fatalf("relay-only and linked 200 must classify distinctly, both got %q", relay.Code)
+	}
+	if !linked.Verified || linked.Code != "linked_confirmed" || linked.Message != "Linked successfully." {
+		t.Fatalf("linked 200 must stay Verified linked_confirmed \"Linked successfully.\", got Verified=%v Code=%q Message=%q", linked.Verified, linked.Code, linked.Message)
+	}
+
+	// Backward compat: a 200 with no LinkState (old server -> Unknown zero value)
+	// keeps the legacy Verified behavior (chat_id fallback resolves linked upstream).
+	unknown := ClassifyTelegramSetupResult(notify.TelegramRegistrationResult{
+		Status: notify.TelegramRegistrationStatus{Code: 200},
+	})
+	if !unknown.Verified || unknown.Code != "linked_confirmed" {
+		t.Fatalf("200 with Unknown LinkState must stay Verified linked_confirmed, got Verified=%v Code=%q", unknown.Verified, unknown.Code)
 	}
 }
 

--- a/internal/safefs/confined.go
+++ b/internal/safefs/confined.go
@@ -49,15 +49,24 @@ func ReadFileUnderRoot(path string) ([]byte, error) {
 }
 
 // ReadFileInRoot reads absPath interpreted relative to root, following symlink
-// chains but confining every hop inside root. It exists because os.Root does NOT
-// re-anchor an absolute symlink target: os.Root.Open on a component whose target
-// is an absolute path (for example /etc/ceph/ceph.conf -> /etc/pve/ceph.conf on a
-// Proxmox host) is refused with "path escapes from parent", so a bare
-// os.OpenRoot(root).Open(rel) cannot read such a file. This helper instead walks
-// the chain by hand with Lstat/Readlink and re-anchors every absolute target back
-// under root, so /etc/ceph/ceph.conf resolves to root/etc/pve/ceph.conf and a
-// hostile target like /etc/shadow re-anchors to root/etc/shadow, never the real
-// host file. Relative "../" escapes are refused by os.Root at the syscall level.
+// chains but confining every resolved path inside root. It exists because os.Root
+// does NOT re-anchor an absolute symlink target: os.Root.Open on a component whose
+// target is an absolute path (for example /etc/ceph/ceph.conf -> /etc/pve/ceph.conf
+// on a Proxmox host) is refused with "path escapes from parent", so a bare
+// os.OpenRoot(root).Open(rel) cannot read such a file. This helper instead resolves
+// the WHOLE-PATH symlink at each hop by hand with Lstat/Readlink and re-anchors an
+// absolute target back under root, so /etc/ceph/ceph.conf resolves to
+// root/etc/pve/ceph.conf and a hostile target like /etc/shadow re-anchors to
+// root/etc/shadow, never the real host file.
+//
+// Scope and containment, precisely:
+//   - It re-anchors a symlink whose whole current path resolves to a symlink (the
+//     Proxmox /etc/ceph/ceph.conf case). An INTERMEDIATE directory component that is
+//     itself an absolute symlink is not re-anchored: os.Root.Lstat refuses it with
+//     "path escapes from parent", so such a layout fails closed (safe, but not read).
+//   - A relative "../" target is lexically collapsed and re-anchored under root by
+//     filepath.Clean (leading ".." above root are dropped), so it stays confined;
+//     os.Root is the syscall-level backstop, not the primary guard for that case.
 //
 // Use it to read a system file under a SYSTEM_ROOT_PREFIX when the file may be an
 // absolute symlink into another prefixed subtree. It is read-only and never

--- a/internal/safefs/confined.go
+++ b/internal/safefs/confined.go
@@ -1,10 +1,16 @@
 package safefs
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+// maxSymlinkHops caps the symlink chain length ReadFileInRoot will follow,
+// mirroring the kernel MAXSYMLINKS limit so a symlink loop terminates.
+const maxSymlinkHops = 40
 
 // OpenFileUnderRoot opens path through an *os.Root on its parent directory,
 // confining the open at the syscall level: the path is no longer a raw variable
@@ -40,4 +46,61 @@ func ReadFileUnderRoot(path string) ([]byte, error) {
 	}
 	defer func() { _ = f.Close() }()
 	return io.ReadAll(f)
+}
+
+// ReadFileInRoot reads absPath interpreted relative to root, following symlink
+// chains but confining every hop inside root. It exists because os.Root does NOT
+// re-anchor an absolute symlink target: os.Root.Open on a component whose target
+// is an absolute path (for example /etc/ceph/ceph.conf -> /etc/pve/ceph.conf on a
+// Proxmox host) is refused with "path escapes from parent", so a bare
+// os.OpenRoot(root).Open(rel) cannot read such a file. This helper instead walks
+// the chain by hand with Lstat/Readlink and re-anchors every absolute target back
+// under root, so /etc/ceph/ceph.conf resolves to root/etc/pve/ceph.conf and a
+// hostile target like /etc/shadow re-anchors to root/etc/shadow, never the real
+// host file. Relative "../" escapes are refused by os.Root at the syscall level.
+//
+// Use it to read a system file under a SYSTEM_ROOT_PREFIX when the file may be an
+// absolute symlink into another prefixed subtree. It is read-only and never
+// touches anything outside root. This is a structural G304 remedy (os.Root), not a
+// suppression, and is distinct from OpenFileUnderRoot which roots at the parent
+// directory and guards only the final component.
+func ReadFileInRoot(root, absPath string) ([]byte, error) {
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	rel := strings.TrimPrefix(filepath.Clean("/"+absPath), "/")
+	if rel == "" || rel == "." {
+		return nil, fmt.Errorf("read in root %q: empty relative path", root)
+	}
+
+	for hop := 0; hop < maxSymlinkHops; hop++ {
+		info, lerr := r.Lstat(rel)
+		if lerr != nil {
+			return nil, lerr
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			f, oerr := r.Open(rel)
+			if oerr != nil {
+				return nil, oerr
+			}
+			defer func() { _ = f.Close() }()
+			return io.ReadAll(f)
+		}
+		target, rlerr := r.Readlink(rel)
+		if rlerr != nil {
+			return nil, rlerr
+		}
+		if filepath.IsAbs(target) {
+			rel = strings.TrimPrefix(filepath.Clean(target), "/")
+		} else {
+			rel = strings.TrimPrefix(filepath.Clean("/"+filepath.Join(filepath.Dir(rel), target)), "/")
+		}
+		if rel == "" || rel == "." {
+			return nil, fmt.Errorf("read in root %q: symlink resolves to root", root)
+		}
+	}
+	return nil, fmt.Errorf("read in root %q: too many symlink hops resolving %q", root, absPath)
 }

--- a/internal/safefs/confined_test.go
+++ b/internal/safefs/confined_test.go
@@ -86,3 +86,103 @@ func TestOpenFileUnderRootCreatesAndWrites(t *testing.T) {
 		t.Fatalf("got %q want data", b)
 	}
 }
+
+func TestReadFileInRootReadsPlainFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "etc/hostname"), []byte("host\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFileInRoot(root, "/etc/hostname")
+	if err != nil {
+		t.Fatalf("ReadFileInRoot: %v", err)
+	}
+	if string(got) != "host\n" {
+		t.Fatalf("got %q want %q", got, "host\n")
+	}
+}
+
+// TestReadFileInRootReanchorsAbsoluteSymlink is the regression for issue #255:
+// on a Proxmox host /etc/ceph/ceph.conf is an absolute symlink to
+// /etc/pve/ceph.conf. Under a prefix the target must re-anchor to
+// PREFIX/etc/pve/ceph.conf, not escape to the container root.
+func TestReadFileInRootReanchorsAbsoluteSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc/pve"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "etc/ceph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "etc/pve/ceph.conf"), []byte("fsid=DEADBEEF\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/pve/ceph.conf", filepath.Join(root, "etc/ceph/ceph.conf")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFileInRoot(root, "/etc/ceph/ceph.conf")
+	if err != nil {
+		t.Fatalf("ReadFileInRoot: %v", err)
+	}
+	if string(got) != "fsid=DEADBEEF\n" {
+		t.Fatalf("got %q want %q", got, "fsid=DEADBEEF\n")
+	}
+}
+
+// TestReadFileInRootConfinesHostileAbsoluteTarget proves a symlink pointing at an
+// absolute path outside the intended subtree re-anchors under root and can never
+// read the real host file: a decoy planted at root/etc/shadow is returned, and
+// with no decoy the read fails rather than reaching the machine's /etc/shadow.
+func TestReadFileInRootConfinesHostileAbsoluteTarget(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/shadow", filepath.Join(root, "etc/evil")); err != nil {
+		t.Fatal(err)
+	}
+	// Without a decoy the confined target does not exist: must fail, never read the real /etc/shadow.
+	if _, err := ReadFileInRoot(root, "/etc/evil"); err == nil {
+		t.Fatal("expected error resolving hostile symlink with no in-root target")
+	}
+	// With a decoy inside root, the read is confined to it.
+	if err := os.WriteFile(filepath.Join(root, "etc/shadow"), []byte("CONFINED\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFileInRoot(root, "/etc/evil")
+	if err != nil {
+		t.Fatalf("ReadFileInRoot: %v", err)
+	}
+	if string(got) != "CONFINED\n" {
+		t.Fatalf("got %q want confined decoy", got)
+	}
+}
+
+func TestReadFileInRootRefusesRelativeEscape(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A relative target climbing above root is refused by os.Root at Lstat time.
+	if err := os.Symlink("../../../../etc/passwd", filepath.Join(root, "etc/climb")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileInRoot(root, "/etc/climb"); err == nil {
+		t.Fatal("expected error for relative escape target")
+	}
+}
+
+func TestReadFileInRootDetectsLoop(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/loop", filepath.Join(root, "etc/loop")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileInRoot(root, "/etc/loop"); err == nil {
+		t.Fatal("expected error for symlink loop")
+	}
+}

--- a/internal/safefs/confined_test.go
+++ b/internal/safefs/confined_test.go
@@ -160,17 +160,52 @@ func TestReadFileInRootConfinesHostileAbsoluteTarget(t *testing.T) {
 	}
 }
 
-func TestReadFileInRootRefusesRelativeEscape(t *testing.T) {
+func TestReadFileInRootConfinesRelativeEscape(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "etc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// A relative target climbing above root is refused by os.Root at Lstat time.
+	// A relative target climbing above root is lexically collapsed by filepath.Clean
+	// (the leading ".." above root are dropped) and re-anchored under root, so it
+	// resolves to root/etc/passwd, never the machine's real /etc/passwd.
 	if err := os.Symlink("../../../../etc/passwd", filepath.Join(root, "etc/climb")); err != nil {
 		t.Fatal(err)
 	}
+	// With no in-root target the read fails rather than reaching the real file.
 	if _, err := ReadFileInRoot(root, "/etc/climb"); err == nil {
-		t.Fatal("expected error for relative escape target")
+		t.Fatal("expected error resolving relative escape with no in-root target")
+	}
+	// With a decoy inside root, the read is confined to it, proving containment.
+	if err := os.WriteFile(filepath.Join(root, "etc/passwd"), []byte("CONFINED\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFileInRoot(root, "/etc/climb")
+	if err != nil {
+		t.Fatalf("ReadFileInRoot: %v", err)
+	}
+	if string(got) != "CONFINED\n" {
+		t.Fatalf("got %q want confined decoy", got)
+	}
+}
+
+// TestReadFileInRootRefusesIntermediateAbsoluteSymlinkDir documents that an
+// intermediate directory component that is itself an absolute symlink is not
+// re-anchored: os.Root refuses it and the read fails closed (safe). The real
+// Proxmox layout uses a final-component symlink, which is handled.
+func TestReadFileInRootRefusesIntermediateAbsoluteSymlinkDir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc/pve"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "etc/pve/ceph.conf"), []byte("fsid=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// etc/cephdir is an absolute-symlink DIRECTORY; the file under it is a real file.
+	if err := os.Symlink("/etc/pve", filepath.Join(root, "etc/cephdir")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileInRoot(root, "/etc/cephdir/ceph.conf"); err == nil {
+		t.Fatal("expected fail-closed error for an intermediate absolute-symlink directory")
 	}
 }
 


### PR DESCRIPTION
Automated release PR for `v0.30.0-beta5`.

<!-- release-tag: v0.30.0-beta5 -->

## Summary by Sourcery

Introduce host-backup mode and prefix-aware environment detection, collection, and documentation, and refine Telegram registration handling to distinguish chat-linked vs relay-only hosts while adding symlink-safe filesystem reads.

New Features:
- Add HOST_BACKUP_MODE configuration and logic to support running ProxSave as an HA-LXC backup appliance against a Proxmox host mounted under SYSTEM_ROOT_PREFIX.
- Provide prefix-aware Proxmox environment detection via DetectWith options, enabling accurate host-type detection under a mounted root prefix.
- Expose Telegram link state (chat-linked vs relay-only) in registration responses and setup classification so centralized monitoring can work without a linked chat while being surfaced distinctly.

Enhancements:
- Implement safe, prefix-aware file reading that follows and confines absolute and relative symlinks under a root, and use it for Ceph configuration detection.
- Gate host-namespace commands and enable shared-kernel ZFS collection appropriately under SYSTEM_ROOT_PREFIX and host-backup mode, with clearer logging and inventory markers.
- Refine bootstrap/runtime behavior to re-detect the Proxmox host environment under the prefix and warn about common host-backup mount misconfigurations, including missing /etc/pve binds.
- Improve Telegram logging and setup classification to keep provisioning behavior unchanged while providing clearer diagnostics and user-facing messages for relay-only states.

Documentation:
- Document HA-LXC backup appliance usage, HOST_BACKUP_MODE, and SYSTEM_ROOT_PREFIX semantics in configuration and examples, including behavior of host commands, ZFS inventory, and symlink handling.

Tests:
- Add tests for prefix-aware environment detection, host-backup re-detection and mount warnings, Ceph config reading through absolute symlinks under a prefix, host-command gating and kernel-shared command behavior, network inventory logging under host-backup mode, Telegram link-state resolution and setup classification, and symlink-confined filesystem reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **HOST_BACKUP_MODE** for HA-LXC host-backed, read-only Proxmox mounts, including improved environment detection and conditional data collection.
  * Added clearer Telegram setup outcomes for **relay-only vs linked** cases to guide next steps.
* **Bug Fixes**
  * Improved prefixed/proxied host handling to fail safely when expected host markers/mounts aren’t present.
  * Added safeguards and warnings for missing host `/etc/pve` bind-mount shape and stricter host-path/symlink confinement.
* **Documentation**
  * Updated configuration docs, examples, and installer messaging to describe HA-LXC host-backup mode and required settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds host-backup support for mounted Proxmox roots and improves Telegram registration handling. The main changes are:

- Adds prefix-aware Proxmox environment detection and host-backup configuration.
- Confines symlink-following filesystem reads to the configured root.
- Separates namespace-scoped commands from shared-kernel ZFS collection.
- Marks relay-only Telegram registrations separately from chat-linked hosts.
- Documents the HA-LXC backup appliance setup and mount requirements.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Failed prefix detection now replaces the live environment type with unknown.
- The corrected environment is set before backup orchestration and collection begin.
- Tests cover failed prefix detection for both live PVE and PBS environments.
- No blocking issue remains in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/proxsave/main_runtime.go | Re-detects the mounted host after configuration loading and fails closed when the prefix has no Proxmox markers. |
| internal/environment/detect.go | Adds filesystem-only, prefix-aware detection with offline PVE and PBS markers. |
| internal/safefs/confined.go | Adds root-confined reads that safely resolve relative and absolute symlinks. |
| internal/backup/collector_network_inventory.go | Skips namespace-scoped host commands under a prefix while recording why inventory fields are absent. |
| internal/notify/telegram_registration.go | Exposes whether Telegram registration is chat-linked or relay-only. |

<sub>Reviews (2): Last reviewed commit: ["test(environment): centralize marker-sea..."](https://github.com/tis24dev/proxsave/commit/9e3dd7da76acd402588d513455bd29aee782cfcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45889645)</sub>

<!-- /greptile_comment -->