### PR TITLE
Release v0.30.0-beta8

### DIFF
--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -79,24 +79,43 @@ const whatsnewScreenTimeout = 10 * time.Minute
 // the flag untouched, so the write sits inside `if err == nil`, never in a
 // defer/teardown (SCRN-03, SCRN-04, Pitfall 9).
 func maybeShowWhatsnew(ctx context.Context, session *shell.Session, baseDir, toolVersion string) {
-	show, body, err := whatsnewDecide(baseDir, toolVersion)
-	if err != nil {
-		if errors.Is(err, whatsnew.ErrStateParse) {
-			// Best-effort self-heal, stay silent. No dry-run gate here (unlike maybeWarnWhatsnew):
-			// both callers guarantee no --dry-run before reaching this point -- the dashboard is
-			// bare-invocation-only, and showWhatsnewScreen (the --show-whatsnew entry) returns early
-			// under args.DryRun -- so the --dry-run flag can never coexist with this write.
-			_ = whatsnewSaveSeen(baseDir, toolVersion)
-		}
-		return
-	}
+	show, body := whatsnewResolve(baseDir, toolVersion)
 	if !show {
 		return
 	}
+	whatsnewRender(ctx, session, baseDir, toolVersion, body)
+}
+
+// whatsnewResolve makes the Screen 0 SHOW/skip decision WITHOUT touching any TTY, so a
+// caller can decide before starting a Bubble Tea program. It mirrors maybeShowWhatsnew's
+// fail-toward-silence contract: a not-unseen verdict, or any non-parse Decide error,
+// returns show=false; a corrupt seen-flag (whatsnew.ErrStateParse) self-heals best-effort
+// (re-seed last_seen=current via whatsnewSaveSeen, silent) and also returns show=false. No
+// dry-run gate is needed here: both callers guarantee no --dry-run before reaching this
+// point (the dashboard is bare-invocation-only; showWhatsnewScreen returns early under
+// args.DryRun), so the self-heal write can never coexist with --dry-run. Callers MUST NOT
+// start a session unless this returns show=true: starting one only to Close it on a no-op
+// leaks the terminal's async capability-query responses (mode 2026/2027) into the shell.
+func whatsnewResolve(baseDir, toolVersion string) (show bool, body string) {
+	show, body, err := whatsnewDecide(baseDir, toolVersion)
+	if err != nil {
+		if errors.Is(err, whatsnew.ErrStateParse) {
+			_ = whatsnewSaveSeen(baseDir, toolVersion)
+		}
+		return false, ""
+	}
+	return show, body
+}
+
+// whatsnewRender pushes Screen 0 (body) onto session, bounded by the total
+// whatsnewScreenTimeout, and clears the seen-flag ONLY on an explicit continue
+// (err == nil): a timeout (context.DeadlineExceeded) or Esc (shell.ErrAborted) is a
+// non-nil error and leaves the flag untouched, so the write stays out of any
+// defer/teardown and the fallback warning keeps firing next run (SCRN-03/04, Pitfall 9).
+func whatsnewRender(ctx context.Context, session *shell.Session, baseDir, toolVersion, body string) {
 	wnCtx, cancel := context.WithTimeout(ctx, whatsnewScreenTimeout)
 	defer cancel()
-	err = whatsnewRun(wnCtx, session, body)
-	if err == nil {
+	if whatsnewRun(wnCtx, session, body) == nil {
 		_ = whatsnewSaveSeen(baseDir, toolVersion)
 	}
 }
@@ -106,11 +125,14 @@ func maybeShowWhatsnew(ctx context.Context, session *shell.Session, baseDir, too
 // freshly installed binary, so Screen 0 opens at the end of every interactive upgrade,
 // rendered by the binary that actually carries the notes (each binary compiles in its own
 // notes registry, so the download path -- where the OLD binary drives finalize -- MUST
-// hand off to the installed binary to show the new release's notes). It builds its own
-// shell.Session (the upgrade has none) using the same testDashboardSession seam as the
-// dashboard, and delegates to maybeShowWhatsnew so the seen-flag gating, self-heal, timeout,
-// and write-only-on-continue behavior are identical and the seen-flag write dedupes against
-// the dashboard trigger. Interactive-gated so an automated/piped re-invocation is a no-op.
+// hand off to the installed binary to show the new release's notes). It shares the exact
+// gating/self-heal (whatsnewResolve) and render/continue-write (whatsnewRender) helpers with
+// the dashboard's maybeShowWhatsnew, so the seen-flag behavior is identical and dedupes
+// against the dashboard trigger, and it builds its own shell.Session (the upgrade has none)
+// via the same testDashboardSession seam. Crucially it resolves the SHOW/skip decision
+// BEFORE building the session, so a no-op re-invocation never starts a TTY program (which
+// would leak the terminal's async mode-2026/2027 replies into the shell). Interactive-gated
+// so an automated/piped re-invocation is a no-op.
 func showWhatsnewScreen(ctx context.Context, args *cli.Args, toolVersion string) {
 	if !dashboardIsInteractive() {
 		return
@@ -122,6 +144,18 @@ func showWhatsnewScreen(ctx context.Context, args *cli.Args, toolVersion string)
 	if args != nil && args.DryRun {
 		return
 	}
+	// Decide BEFORE starting a Bubble Tea program. Unlike the dashboard (which keeps its
+	// program alive for the menu loop that drains the terminal's replies), this entry
+	// Closes immediately after Screen 0, so a program started for a no-op quits before the
+	// input reader consumes the terminal's async mode-2026/2027 capability-query responses,
+	// which then leak into the parent shell as stray input ("2026: command not found"). So
+	// a not-unseen verdict (or a corrupt-flag self-heal) must never spin up a TTY at all.
+	baseDir, _ := detectedBaseDirOrFallback()
+	show, body := whatsnewResolve(baseDir, toolVersion)
+	if !show {
+		return
+	}
+
 	var session *shell.Session
 	if s := testDashboardSession; s != nil {
 		session = s(ctx)
@@ -145,8 +179,7 @@ func showWhatsnewScreen(ctx context.Context, args *cli.Args, toolVersion string)
 	}
 	defer func() { _ = session.Close() }()
 
-	baseDir, _ := detectedBaseDirOrFallback()
-	maybeShowWhatsnew(ctx, session, baseDir, toolVersion)
+	whatsnewRender(ctx, session, baseDir, toolVersion, body)
 }
 
 // dashboardBareInvocationCheck: only a completely bare `proxsave` (no flags

--- a/cmd/proxsave/whatsnew_upgrade_test.go
+++ b/cmd/proxsave/whatsnew_upgrade_test.go
@@ -196,8 +196,9 @@ func TestShowWhatsnewScreenSkipsUnderDryRun(t *testing.T) {
 }
 
 // TestShowWhatsnewScreenDelegatesWhenInteractive: on an interactive terminal showWhatsnewScreen
-// builds a session and delegates to maybeShowWhatsnew, keyed on the RUNNING binary's version
-// (the value passed in), so it renders from the binary's own compiled-in notes registry.
+// resolves the SHOW/skip decision keyed on the RUNNING binary's version (the value passed in),
+// so it renders from the binary's own compiled-in notes registry. Decide returns no-show here,
+// so the session is intentionally never built (that path is covered separately).
 func TestShowWhatsnewScreenDelegatesWhenInteractive(t *testing.T) {
 	origInter := dashboardIsInteractive
 	origSess := testDashboardSession
@@ -226,6 +227,82 @@ func TestShowWhatsnewScreenDelegatesWhenInteractive(t *testing.T) {
 	}
 	if gotVersion != "0.30.0-beta6" {
 		t.Fatalf("Decide called with version %q, want the running binary version 0.30.0-beta6", gotVersion)
+	}
+}
+
+// TestShowWhatsnewScreenSkipsSessionWhenNothingUnseen guards the terminal-leak fix: when
+// Decide reports nothing unseen, --show-whatsnew must return WITHOUT building a Bubble Tea
+// session. The standalone entry Closes its program immediately after Screen 0, so starting
+// one for a no-op quits before the input reader consumes the terminal's async mode-2026/2027
+// capability-query replies, which then leak into the parent shell ("2026: command not found").
+func TestShowWhatsnewScreenSkipsSessionWhenNothingUnseen(t *testing.T) {
+	origInter := dashboardIsInteractive
+	origSess := testDashboardSession
+	origDecide := whatsnewDecide
+	dashboardIsInteractive = func() bool { return true }
+	sessionBuilt := false
+	testDashboardSession = func(ctx context.Context) *shell.Session {
+		sessionBuilt = true
+		return shell.StartForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"})
+	}
+	whatsnewDecide = func(baseDir, current string) (bool, string, error) { return false, "", nil }
+	t.Cleanup(func() {
+		dashboardIsInteractive = origInter
+		testDashboardSession = origSess
+		whatsnewDecide = origDecide
+		releaseDashboardLeftovers()
+	})
+
+	showWhatsnewScreen(context.Background(), &cli.Args{}, "0.30.0-beta7")
+	if sessionBuilt {
+		t.Fatal("nothing-unseen showWhatsnewScreen must NOT build a session (a started-then-closed program leaks the terminal's query replies)")
+	}
+}
+
+// TestShowWhatsnewScreenBuildsSessionWhenUnseen: when Decide reports unseen notes, the
+// standalone --show-whatsnew entry builds a session and renders Screen 0 with the resolved
+// body, then clears the seen-flag on a clean continue.
+func TestShowWhatsnewScreenBuildsSessionWhenUnseen(t *testing.T) {
+	origInter := dashboardIsInteractive
+	origSess := testDashboardSession
+	origDecide := whatsnewDecide
+	origRun := whatsnewRun
+	origSave := whatsnewSaveSeen
+	dashboardIsInteractive = func() bool { return true }
+	sessionBuilt := false
+	testDashboardSession = func(ctx context.Context) *shell.Session {
+		sessionBuilt = true
+		return shell.StartForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"})
+	}
+	whatsnewDecide = func(baseDir, current string) (bool, string, error) { return true, "NOTES-BODY", nil }
+	gotBody := ""
+	whatsnewRun = func(ctx context.Context, session *shell.Session, body string) error {
+		if session == nil {
+			t.Error("whatsnewRun received a nil session")
+		}
+		gotBody = body
+		return nil
+	}
+	saved := false
+	whatsnewSaveSeen = func(baseDir, version string) error { saved = true; return nil }
+	t.Cleanup(func() {
+		dashboardIsInteractive = origInter
+		testDashboardSession = origSess
+		whatsnewDecide = origDecide
+		whatsnewRun = origRun
+		whatsnewSaveSeen = origSave
+		releaseDashboardLeftovers()
+	})
+
+	showWhatsnewScreen(context.Background(), &cli.Args{}, "0.30.0-beta7")
+	if !sessionBuilt {
+		t.Fatal("unseen showWhatsnewScreen must build a session to render Screen 0")
+	}
+	if gotBody != "NOTES-BODY" {
+		t.Fatalf("whatsnewRun body = %q, want the resolved body NOTES-BODY", gotBody)
+	}
+	if !saved {
+		t.Fatal("a clean continue must clear the seen-flag")
 	}
 }
 

--- a/cmd/proxsave/whatsnew_wiring_test.go
+++ b/cmd/proxsave/whatsnew_wiring_test.go
@@ -440,15 +440,17 @@ func TestScreen0UsesDedicatedTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse dashboard.go: %v", err)
 	}
+	// The render + timeout live in whatsnewRender (shared by maybeShowWhatsnew and the
+	// standalone showWhatsnewScreen), so the dedicated-cap guard inspects that helper.
 	var fn *ast.FuncDecl
 	for _, d := range f.Decls {
-		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == "maybeShowWhatsnew" {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == "whatsnewRender" {
 			fn = fd
 			break
 		}
 	}
 	if fn == nil || fn.Body == nil {
-		t.Fatal("maybeShowWhatsnew not found in dashboard.go")
+		t.Fatal("whatsnewRender not found in dashboard.go")
 	}
 
 	usesDedicated, usesSharedIdle := false, false
@@ -475,10 +477,10 @@ func TestScreen0UsesDedicatedTimeout(t *testing.T) {
 	})
 
 	if !usesDedicated {
-		t.Fatal("maybeShowWhatsnew must bound Screen 0 with context.WithTimeout(ctx, whatsnewScreenTimeout) (SCRN-04 dedicated cap)")
+		t.Fatal("whatsnewRender must bound Screen 0 with context.WithTimeout(ctx, whatsnewScreenTimeout) (SCRN-04 dedicated cap)")
 	}
 	if usesSharedIdle {
-		t.Fatal("maybeShowWhatsnew must NOT use the shared withDashboardIdle for Screen 0 (SCRN-04 requires a dedicated timeout distinct from the menu idle cap)")
+		t.Fatal("whatsnewRender must NOT use the shared withDashboardIdle for Screen 0 (SCRN-04 requires a dedicated timeout distinct from the menu idle cap)")
 	}
 }
 


### PR DESCRIPTION
Automated release PR for `v0.30.0-beta8`.

<!-- release-tag: v0.30.0-beta8 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “What’s New” screen now determines whether content should be shown before starting the interactive session.
  * Skipped screens no longer open an unnecessary dashboard session.
  * Seen-status recovery is handled more safely when stored state is invalid.
  * The seen status is updated only after the “What’s New” flow completes successfully.

* **Tests**
  * Added coverage for skipped and displayed “What’s New” scenarios.
  * Updated validation for screen timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors the whats-new screen flow to avoid starting a terminal session when there are no unseen release notes.
- Separates release-note resolution from terminal rendering while preserving timeout and seen-state behavior.
- Resolves visibility before constructing the standalone upgrade session.
- Adds regression coverage for skipped and rendered standalone sessions and updates timeout wiring assertions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security defects identified.

The refactor preserves the existing decision, timeout, error, and seen-state contracts while preventing terminal initialization on the no-op standalone path, with targeted tests covering both branches.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/proxsave/dashboard.go | Cleanly separates decision and rendering phases so no-op standalone invocations avoid initializing a terminal session while retaining existing state and timeout semantics. |
| cmd/proxsave/whatsnew_upgrade_test.go | Adds focused regression tests proving sessions are skipped when notes are already seen and created when unseen notes must render. |
| cmd/proxsave/whatsnew_wiring_test.go | Updates the AST-based timeout contract test to inspect the new shared rendering helper. |

<sub>Reviews (1): Last reviewed commit: ["fix(whatsnew): decide before starting th..."](https://github.com/tis24dev/proxsave/commit/fc946dac1a910c8f0d5cd2877fe6ad64d15e1326) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47073800)</sub>

<!-- /greptile_comment -->