### PR TITLE
Release v0.30.0-beta9

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -103,7 +103,7 @@ proxsave -h
 | `--version` | `-v` | Display version information |
 | `--help` | `-h` | Show help message |
 | `--backup` | | Run the backup now and skip the interactive dashboard. This is the default behavior when proxsave runs non-interactively (cron, pipe, systemd). |
-| `--daemon` | | Run as the resident backup daemon (schedules + supervises runs, reports to healthchecks). Invoked by `proxsave-daemon.service`; not run by hand. See [docs/DAEMON.md](DAEMON.md). |
+| `--daemon` | | Run as the resident backup daemon (schedules + supervises runs, reports to healthchecks). Invoked by `proxsave-daemon.service`; not run by hand. See [docs/DAEMON.md](DAEMON.md) and [docs/HEALTHCHECKS.md](HEALTHCHECKS.md). |
 | `--daemon-setup` | | Switch this install to daemon mode: install+enable the service and remove the cron entry. |
 | `--daemon-remove` | | Revert to the cron scheduler, disable the service, and block future upgrades from reinstalling the daemon. |
 | `--daemon-status` | | Print the daemon status (scheduler mode, service state, running version, binary alignment) and exit. Exit code is `0` only when the daemon is running and aligned, non-zero otherwise, so scripts can gate on it. |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,7 +93,7 @@ The compiled default for `SCHEDULER_MODE` is `cron`, but a fresh install default
 
 ## Healthchecks connector (daemon)
 
-The daemon can push to an external [healthchecks](https://healthchecks.io/) monitor. The four checks and the centralized-vs-self behavior are documented in [DAEMON.md](DAEMON.md); the keys are:
+The daemon can push to an external [healthchecks](https://healthchecks.io/) monitor. The four checks, the monitoring portal, and the centralized-vs-self behavior are documented in [HEALTHCHECKS.md](HEALTHCHECKS.md); the keys are:
 
 ```bash
 HEALTHCHECK_ENABLED=false      # forced true by --daemon-setup / --upgrade auto-migration

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -1,6 +1,8 @@
-# Resident daemon + healthchecks monitoring
+# Resident daemon
 
-ProxSave can run as a **resident daemon** instead of a one-shot `cron` job. The daemon schedules and supervises each backup, adds a hang watchdog, and reports to an external [healthchecks](https://healthchecks.io/) monitor so silent failures (a crash before notifying, a run that hangs, a host that is simply down) are caught by an external dead-man switch.
+ProxSave can run as a **resident daemon** instead of a one-shot `cron` job. The daemon schedules and supervises each backup, adds a hang watchdog, and reports to an external monitor so silent failures (a crash before notifying, a run that hangs, a host that is simply down) are caught by an external dead-man switch.
+
+This document covers the daemon itself. The monitoring side, which checks exist, what they cover, and how to configure the centralized or self-hosted monitor, is in [HEALTHCHECKS.md](HEALTHCHECKS.md).
 
 ## Why
 
@@ -10,40 +12,17 @@ A pure "notify only on failure" model is blind to the worst failures: the proces
 
 - **Schedules** the daily backup itself (replacing the crontab entry) at the `SCHEDULER_TIME` ("Run at") time.
 - **Supervises** each run as a child process (`proxsave --backup`) under a `MAX_RUN_DURATION` timeout. A run that overruns gets `SIGTERM`, then `SIGKILL` after a 30-second grace, and is reported as a **hang**.
-- **Reports** four kinds of monitored checks (see below). systemd (`proxsave-daemon.service`, `Restart=always`) is only the keep-alive supervisor; the daemon schedules internally.
+- **Reports** four families of monitored checks: daemon liveness, the backup outcome, release updates, and one per notification channel. See [HEALTHCHECKS.md](HEALTHCHECKS.md).
 
-## The monitored checks
-
-The daemon reports **four** check families to the monitor, each shown as a `proxsave-*` check:
-
-| Check | When it pings | Meaning |
-|-------|---------------|---------|
-| `proxsave-alive` | a heartbeat every `HEALTHCHECK_HEARTBEAT_INTERVAL` (and once at startup) | if the daemon dies or the host goes down, this check stops pinging and the monitor alarms on the silence |
-| `proxsave-backup` | per run: `/start` at launch, then the child's exit code, or `/fail` on a hang | `/0` is success (green); any non-zero exit code makes the check go DOWN (red); `/fail` is the hang case |
-| `proxsave-updates` | every `HEALTHCHECK_UPDATE_INTERVAL` (and once at startup) | `/0` when up to date, `/1` when a newer release exists (the check goes DOWN so you get alerted to upgrade) |
-| `proxsave-notify-<channel>` | after each run, one per channel the backup child attempted | `/0` when that channel delivered cleanly, `/1` on a warning or error (the check goes DOWN) |
-
-Notes on the exact semantics:
-
-- The `proxsave-backup` finish ping is always `/` plus the run's exit status (clamped to 0..255). There is no separate "warning" suffix: exit `1` simply pings `/1`, and a start failure or an external kill is reported as a non-zero code too. When `HEALTHCHECK_SEND_LOG` is on, a bounded log tail (up to about 8 KiB) rides along as the request body on a **supervised** run's non-zero exit or hang. A standalone (manual or dashboard) backup hands off only its exit code, so its finish ping carries no log tail.
-- The `proxsave-updates` check only flips to `/0` on a definite up-to-date answer. An inconclusive check (GitHub unreachable or rate-limited) re-affirms the last verdict rather than flapping a real `/1` back to `/0`.
-- The `proxsave-notify-<channel>` checks are driven by what the backup child actually attempted (recorded per run), not by cached config, so a channel toggled off does not leave a stale DOWN.
-- One notify check exists per enabled channel among email, telegram, gotify, and webhook. In centralized mode the daemon tells the server which channels are enabled so it provisions exactly those checks.
+systemd (`proxsave-daemon.service`, `Restart=always`) is only the keep-alive supervisor; the daemon schedules internally.
 
 ### BACKUP_ENABLED=false
 
-When `BACKUP_ENABLED=false`, the daemon skips the scheduled run entirely: no child process, no backup-outcome ping, so `proxsave-backup` honestly goes down (no false green). The `proxsave-alive` heartbeat keeps signalling, so you can still tell the daemon is up.
+When `BACKUP_ENABLED=false`, the daemon skips the scheduled run entirely: no child process, no backup-outcome ping, so `proxsave-backup` honestly goes down (no false green). The liveness heartbeat keeps signalling, so you can still tell the daemon is up.
 
 ## Standalone backups: the SIGUSR1 handoff
 
-A backup run outside the daemon (by hand, or the dashboard "run now") does not ping the monitor itself. The resident daemon is the sole pinger. Instead, a standalone run drops a handoff file (`.manual_backup_outcome.json`) and wakes the daemon with `SIGUSR1`; the daemon then pings `proxsave-backup` with that run's outcome. A handoff older than 15 minutes is dropped without pinging (so a long-past run never flips the check), and if no live daemon is found nothing pings.
-
-## Two modes
-
-- **centralized** (default): the daemon fetches its ping URLs from the ProxSave server (`GET /api/healthcheck/config`), reusing the SAME identity it already uses for Telegram notifications (`server_id` + relay secret). No manual setup, no API key on the client. It requires the client to have been paired on Telegram (that is where the relay secret comes from). If the fetch fails, the daemon falls back to the cached `HEALTHCHECK_ALIVE_URL` / `HEALTHCHECK_BACKUP_URL`.
-- **self**: point the daemon at your own healthchecks (self-hosted or SaaS). Set `HEALTHCHECK_PING_ENDPOINT` (plus optional `HEALTHCHECK_PING_KEY`) and the per-check IDs, or give full per-check URLs. Self mode covers all four check families: `*_ALIVE_*`, `*_BACKUP_*`, `*_UPDATES_*`, and the `*_NOTIFY_<CHANNEL>_*` keys (a URL and an ID per channel). A full `*_URL` takes precedence over the matching `*_ID`.
-
-A client without a relay secret still gets the daemon (scheduling + hang watchdog); the healthcheck reporting stays off until `self` mode is configured.
+A backup run outside the daemon (by hand, or the dashboard "run now") does not ping the monitor itself. The resident daemon is the sole pinger. Instead, a standalone run drops a handoff file (`.manual_backup_outcome.json`) and wakes the daemon with `SIGUSR1`; the daemon then pings the backup check with that run's outcome. A handoff older than 15 minutes is dropped without pinging (so a long-past run never flips the check), and if no live daemon is found nothing pings.
 
 ## Binary alignment after an upgrade
 
@@ -77,7 +56,7 @@ The last two lines (`Running version:` and `Binary alignment:`) appear only when
 
 ## Install
 
-New installs default to the daemon. The install wizard (TUI and `--cli`) asks for the **Scheduler engine** (daemon or cron) just before the **Run at** time. Choosing the daemon installs `proxsave-daemon.service`, removes the cron entry, and turns on centralized healthchecks.
+New installs default to the daemon. The install wizard (TUI and `--cli`) asks for the **Scheduler engine** (daemon or cron) just before the **Run at** time. Choosing the daemon installs `proxsave-daemon.service`, removes the cron entry, and turns on centralized monitoring. The wizard then asks for the monitoring mode; see [HEALTHCHECKS.md](HEALTHCHECKS.md).
 
 ## Retrofit existing installs
 
@@ -134,35 +113,11 @@ MAX_RUN_DURATION=1h            # watchdog hard timeout for one backup
 DAEMON_OPT_OUT=false           # set true by --daemon-remove; upgrade won't re-migrate
 BACKUP_ENABLED=true            # false: daemon skips the scheduled run (backup check goes down)
 
-# Healthchecks
+# Monitoring: enabled here, configured in HEALTHCHECKS.md
 HEALTHCHECK_ENABLED=false      # forced true by --daemon-setup / auto-migration
-HEALTHCHECK_MODE=centralized   # centralized (fetch from server) | self
-HEALTHCHECK_HEARTBEAT_INTERVAL=5m
-HEALTHCHECK_UPDATE_INTERVAL=5m
-HEALTHCHECK_SEND_LOG=true      # attach a log tail on a failed/hung run
-
-# Centralized cache (auto-filled from the server; do not edit)
-HEALTHCHECK_ALIVE_URL=
-HEALTHCHECK_BACKUP_URL=
-
-# Self mode
-HEALTHCHECK_PING_ENDPOINT=https://hc-ping.com
-HEALTHCHECK_PING_KEY=
-HEALTHCHECK_ALIVE_ID=
-HEALTHCHECK_BACKUP_ID=
-HEALTHCHECK_UPDATES_URL=
-HEALTHCHECK_UPDATES_ID=
-HEALTHCHECK_NOTIFY_EMAIL_URL=
-HEALTHCHECK_NOTIFY_EMAIL_ID=
-HEALTHCHECK_NOTIFY_TELEGRAM_URL=
-HEALTHCHECK_NOTIFY_TELEGRAM_ID=
-HEALTHCHECK_NOTIFY_GOTIFY_URL=
-HEALTHCHECK_NOTIFY_GOTIFY_ID=
-HEALTHCHECK_NOTIFY_WEBHOOK_URL=
-HEALTHCHECK_NOTIFY_WEBHOOK_ID=
 ```
 
-In self mode you only need the checks you actually want: set the endpoint plus the alive and backup IDs to get the two core checks, and add the updates and per-channel notify IDs (or full URLs) to report those too. In centralized mode the server resolves all of these for you.
+The `HEALTHCHECK_*` keys that decide *where* and *what* the daemon reports live in [HEALTHCHECKS.md](HEALTHCHECKS.md).
 
 See [CONFIGURATION.md](CONFIGURATION.md) for the full variable reference and [CLI_REFERENCE.md](CLI_REFERENCE.md) for the `--daemon-*` flags.
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -179,7 +179,7 @@ Your monitoring portal (single-use link, valid ~1h):
 
 Open it to set a password and configure alert channels. The link is single-use and valid for about an hour. If you run your own healthchecks server (self mode), the check instead confirms that your alive URL is reachable and shows no link. After each check a `Sensors:` list shows one colored line per monitored check with its state and last-ping age.
 
-See [DAEMON.md](DAEMON.md) for the monitoring model.
+See [HEALTHCHECKS.md](HEALTHCHECKS.md) for the monitoring model, what each status keyword means, and what to do about it.
 
 ### Post-install
 

--- a/docs/DASHBOARD_TUI.md
+++ b/docs/DASHBOARD_TUI.md
@@ -165,6 +165,29 @@ The new-key flow is the exception: it uses a separate `agesetup` adapter via `ru
 
 Every flow that owns a session swaps its console output to `io.Discard` for the session lifetime, because raw stdout corrupts the altscreen diff renderer, and defers `Close` so it runs LIFO (terminal restored before the writer comes back). The streamed backup instead redirects `os.Stdout` and captures both loggers into the panel's pipe, so the panel shows the same colored lines and blank-line spacers in the same order as the CLI.
 
+## The healthchecks setup screen
+
+`install.RunHealthcheckSetup` (`internal/ui/flows/install/healthcheck.go`) is one screen serving two callers: the install wizard and the dashboard's `Healthchecks` diagnostic check. The `backToMenu` flag is the only difference. It relabels `Check` to `Re-check` and `Skip`/`Continue` to `Back`, and it makes the check run automatically on entry instead of waiting for a keypress. Nothing else forks, so the two surfaces cannot drift.
+
+Structure worth knowing before touching it:
+
+- **The bootstrap can do network work.** `orchestrator.BuildHealthcheckSetupBootstrap` may run a relay-secret provisioning handshake of up to ten seconds when a centralized host has a resolved Server ID but no secret on disk. It is wrapped in the same `components.RunTask` spinner the connection check uses, so the screen shows progress instead of looking frozen. An already-provisioned host returns immediately.
+- **Eligibility decides whether the screen exists at all.** Only the centralized and self verdicts render; every other verdict sets `Shown=false` and returns. The skip reasons are classified separately by `orchestrator.ClassifyHealthcheckSetupSkip` so the caller can say *why* rather than printing one generic line.
+- **The classifiers own all user-facing copy.** `ClassifyHealthcheckSetupResult`, `ClassifyHealthcheckSelfResult`, and `ClassifyHealthcheckSetupSkip` return a `HealthcheckSetupState` (keyword, message, level, plus the `Verified` and `Fatal` policy flags). `cmd/proxsave/healthcheck_setup_cli.go` renders the same struct, which is what keeps the TUI and `--cli` wordings identical. Add a state there, not in a renderer.
+- **`Verified` latches and `Fatal` removes `Check`.** A hard blocker means another attempt cannot help, so the action disappears rather than inviting a pointless retry. `HealthcheckSetupMaxVerificationAttempts` caps the rest. Esc skips unless already verified.
+- **Self mode swaps three things**: the check seam, the classifier, and the intro copy. The magic-link box and the sensor list stay naturally empty, so there is no self-mode branch in the renderer.
+- **Ordering constraint.** `RunHealthcheckSelfParams` must run *before* `RunHealthcheckSetup`, because the bootstrap re-reads the alive URL from the just-written `backup.env`. The params screen is the only one of the two that writes config; the check screen writes nothing.
+
+Rendering goes through `WithSelectorPromptStyled`, the intentional sanitizer bypass, so everything untrusted is scrubbed by the builder itself:
+
+- the status keyword and its explanation run through `components.SanitizeText`, because the explanation embeds probe error text read raw from the status file;
+- each sensor line is composed then sanitized, because the sensor name is a status-file record key;
+- the portal magic link is validated *upstream* at the capture boundary by `serverbot.TrustedLoginURL`, which is `SanitizeLoginURL` (http(s), printable ASCII) plus a same-registrable-domain check against the bot server. A link that fails either test is dropped to empty and the box is skipped.
+
+Colors come from `renderHealthcheckLevel`, which delegates to `orchestrator.RenderStatusLevel`, and `sensorSetupLevel`, which maps a `health.SensorLevel` onto the same four levels rather than introducing a second palette switch. The rows themselves are built by `health.SensorRows(status, heartbeatInterval, updateInterval, now)`, with `now` injected so the staleness branches stay deterministic in tests.
+
+The user-facing meaning of every keyword and sensor state is in [HEALTHCHECKS.md](HEALTHCHECKS.md).
+
 ## Writing a new screen or flow
 
 To add a component screen:

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1032,7 +1032,8 @@ journalctl -u proxsave-daemon.service -f      # follow its log
 proxsave --daemon-remove                       # revert to a cron entry
 ```
 
-See [DAEMON.md](DAEMON.md) for the healthchecks modes (centralized vs self) and the full
+See [DAEMON.md](DAEMON.md) for the daemon itself and [HEALTHCHECKS.md](HEALTHCHECKS.md)
+for the monitoring modes (centralized vs self), the monitoring portal, and the full
 configuration keys.
 
 ---

--- a/docs/HEALTHCHECKS.md
+++ b/docs/HEALTHCHECKS.md
@@ -1,0 +1,314 @@
+# Backup monitoring (healthchecks)
+
+ProxSave reports every backup outcome, plus a liveness heartbeat, to an external
+[healthchecks](https://healthchecks.io/) monitor. The monitor alarms on **silence**, so
+the failures ProxSave cannot report itself are still caught: a crash before the
+notification phase, an OOM kill, a run wedged on a dead mount, a host that never came
+back from a reboot.
+
+Monitoring is driven by the resident daemon, which is the only thing that pings. A host
+still on the cron scheduler reports nothing, no matter how the keys below are set. See
+[DAEMON.md](DAEMON.md) for the scheduler engines and how to switch.
+
+## Why silence is the signal
+
+A "notify me when a backup fails" setup is blind to the worst failures, because a
+process that panics, hangs, or never starts cannot send you anything. Every channel in
+[NOTIFICATIONS.md](NOTIFICATIONS.md) has that blind spot by construction.
+
+The daemon closes it by pushing to something outside this host. Each check has an
+expected cadence on the monitor side. Miss it and the check goes down and your alerts
+fire, whether ProxSave was able to say anything or not.
+
+## What gets monitored
+
+The daemon reports four families of checks, each shown on the monitor as a
+`proxsave-*` check.
+
+| Check | When it pings | What it covers |
+|-------|---------------|----------------|
+| `proxsave-alive` | immediately at daemon start, then every `HEALTHCHECK_HEARTBEAT_INTERVAL` | the daemon and the host are up. Stops when either dies, and the monitor alarms on the silence |
+| `proxsave-backup` | per run: `/start` at launch, then the run's exit code, or `/fail` on a hang | whether the backup ran and how it ended |
+| `proxsave-updates` | immediately at daemon start, then every `HEALTHCHECK_UPDATE_INTERVAL` | `/0` when up to date, `/1` when a newer release exists, so the check goes down and tells you to upgrade |
+| `proxsave-notify-<channel>` | after each run, one per channel the backup attempted | whether that notification channel actually delivered |
+
+### Ping details
+
+The exact wire behavior, in case you are reading the monitor's event log:
+
+- Every ping is a POST, bounded at 10 seconds. A slow or down monitor never stalls the
+  daemon and never delays a backup.
+- The run start ping carries `?rid=<uuid>`, a fresh run id, so the monitor can pair it
+  with the finish ping and measure the run's duration.
+- The finish ping is `/` plus the run's exit status, clamped into 0..255. There is no
+  separate "warning" suffix: exit `1` pings `/1`, and a start failure or an external
+  kill reports a non-zero code the same way. `/0` is the only green outcome.
+- A hang pings `/fail` with a `timed out after <duration>` body, because a killed child
+  has no exit code to report.
+- With `HEALTHCHECK_SEND_LOG=true`, a log tail rides along as the request body on a
+  **supervised** run that failed or hung. The daemon keeps the last 8 KiB of the run's
+  output for this, and the ping body is hard-capped at 100 kB regardless. A standalone
+  run (see below) hands off only its exit code, so its finish ping carries no log tail.
+- The updates check only pings `/0` on a definite up-to-date answer. An inconclusive
+  check, for instance GitHub unreachable or rate limited, re-affirms the previous
+  verdict instead of flapping a real `/1` back to green, and pings nothing at all when
+  there is no previous verdict to re-affirm.
+- The per-channel checks are driven by what the backup actually attempted, recorded per
+  run, and not by cached configuration. A channel you turn off does not leave a stale
+  down check behind. There is one check per enabled channel among email, telegram,
+  gotify, and webhook. In centralized mode the daemon tells the server which channels
+  are enabled, so it provisions exactly those.
+- Ping URLs embed the check identifier, which is a low-capability secret. ProxSave
+  registers them with the log masker and strips them out of transport errors, so a
+  failed ping logs the reason and never the URL.
+
+### When the daemon has no backup to report
+
+With `BACKUP_ENABLED=false` the daemon skips the scheduled run entirely: no child
+process and no outcome ping, so `proxsave-backup` honestly goes down rather than
+reporting a false green. The heartbeat keeps signalling, so you can still tell the
+daemon itself is healthy.
+
+### Backups run outside the daemon
+
+A backup started by hand, or from the dashboard's "run now", does not ping the monitor
+itself. The resident daemon is the only pinger. A standalone run instead drops a handoff
+file and wakes the daemon with `SIGUSR1`, and the daemon pings `proxsave-backup` with
+that outcome. A handoff older than 15 minutes is discarded without pinging, so a
+long-past run never flips the check, and if no live daemon is found nothing pings at
+all.
+
+## Two modes
+
+`HEALTHCHECK_MODE` picks where the pings go.
+
+- **`centralized`** (the default): ProxSave runs the monitor for you and provisions
+  this host's checks. Nothing to set up, no API key on this machine.
+- **`self`**: you point the daemon at your own healthchecks instance, self-hosted or
+  the SaaS, and own the checks yourself.
+
+## Centralized: the ProxSave monitoring server
+
+This host is identified to the monitoring server by its **Server ID**, which is
+generated at install time, and a per-server relay credential. The credential is
+**provisioned automatically**: the daemon asks the server for one on its first run and
+persists it. No Telegram pairing, no account, no key to copy. It is the same identity
+the centralized Telegram relay uses, so a host that already sends Telegram
+notifications is already provisioned.
+
+Once provisioned, the daemon fetches its ping URLs from the server and starts
+reporting. If a later fetch fails, it falls back to the URLs cached in `backup.env`
+(`HEALTHCHECK_ALIVE_URL` and `HEALTHCHECK_BACKUP_URL`), so a transient server outage
+does not stop reporting. It warns once and then keeps retrying quietly.
+
+The credential also self-heals. If the server ever rejects it, or reports that this
+host's account was parked for being unused, the daemon clears the stale credential and
+provisions a fresh one on its next attempt, which re-registers the host. Transient
+errors never touch a working credential. Provisioning retries are throttled to roughly
+every 15 minutes, spread out per host, and the daemon honors a server-side back-off
+when it is asked to wait.
+
+### Your monitoring portal
+
+Every centralized host gets its own portal on the monitoring server, where you can see
+each check's state and history and decide how you want to be alerted.
+
+You reach it through a **single-use login link**, valid for about an hour, which
+ProxSave shows you in three places:
+
+- during the install wizard, on the monitoring screen, in both the TUI and `--cli`;
+- in the dashboard, under `Healthchecks` in the diagnostic checks;
+- at the end of a backup run, on the `Healthchecks Portal:` line.
+
+Open it and **set a password**. That is what turns the link into an account you can log
+into later, and it is the point at which you can configure alert channels, email and
+the rest, so the monitor can reach you when a check goes down.
+
+Two things worth knowing:
+
+- The server stops minting new links after your first login, since from then on you
+  have a password. Before that first login, every place listed above hands you a fresh
+  one, so a link that expired is never a problem: just open the dashboard check again.
+- ProxSave never opens or follows the link, it only prints it. It also refuses to print
+  anything that is not a clean http(s) URL on the monitoring server's own domain, so a
+  tampered response cannot put a phishing address in front of you.
+
+## Self mode: your own healthchecks
+
+In self mode ProxSave pings the URLs you give it and does nothing else. There is no
+identity, no portal, and no provisioning: the checks, the alert rules, and the
+retention are yours to manage on your own instance.
+
+### During install
+
+Choosing `Your own server` on the monitoring step opens a form that collects the full
+ping URL of each check, for example `https://hc-ping.com/<uuid>`. The alive and backup
+URLs are required; the updates URL and the four per-channel notification URLs are
+optional. Whatever you leave empty simply is not reported. A verification screen then
+pings your alive URL to confirm it is reachable from this host, using a state-neutral
+ping that does not leave a spurious success or failure on your check.
+
+### In backup.env
+
+You can also configure it by hand. Each check accepts either a full URL or an
+identifier that gets assembled onto a shared endpoint:
+
+```bash
+HEALTHCHECK_PING_ENDPOINT=https://hc-ping.com   # base for the *_ID form
+HEALTHCHECK_PING_KEY=                           # optional, inserted between base and id
+HEALTHCHECK_ALIVE_ID=
+HEALTHCHECK_BACKUP_ID=
+```
+
+A full `*_URL` always wins over the matching `*_ID`. With a ping key set, an id
+resolves to `<endpoint>/<key>/<id>`; without one, to `<endpoint>/<id>`.
+
+Self mode covers all four families: `*_ALIVE_*`, `*_BACKUP_*`, `*_UPDATES_*`, and
+`*_NOTIFY_<CHANNEL>_*` for email, telegram, gotify, and webhook. Configure only the
+checks you actually want. The alive and backup pair alone is a perfectly reasonable
+setup.
+
+Note that `HEALTHCHECK_ALIVE_URL` and `HEALTHCHECK_BACKUP_URL` do double duty: in self
+mode they are your own ping URLs, and in centralized mode they are the cache the server
+fills in for you. In centralized mode, do not edit them.
+
+## Where monitoring shows up
+
+**Install wizard.** With the daemon engine selected, step 8 asks for the monitoring
+mode, then a screen verifies the connection. In centralized mode it also boxes the
+portal link. `--cli` installs show the same information as plain text.
+
+**Dashboard.** `Healthchecks` under the diagnostic checks runs on entry and reports the
+real operational state, not just one-shot reachability. In centralized mode it boxes a
+fresh portal link. Under the verdict, a `Sensors:` list gives one colored line per
+monitored check with its state and the age of its last ping.
+
+**End of a backup run.** The run prints a `Healthchecks` line reporting whether the
+daemon is actually transmitting. This section sends nothing itself: the daemon is the
+only pinger, and it records every ping outcome to disk, so the run reads that record
+and reports what was really sent. A missing record reads as "nothing transmitted yet",
+which is honest for a first run or a stopped daemon, and never as a false success.
+
+**`proxsave --daemon-status`.** A scriptable verdict on the daemon itself, covered in
+[DAEMON.md](DAEMON.md).
+
+## Troubleshooting
+
+### What the check screen tells you
+
+The install screen and the dashboard check share one vocabulary. `WORKING` is the only
+fully healthy centralized state; in self mode it is `REACHABLE`.
+
+| Keyword | What it means | What to do |
+|---------|---------------|------------|
+| `WORKING` | daemon running and reporting | nothing |
+| `REACHABLE` | self mode: your ping URL answered | nothing |
+| `PROVISIONING` | the credential or the server-side setup is not ready yet | check again shortly; if it persists, this host cannot reach the monitoring server |
+| `UNREACHABLE` | the monitor did not answer from this host | check outbound connectivity and DNS |
+| `UNCONFIRMED` | provisioned, but reachability could not be confirmed | run the check again |
+| `NOT INSTALLED` | the monitor is reachable but the daemon service is not installed | `proxsave --daemon-setup` |
+| `NOT RUNNING` | the service is installed and stopped, or never wrote a heartbeat | `systemctl start proxsave-daemon.service` |
+| `RUNNING, NOT REPORTING` | the process is up but has written no heartbeat yet | usually a stale build; restart the service |
+| `STALE` | the last heartbeat is older than twice the heartbeat interval, with a one-minute floor so a single slipped tick does not read as down | the daemon is stopped or wedged; check `journalctl -u proxsave-daemon.service` |
+| `BEHIND` | the running daemon is on an older binary than the one on disk | restart the service so it loads the upgrade |
+| `NOT PROVISIONED` | the daemon runs but has no ping target yet | centralized: wait for provisioning. Self: the ping URLs are missing |
+| `MONITOR UNREACHABLE` | the daemon runs but its pings do not arrive | outbound connectivity from this host |
+| `TRANSMIT FAILED` | the last backup outcome did not reach the monitor | usually transient; check the daemon log |
+| `REJECTED` | the server refused this host's credential | it is cleared and re-provisioned automatically on the next daemon run |
+| `NOT REGISTERED` | the server does not know this host yet | registered automatically on the next daemon run |
+| `PARKED` | the server had removed this host's unused account | cleared and re-registered automatically |
+| `DISABLED` | centralized monitoring is turned off on the server | nothing to configure here |
+| `NO IDENTITY` | this host has no server identity | re-run the installer to regenerate it |
+| `NOT ENABLED` | monitoring is off on this host | switch to the daemon scheduler with monitoring enabled |
+| `NOT CONFIGURED` | self mode selected but no alive URL entered | fill in the healthchecks parameters |
+| `CONFIG ERROR` | `backup.env` could not be loaded | re-run the installer to repair it |
+| `STATUS UNREADABLE` | the on-disk monitoring status file could not be read | a corrupt file is quarantined and reset automatically |
+| `UNKNOWN` | the daemon state could not be determined | check the service and its log |
+
+### What the sensor list tells you
+
+The `Sensors:` list under the dashboard check reports each monitored check separately.
+Its wording distinguishes two different things: whether the ping left this host, and
+what the ping said.
+
+| State | Meaning |
+|-------|---------|
+| `no data` | nothing recorded for this check yet |
+| `stale` | the last ping is older than the check's expected cadence |
+| `not provisioned` | the daemon tried to report but has no URL for this check |
+| `transmit failed` | the ping did not reach the monitor |
+| `ok` | fresh and transmitted |
+| `up to date` | updates check: you are on the latest release |
+| `update available` | updates check: a newer release exists, so the check is down |
+| `sent` | notification check: that channel delivered cleanly |
+| `send failed` | notification check: that channel reported a warning or an error |
+| `failed` | backup check: the last run failed or hung |
+
+Only the alive and updates checks can go `stale`, because only they have a fixed
+cadence. The backup and notification checks are event driven: they report when a run
+happens, so an old timestamp on them is not a fault.
+
+### The portal link is not shown
+
+Expected once you have logged into the portal for the first time: the server stops
+minting links from then on, and you log in with the password you set. Before that first
+login, a missing link means the mint attempt did not succeed, which is best effort and
+deliberately quiet. Open the dashboard check again to get another one.
+
+A link is also dropped, silently, if it does not pass the trust rules: it must be a
+clean http(s) URL on the monitoring server's own domain.
+
+### A backup ran but the check stayed silent
+
+Only the daemon pings. A run outside the daemon relies on the handoff described above,
+which needs a live daemon and a handoff no older than 15 minutes. If the daemon was
+down while you ran the backup by hand, that outcome is not reported.
+
+### Everything looks right but nothing arrives
+
+Check the daemon's own log first:
+
+```bash
+journalctl -u proxsave-daemon.service -f
+```
+
+The daemon warns once when it cannot reach the monitoring server and then drops to
+debug, so a recurring failure is quiet by design. Raise `DEBUG_LEVEL` if you need to
+see each attempt.
+
+## Configuration keys
+
+```bash
+HEALTHCHECK_ENABLED=false      # forced true by --daemon-setup and by upgrade auto-migration
+HEALTHCHECK_MODE=centralized   # centralized | self
+HEALTHCHECK_HEARTBEAT_INTERVAL=5m
+HEALTHCHECK_UPDATE_INTERVAL=5m
+HEALTHCHECK_SEND_LOG=true      # attach a log tail on a failed or hung supervised run
+
+# Centralized cache, filled in from the server. Do not edit.
+HEALTHCHECK_ALIVE_URL=
+HEALTHCHECK_BACKUP_URL=
+
+# Self mode
+HEALTHCHECK_PING_ENDPOINT=https://hc-ping.com
+HEALTHCHECK_PING_KEY=
+HEALTHCHECK_ALIVE_ID=
+HEALTHCHECK_BACKUP_ID=
+HEALTHCHECK_UPDATES_URL=
+HEALTHCHECK_UPDATES_ID=
+HEALTHCHECK_NOTIFY_EMAIL_URL=
+HEALTHCHECK_NOTIFY_EMAIL_ID=
+HEALTHCHECK_NOTIFY_TELEGRAM_URL=
+HEALTHCHECK_NOTIFY_TELEGRAM_ID=
+HEALTHCHECK_NOTIFY_GOTIFY_URL=
+HEALTHCHECK_NOTIFY_GOTIFY_ID=
+HEALTHCHECK_NOTIFY_WEBHOOK_URL=
+HEALTHCHECK_NOTIFY_WEBHOOK_ID=
+```
+
+Both interval defaults fall back to 5 minutes when the configured value is not a
+positive duration.
+
+See [DAEMON.md](DAEMON.md) for the daemon itself, [CONFIGURATION.md](CONFIGURATION.md)
+for the full `backup.env` reference, and [NOTIFICATIONS.md](NOTIFICATIONS.md) for how
+the per-channel checks relate to the delivery channels.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -220,10 +220,30 @@ Final install steps still run:
 5. **Notifications**: Enable Telegram (centralized) and Email notifications; Email asks for a delivery method and defaults to `relay` with `sendmail` failover. Use `pmf` only when you want Proxmox Notifications via `proxmox-mail-forward`.
 6. **Encryption**: AGE encryption setup (runs sub-wizard immediately if enabled)
 7. **Scheduler engine**: choose the ProxSave local daemon or system cron. Fresh installs and Overwrite default to the daemon (a resident systemd service with a hang watchdog and healthchecks); editing an existing config keeps its current engine. See [DAEMON.md](DAEMON.md).
-8. **Healthchecks** (daemon only): with the daemon engine, choose the monitoring mode: `Off`, `ProxSave HC Server` (centralized, zero setup, the default), or `Your own server` (self). Self mode opens a follow-up screen to paste your ping URLs, then a verification screen. With the cron engine this choice is dimmed and forced off.
+8. **Healthchecks** (daemon only): with the daemon engine, choose the monitoring mode: `Off`, `ProxSave HC Server` (centralized, zero setup, the default), or `Your own server` (self). Self mode opens a follow-up screen to paste your ping URLs, then a verification screen. Centralized mode goes straight to the verification screen, which also hands you a single-use link to your monitoring portal. With the cron engine this choice is dimmed and forced off. See [HEALTHCHECKS.md](HEALTHCHECKS.md).
 9. **Run at (HH:MM)**: the daily backup time (default `02:00`), used by whichever engine you chose (the daemon's daily run, or the cron entry).
 10. **Post-install check (optional)**: Runs `proxsave --dry-run` and shows actionable warnings like `set BACKUP_*=false to disable`, allowing you to disable unused collectors and reduce WARNING noise
 11. **Telegram pairing (optional)**: If Telegram centralized mode is enabled and the installer can load a valid config plus a Server ID, it shows your Server ID and lets you verify pairing with the bot (retry/skip supported). Otherwise installation continues and logs why pairing was skipped.
+
+#### Backup monitoring wizard (TUI)
+
+When the daemon engine is selected with monitoring on, the installer opens a **Backup monitoring (healthchecks)** screen after the config has been written. Self mode gets a parameters screen first, where you paste the full ping URL of each check (alive and backup required, updates and the four per-channel URLs optional); those go into `backup.env`. The verification screen itself writes nothing.
+
+**What you see:**
+- A short explanation of what gets reported
+- **Centralized only**: your monitoring portal in a boxed **single-use link, valid about an hour**, with the instruction to open it and **set a password and configure alert channels**. That first login is what turns the link into an account you can return to
+- **Status**: a state keyword plus a plain-language explanation
+- **Sensors**: after a check, one colored line per monitored check with its state and last-ping age
+- **Actions**: `Check` (repeatable up to the attempt cap), then `Continue` once verified or `Skip` to move on. A hard blocker removes `Check`, since another attempt cannot help
+
+The screen is skipped, with the reason logged, when monitoring is off, the config cannot be loaded, self mode has no alive URL yet, or the host has no server identity.
+
+Centralized mode needs no pairing and no API key: the credential is provisioned automatically. `PROVISIONING` simply means it has not completed yet.
+
+**CLI mode:**
+- With `--install --cli` the installer applies the same rules and prints the same information as plain text, portal link and password instruction included, then asks whether to run the check now, with a retry loop.
+
+Status keywords, sensor states, and what to do about each are in [HEALTHCHECKS.md](HEALTHCHECKS.md).
 
 #### Telegram pairing wizard (TUI)
 

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -9,7 +9,8 @@ model, the portal magic-link, and the log-redaction rules that keep secrets out 
 the logs.
 
 For the full list of `backup.env` keys see [CONFIGURATION.md](CONFIGURATION.md).
-For the per-channel healthchecks sensors and the resident daemon that pings them see
+For the per-channel healthchecks sensors, the monitoring portal, and what each state
+means see [HEALTHCHECKS.md](HEALTHCHECKS.md); for the daemon that pings them see
 [DAEMON.md](DAEMON.md).
 
 ## The one invariant: notifications never abort the backup
@@ -42,7 +43,8 @@ There are two independent layers, and it helps to keep them apart:
   `disabled`) is handed to the resident daemon, which turns it into a per-channel
   `proxsave-notify-<channel>` healthchecks sensor (`/0` up, `/1` down). Alongside it,
   an always-visible **Healthchecks** section prints the current transmission status.
-  This is the "is my monitoring actually working" layer. See [DAEMON.md](DAEMON.md).
+  This is the "is my monitoring actually working" layer. See
+  [HEALTHCHECKS.md](HEALTHCHECKS.md).
 
 The two tiers are decoupled on purpose. A Telegram message the relay accepted but
 Telegram did not deliver keeps the run green (Tier 1 success), yet drives the
@@ -229,6 +231,9 @@ DOWN), even though the run stays green. Only `failed` counts; `pending` and
 not report "ok" and defeat the monitoring.
 
 ## The portal magic-link
+
+This section is the mechanics. What the portal is for, and what a user is meant to do
+with the link, is in [HEALTHCHECKS.md](HEALTHCHECKS.md#your-monitoring-portal).
 
 The bot-server can piggyback a fresh portal login link on its `/api/notify` response
 (field `login_url`), until the user's first portal login, after which it stops. The

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,15 +12,21 @@ below for the current operational and technical behavior.
 - [CLI_REFERENCE.md](CLI_REFERENCE.md): commands, flags, and workflow phases
 - [EXAMPLES.md](EXAMPLES.md): ready-to-use configuration examples
 - [RESTORE_GUIDE.md](RESTORE_GUIDE.md): full restore guide and category behavior
+- [DASHBOARD.md](DASHBOARD.md): the interactive dashboard, screen by screen
 - [NOTIFICATIONS.md](NOTIFICATIONS.md): notification channels and the centralized bot relay
+- [DAEMON.md](DAEMON.md): the resident daemon, its watchdog, and the scheduler engines
+- [HEALTHCHECKS.md](HEALTHCHECKS.md): backup monitoring, the monitoring portal, and self-hosted setups
 - [TROUBLESHOOTING.md](TROUBLESHOOTING.md): operational diagnostics and fixes
 
 ## Architecture & Developer Docs
 
 - [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md): contributor setup and development workflow
 - [COLLECTOR_ARCHITECTURE.md](COLLECTOR_ARCHITECTURE.md): collector recipes, bricks, and `dual`
+- [DASHBOARD_TUI.md](DASHBOARD_TUI.md): dashboard internals, components, and screen contracts
 - [RESTORE_TECHNICAL.md](RESTORE_TECHNICAL.md): restore internals and orchestration details
 - [RESTORE_DIAGRAMS.md](RESTORE_DIAGRAMS.md): visual restore workflow diagrams
+- [SECURITY.md](SECURITY.md): execution model, preflight checks, and secret handling
+- [TEST_STRATEGY.md](TEST_STRATEGY.md): test conventions and coverage policy
 
 ## Supporting References
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -13,6 +13,7 @@ Complete troubleshooting guide for Proxsave with common issues, solutions, and d
   - [Disk Space Issues](#5-disk-space-issues)
   - [Email Notification Issues](#6-email-notification-issues)
   - [Restore Issues](#7-restore-issues)
+  - [Backup Monitoring Issues](#8-backup-monitoring-issues)
 - [Debug Procedures](#debug-procedures)
 - [Getting Help](#getting-help)
 - [Exit Codes](#exit-codes)
@@ -752,6 +753,80 @@ chattr -i /mnt/pve/<id>
 
 ---
 
+### 8. Backup Monitoring Issues
+
+The full status vocabulary, both the check-screen keywords and the per-sensor states, is documented in [HEALTHCHECKS.md](HEALTHCHECKS.md#troubleshooting). This section covers the cases that send people looking for a fix.
+
+#### The monitoring check never leaves `PROVISIONING`
+
+**Symptoms**:
+- The install screen or the dashboard `Healthchecks` check keeps reporting `PROVISIONING`.
+
+**Cause**:
+- Centralized monitoring provisions this host's credential automatically on a daemon run. No Telegram pairing and no API key are involved. A state that never advances means the request is not getting through.
+
+**Resolution**:
+```bash
+# 1. Is the daemon actually running? It is what provisions.
+proxsave --daemon-status
+systemctl status proxsave-daemon.service
+
+# 2. Watch it try
+journalctl -u proxsave-daemon.service -f
+```
+- Provisioning retries are throttled to roughly every 15 minutes, so give it one interval before concluding anything.
+- If the daemon reports the server is unreachable, this is outbound connectivity from the host, not a ProxSave setting.
+
+#### No monitoring portal link is shown
+
+**Symptoms**:
+- The dashboard check or the end of a run shows no `Healthchecks Portal:` line.
+
+**Cause**:
+- The server stops minting links once you have logged into the portal for the first time. This is the expected steady state: from then on you log in with the password you set.
+- Before that first login, minting is best effort and stays quiet when it fails.
+- A link that is not a clean http(s) URL on the monitoring server's own domain is dropped on purpose, so a tampered response cannot show you a phishing address.
+
+**Resolution**:
+- Log in with your password. If you never set one, open the dashboard `Healthchecks` check again to request a fresh link.
+
+#### A backup ran but `proxsave-backup` stayed silent
+
+**Symptoms**:
+- You ran a backup by hand or from the dashboard, and the monitor recorded nothing.
+
+**Cause**:
+- Only the resident daemon pings. A standalone run hands its outcome off to the daemon, which then pings. The handoff needs a live daemon and is discarded when older than 15 minutes.
+
+**Resolution**:
+- Start the daemon before running standalone backups, or let the daemon run the scheduled backup.
+
+#### Self mode: `UNREACHABLE`
+
+**Symptoms**:
+- The self-mode check cannot reach your ping URL.
+
+**Resolution**:
+```bash
+# The check uses /log, which records a ping without changing check state
+curl -fsS -X POST "https://your-monitor.example/<uuid>/log" && echo OK
+```
+- Confirm the URL is the **full** ping URL of that check. When you configure IDs instead, the daemon builds `<HEALTHCHECK_PING_ENDPOINT>/<HEALTHCHECK_PING_KEY>/<id>`, or `<endpoint>/<id>` with no key. A full `*_URL` always wins over the matching `*_ID`.
+
+#### Sensors read `not provisioned` or `transmit failed`
+
+**Symptoms**:
+- The `Sensors:` list shows those states instead of `ok`.
+
+**Cause**:
+- `not provisioned` means the daemon tried to report but has no URL for that check yet. In centralized mode the URLs are still being fetched; in self mode that check is simply not configured, which is fine if you did not want it.
+- `transmit failed` means the ping did not reach the monitor. It is usually transient.
+
+**Resolution**:
+- The daemon warns once when it cannot reach the monitor, then drops to debug so a recurring failure does not flood the journal. Raise `DEBUG_LEVEL` to see each attempt.
+
+---
+
 ## Debug Procedures
 
 ### Enable Debug Logging
@@ -1069,6 +1144,8 @@ A backup that finishes with warnings (no errors) is promoted from `0` to exit `1
 - **[Cloud Storage Guide](CLOUD_STORAGE.md)** - rclone configuration and troubleshooting
 - **[Encryption Guide](ENCRYPTION.md)** - AGE encryption setup
 - **[Restore Guide](RESTORE_GUIDE.md)** - Restore operations
+- **[Backup Monitoring](HEALTHCHECKS.md)** - Monitored checks, the monitoring portal, and status vocabulary
+- **[Resident Daemon](DAEMON.md)** - Scheduler engines, watchdog, and service management
 
 ### Reference
 - **[Examples](EXAMPLES.md)** - Real-world scenarios

--- a/internal/backup/collector.go
+++ b/internal/backup/collector.go
@@ -130,6 +130,11 @@ func (c *Collector) depRunCommandWithEnv(ctx context.Context, extraEnv []string,
 // depRunCommandCaptured runs a command with stdout and stderr kept apart. A Collector
 // wired only with the merged-output hooks falls back to them, reporting the merged text
 // as stdout and no stderr.
+//
+// Any injected hook wins over the package-level runner, extraEnv or not: a caller that
+// supplied a runner never wants a real command executed behind its back. RunCommand
+// cannot carry extraEnv, so a Collector wired with only that hook runs the command
+// without the extra environment; the fact is logged rather than worked around.
 func (c *Collector) depRunCommandCaptured(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
 	if c.deps.RunCommandCaptured != nil {
 		return c.deps.RunCommandCaptured(ctx, extraEnv, name, args...)
@@ -140,6 +145,13 @@ func (c *Collector) depRunCommandCaptured(ctx context.Context, extraEnv []string
 	}
 	if c.deps.RunCommandWithEnv != nil {
 		out, err := c.deps.RunCommandWithEnv(ctx, extraEnv, name, args...)
+		return out, nil, err
+	}
+	if c.deps.RunCommand != nil {
+		if c.logger != nil {
+			c.logger.Debug("Running %s through the RunCommand hook, which cannot carry %d extra environment variable(s)", name, len(extraEnv))
+		}
+		out, err := c.deps.RunCommand(ctx, name, args...)
 		return out, nil, err
 	}
 	return runCommandCapturedWithEnv(ctx, extraEnv, name, args...)

--- a/internal/backup/collector.go
+++ b/internal/backup/collector.go
@@ -1164,10 +1164,12 @@ func (c *Collector) runAndClassifyCommand(ctx context.Context, spec CommandSpec,
 
 	out, stderr, err := c.depRunCommandCaptured(runCtx, nil, spec.Name, spec.Args...)
 	result.output = out
-	// Failure handling reads both streams: exit reasons, privilege hints and the
-	// systemctl markers matched below are printed on stderr.
-	combined := mergeCommandStreams(out, stderr)
 	if err != nil {
+		// Failure handling reads both streams: exit reasons, privilege hints and the
+		// systemctl markers matched below are printed on stderr. Merging happens here
+		// and not before the check so a successful command never pays for a full copy
+		// of its (potentially large) stdout.
+		combined := mergeCommandStreams(out, stderr)
 		if isContextCancellationError(runCtx, err) {
 			if isNonCriticalPveshDeadline(ctx, runCtx, spec, opts.critical) {
 				result.classification = commandRunNonCriticalFailure

--- a/internal/backup/collector.go
+++ b/internal/backup/collector.go
@@ -127,6 +127,24 @@ func (c *Collector) depRunCommandWithEnv(ctx context.Context, extraEnv []string,
 	return runCommandWithEnv(ctx, extraEnv, name, args...)
 }
 
+// depRunCommandCaptured runs a command with stdout and stderr kept apart. A Collector
+// wired only with the merged-output hooks falls back to them, reporting the merged text
+// as stdout and no stderr.
+func (c *Collector) depRunCommandCaptured(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+	if c.deps.RunCommandCaptured != nil {
+		return c.deps.RunCommandCaptured(ctx, extraEnv, name, args...)
+	}
+	if len(extraEnv) == 0 && c.deps.RunCommand != nil {
+		out, err := c.deps.RunCommand(ctx, name, args...)
+		return out, nil, err
+	}
+	if c.deps.RunCommandWithEnv != nil {
+		out, err := c.deps.RunCommandWithEnv(ctx, extraEnv, name, args...)
+		return out, nil, err
+	}
+	return runCommandCapturedWithEnv(ctx, extraEnv, name, args...)
+}
+
 type CommandSpec struct {
 	Name string
 	Args []string
@@ -1074,11 +1092,30 @@ type commandRunOptions struct {
 }
 
 type commandRunResult struct {
+	// output is stdout alone; stderr never reaches the collected artifact.
 	output         []byte
 	classification commandRunClassification
 	exitCode       int
 	outputSummary  string
 	contextInfo    unprivilegedContainerContext
+}
+
+// mergeCommandStreams builds the text used for diagnostics. Artifacts keep stdout alone,
+// but a failing command usually explains itself on stderr, so summaries need both.
+func mergeCommandStreams(stdout, stderr []byte) string {
+	if len(stderr) == 0 {
+		return string(stdout)
+	}
+	if len(stdout) == 0 {
+		return string(stderr)
+	}
+	var buf bytes.Buffer
+	buf.Write(stdout)
+	if stdout[len(stdout)-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.Write(stderr)
+	return buf.String()
 }
 
 func (c *Collector) runAndClassifyCommand(ctx context.Context, spec CommandSpec, opts commandRunOptions) (commandRunResult, error) {
@@ -1125,13 +1162,16 @@ func (c *Collector) runAndClassifyCommand(ctx context.Context, spec CommandSpec,
 		defer cancel()
 	}
 
-	out, err := c.depRunCommand(runCtx, spec.Name, spec.Args...)
+	out, stderr, err := c.depRunCommandCaptured(runCtx, nil, spec.Name, spec.Args...)
 	result.output = out
+	// Failure handling reads both streams: exit reasons, privilege hints and the
+	// systemctl markers matched below are printed on stderr.
+	combined := mergeCommandStreams(out, stderr)
 	if err != nil {
 		if isContextCancellationError(runCtx, err) {
 			if isNonCriticalPveshDeadline(ctx, runCtx, spec, opts.critical) {
 				result.classification = commandRunNonCriticalFailure
-				result.outputSummary = summarizeCommandOutputText(string(out))
+				result.outputSummary = summarizeCommandOutputText(combined)
 				timeoutSeconds := 0
 				if c.config != nil {
 					timeoutSeconds = c.config.PveshTimeoutSeconds
@@ -1147,7 +1187,7 @@ func (c *Collector) runAndClassifyCommand(ctx context.Context, spec CommandSpec,
 			}
 			return result, err
 		}
-		result.outputSummary = summarizeCommandOutputText(string(out))
+		result.outputSummary = summarizeCommandOutputText(combined)
 		if opts.critical {
 			c.incFilesFailed()
 			result.classification = commandRunCriticalFailure
@@ -1158,7 +1198,7 @@ func (c *Collector) runAndClassifyCommand(ctx context.Context, spec CommandSpec,
 		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitCode()
 		}
-		outputText := strings.TrimSpace(string(out))
+		outputText := strings.TrimSpace(combined)
 		result.exitCode = exitCode
 		result.outputSummary = summarizeCommandOutputText(outputText)
 		result.classification = commandRunNonCriticalFailure
@@ -1239,6 +1279,14 @@ func (c *Collector) runAndClassifyCommand(ctx context.Context, spec CommandSpec,
 			)
 		}
 		return result, nil
+	}
+
+	if len(bytes.TrimSpace(stderr)) > 0 {
+		// The command succeeded, so its stdout is the artifact; stderr is only noise
+		// worth keeping for troubleshooting (e.g. smartctl failures reported by
+		// `proxmox-backup-manager disk list`).
+		c.logger.Debug("Command `%s` wrote to stderr while succeeding (%s): %s",
+			cmdString, opts.description, summarizeCommandOutputText(string(stderr)))
 	}
 
 	result.classification = commandRunSucceeded
@@ -1353,19 +1401,25 @@ func (c *Collector) safeCmdOutputWithPBSAuth(ctx context.Context, spec CommandSp
 	}
 
 	cmdString := spec.String()
-	out, err := c.depRunCommandWithEnv(ctx, extraEnv, spec.Name, spec.Args...)
+	out, stderr, err := c.depRunCommandCaptured(ctx, extraEnv, spec.Name, spec.Args...)
 	if err != nil {
+		summary := summarizeCommandOutputText(mergeCommandStreams(out, stderr))
 		if critical {
 			c.incFilesFailed()
-			return fmt.Errorf("critical command `%s` failed for %s: %w (output: %s)", cmdString, description, err, summarizeCommandOutputText(string(out)))
+			return fmt.Errorf("critical command `%s` failed for %s: %w (output: %s)", cmdString, description, err, summary)
 		}
 		c.logger.Warning("Skipping %s: command `%s` failed (%v). Non-critical; backup continues. Ensure the PBS CLI is available and has proper permissions. Output: %s",
 			description,
 			cmdString,
 			err,
-			summarizeCommandOutputText(string(out)),
+			summary,
 		)
 		return nil // Non-critical failure
+	}
+
+	if len(bytes.TrimSpace(stderr)) > 0 {
+		c.logger.Debug("Command `%s` wrote to stderr while succeeding (%s): %s",
+			cmdString, description, summarizeCommandOutputText(string(stderr)))
 	}
 
 	if err := c.writeReportFile(output, out); err != nil {
@@ -1461,19 +1515,25 @@ func (c *Collector) safeCmdOutputWithPBSAuthForDatastore(ctx context.Context, sp
 	}
 
 	cmdString := spec.String()
-	out, err := c.depRunCommandWithEnv(ctx, extraEnv, spec.Name, spec.Args...)
+	out, stderr, err := c.depRunCommandCaptured(ctx, extraEnv, spec.Name, spec.Args...)
 	if err != nil {
+		summary := summarizeCommandOutputText(mergeCommandStreams(out, stderr))
 		if critical {
 			c.incFilesFailed()
-			return fmt.Errorf("critical command `%s` failed for %s: %w (output: %s)", cmdString, description, err, summarizeCommandOutputText(string(out)))
+			return fmt.Errorf("critical command `%s` failed for %s: %w (output: %s)", cmdString, description, err, summary)
 		}
 		c.logger.Warning("Skipping %s: command `%s` failed (%v). Non-critical; backup continues. Ensure the PBS CLI is available and has proper permissions. Output: %s",
 			description,
 			cmdString,
 			err,
-			summarizeCommandOutputText(string(out)),
+			summary,
 		)
 		return nil // Non-critical failure
+	}
+
+	if len(bytes.TrimSpace(stderr)) > 0 {
+		c.logger.Debug("Command `%s` wrote to stderr while succeeding (%s): %s",
+			cmdString, description, summarizeCommandOutputText(string(stderr)))
 	}
 
 	if err := c.writeReportFile(output, out); err != nil {

--- a/internal/backup/collector_deps.go
+++ b/internal/backup/collector_deps.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
@@ -11,15 +12,31 @@ import (
 var (
 	execLookPath = exec.LookPath
 
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
+	// runCommandCapturedWithEnv keeps stdout and stderr apart. Collected artifacts must
+	// carry stdout alone: tools like `proxmox-backup-manager disk list --output-format=json`
+	// write diagnostics to stderr (smartctl failures, for instance) while still emitting
+	// valid JSON on stdout, and merging the streams produces an unparsable file.
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
 		cmd, err := safeexec.CommandContext(ctx, name, args...)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(extraEnv) > 0 {
 			cmd.Env = append(os.Environ(), extraEnv...)
 		}
-		return cmd.CombinedOutput()
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		runErr := cmd.Run()
+		return stdout.Bytes(), stderr.Bytes(), runErr
+	}
+
+	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
+		stdout, stderr, err := runCommandCapturedWithEnv(ctx, extraEnv, name, args...)
+		if len(stderr) == 0 {
+			return stdout, err
+		}
+		return []byte(mergeCommandStreams(stdout, stderr)), err
 	}
 
 	runCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
@@ -30,24 +47,29 @@ var (
 )
 
 // CollectorDeps allows injecting external dependencies for the Collector.
+//
+// RunCommandCaptured returns stdout and stderr separately and is what the collection
+// paths use. RunCommand and RunCommandWithEnv return the two streams concatenated; they
+// remain for callers and tests that only care about the merged text, and a Collector
+// configured with just those keeps working (stderr is then folded into stdout, the
+// pre-split behaviour).
 type CollectorDeps struct {
 	LookPath                    func(string) (string, error)
+	RunCommandCaptured          func(context.Context, []string, string, ...string) ([]byte, []byte, error)
 	RunCommandWithEnv           func(context.Context, []string, string, ...string) ([]byte, error)
 	RunCommand                  func(context.Context, string, ...string) ([]byte, error)
 	Stat                        func(string) (os.FileInfo, error)
 	DetectUnprivilegedContainer func() (bool, string)
 }
 
+// defaultCollectorDeps leaves the command hooks nil on purpose. The Collector already
+// falls back to the package-level runners when a hook is unset, so nil here means the
+// split-stream runner is used by default while a caller that overrides only RunCommand
+// (or RunCommandWithEnv) still has its override honoured.
 func defaultCollectorDeps() CollectorDeps {
 	return CollectorDeps{
 		LookPath: func(name string) (string, error) {
 			return execLookPath(name)
-		},
-		RunCommandWithEnv: func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-			return runCommandWithEnv(ctx, extraEnv, name, args...)
-		},
-		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
-			return runCommand(ctx, name, args...)
 		},
 		Stat: func(path string) (os.FileInfo, error) {
 			return statFunc(path)

--- a/internal/backup/collector_pbs_auth_test.go
+++ b/internal/backup/collector_pbs_auth_test.go
@@ -13,18 +13,18 @@ import (
 
 func TestSafeCmdOutputWithPBSAuthSetsEnv(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
 
 	var capturedEnv []string
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
 		capturedEnv = append([]string(nil), extraEnv...)
-		return []byte("ok"), nil
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -52,18 +52,18 @@ func TestSafeCmdOutputWithPBSAuthSetsEnv(t *testing.T) {
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreBuildsRepo(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
 
 	var capturedEnv []string
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
 		capturedEnv = append([]string(nil), extraEnv...)
-		return []byte("ok"), nil
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -110,18 +110,18 @@ func TestPBSRepositoryWithDatastorePreservesHostPortAndIPv6(t *testing.T) {
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreSkipsWhenNoCredentials(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
 
 	called := false
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
 		called = true
-		return []byte("ok"), nil
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -145,18 +145,18 @@ func TestSafeCmdOutputWithPBSAuthForDatastoreSkipsWhenNoCredentials(t *testing.T
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreDefaultsUserWhenRepoEmpty(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
 
 	var capturedEnv []string
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
 		capturedEnv = append([]string(nil), extraEnv...)
-		return []byte("ok"), nil
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -207,16 +207,16 @@ func TestSafeCmdOutputWithPBSAuthCriticalCommandNotAvailableIncrementsFilesFaile
 
 func TestSafeCmdOutputWithPBSAuthDryRunSkipsExecution(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		t.Fatalf("runCommandWithEnv should not be called in dry-run")
-		return nil, nil
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		t.Fatalf("runCommandCapturedWithEnv should not be called in dry-run")
+		return nil, nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -232,15 +232,15 @@ func TestSafeCmdOutputWithPBSAuthDryRunSkipsExecution(t *testing.T) {
 
 func TestSafeCmdOutputWithPBSAuthWriteFailureIncrementsFilesFailed(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		return []byte("ok"), nil
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -288,15 +288,15 @@ func TestSafeCmdOutputWithPBSAuthNonCriticalCommandNotAvailableIsSkipped(t *test
 
 func TestSafeCmdOutputWithPBSAuthNonCriticalCommandFailureIsSwallowed(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		return []byte("nope"), os.ErrInvalid
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		return []byte("nope"), nil, os.ErrInvalid
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -312,15 +312,15 @@ func TestSafeCmdOutputWithPBSAuthNonCriticalCommandFailureIsSwallowed(t *testing
 
 func TestSafeCmdOutputWithPBSAuthEnsureDirFailureReturnsError(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		return []byte("ok"), nil
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -338,15 +338,15 @@ func TestSafeCmdOutputWithPBSAuthEnsureDirFailureReturnsError(t *testing.T) {
 
 func TestSafeCmdOutputWithPBSAuthCriticalFailureIncrementsFilesFailed(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		return []byte("nope"), os.ErrInvalid
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		return []byte("nope"), nil, os.ErrInvalid
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -362,17 +362,17 @@ func TestSafeCmdOutputWithPBSAuthCriticalFailureIncrementsFilesFailed(t *testing
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreAppendsDatastoreAndIncludesFingerprint(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
 	var capturedEnv []string
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
 		capturedEnv = append([]string(nil), extraEnv...)
-		return []byte("ok"), nil
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -396,15 +396,15 @@ func TestSafeCmdOutputWithPBSAuthForDatastoreAppendsDatastoreAndIncludesFingerpr
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreNonCriticalFailureReturnsNil(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		return []byte("nope"), os.ErrInvalid
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		return []byte("nope"), nil, os.ErrInvalid
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -484,16 +484,16 @@ func TestSafeCmdOutputWithPBSAuthForDatastoreCriticalCommandNotAvailableIncremen
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreDryRunSkipsExecution(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		t.Fatalf("runCommandWithEnv should not be called in dry-run")
-		return nil, nil
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		t.Fatalf("runCommandCapturedWithEnv should not be called in dry-run")
+		return nil, nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -512,15 +512,15 @@ func TestSafeCmdOutputWithPBSAuthForDatastoreDryRunSkipsExecution(t *testing.T) 
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreCriticalFailureIncrementsFilesFailed(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		return []byte("nope"), os.ErrInvalid
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		return []byte("nope"), nil, os.ErrInvalid
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -539,15 +539,15 @@ func TestSafeCmdOutputWithPBSAuthForDatastoreCriticalFailureIncrementsFilesFaile
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreWriteFailureIncrementsFilesFailed(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		return []byte("ok"), nil
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()
@@ -570,15 +570,15 @@ func TestSafeCmdOutputWithPBSAuthForDatastoreWriteFailureIncrementsFilesFailed(t
 
 func TestSafeCmdOutputWithPBSAuthForDatastoreEnsureDirFailureReturnsError(t *testing.T) {
 	origLookPath := execLookPath
-	origRun := runCommandWithEnv
+	origRun := runCommandCapturedWithEnv
 	t.Cleanup(func() {
 		execLookPath = origLookPath
-		runCommandWithEnv = origRun
+		runCommandCapturedWithEnv = origRun
 	})
 
 	execLookPath = func(string) (string, error) { return "/bin/echo", nil }
-	runCommandWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, error) {
-		return []byte("ok"), nil
+	runCommandCapturedWithEnv = func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+		return []byte("ok"), nil, nil
 	}
 
 	cfg := GetDefaultCollectorConfig()

--- a/internal/backup/collector_pbs_datastore.go
+++ b/internal/backup/collector_pbs_datastore.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -795,14 +796,20 @@ func (c *Collector) getDatastoreList(ctx context.Context) ([]pbsDatastore, error
 	} else {
 		// stdout only: warnings printed on stderr would otherwise break the JSON parse
 		// below and silently drop the whole datastore list.
-		output, _, err := c.depRunCommandCaptured(ctx, nil, "proxmox-backup-manager", "datastore", "list", "--output-format=json")
+		output, stderr, err := c.depRunCommandCaptured(ctx, nil, "proxmox-backup-manager", "datastore", "list", "--output-format=json")
 		if err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return nil, ctxErr
 			}
 			c.incFilesFailed()
-			c.logger.Warning("PBS datastore enumeration via proxmox-backup-manager failed; per-datastore status may be incomplete (raw datastore.cfg is still collected): %v", err)
+			// The exit error is usually just "exit status N"; the actionable reason
+			// (permissions, auth, broken config) is on stderr.
+			c.logger.Warning("PBS datastore enumeration via proxmox-backup-manager failed; per-datastore status may be incomplete (raw datastore.cfg is still collected): %v. Output: %s",
+				err, summarizeCommandOutputText(mergeCommandStreams(output, stderr)))
 		} else {
+			if len(bytes.TrimSpace(stderr)) > 0 {
+				c.logger.Debug("`proxmox-backup-manager datastore list` wrote to stderr while succeeding: %s", summarizeCommandOutputText(string(stderr)))
+			}
 			var entries []datastoreEntry
 			if err := json.Unmarshal(output, &entries); err != nil {
 				c.incFilesFailed()

--- a/internal/backup/collector_pbs_datastore.go
+++ b/internal/backup/collector_pbs_datastore.go
@@ -793,7 +793,9 @@ func (c *Collector) getDatastoreList(ctx context.Context) ([]pbsDatastore, error
 	if _, err := c.depLookPath("proxmox-backup-manager"); err != nil {
 		c.logger.Debug("Skipping PBS datastore CLI enumeration: proxmox-backup-manager not available: %v", err)
 	} else {
-		output, err := c.depRunCommand(ctx, "proxmox-backup-manager", "datastore", "list", "--output-format=json")
+		// stdout only: warnings printed on stderr would otherwise break the JSON parse
+		// below and silently drop the whole datastore list.
+		output, _, err := c.depRunCommandCaptured(ctx, nil, "proxmox-backup-manager", "datastore", "list", "--output-format=json")
 		if err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return nil, ctxErr

--- a/internal/backup/collector_stderr_isolation_test.go
+++ b/internal/backup/collector_stderr_isolation_test.go
@@ -155,6 +155,43 @@ func TestDatastoreEnumerationWarningCarriesStderr(t *testing.T) {
 	}
 }
 
+// An injected runner must never be bypassed: falling through to the real runner because
+// the path needs extra environment would execute the command against the host.
+func TestExtraEnvPathNeverEscapesAnInjectedRunner(t *testing.T) {
+	called := false
+	deps := CollectorDeps{
+		LookPath: func(name string) (string, error) {
+			return "/bin/" + name, nil
+		},
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			called = true
+			return []byte(diskListStdout), nil
+		},
+	}
+	collector := NewCollectorWithDeps(newTestLogger(), GetDefaultCollectorConfig(), t.TempDir(), types.ProxmoxBS, false, deps)
+	collector.config.PBSRepository = "root@pam@localhost:store"
+	output := filepath.Join(collector.tempDir, "var/lib/proxsave-info", "commands", "pbs", "snapshots.json")
+
+	if err := collector.safeCmdOutputWithPBSAuth(context.Background(),
+		commandSpec("proxmox-backup-client", "snapshot", "list", "--output-format=json"),
+		output,
+		"Snapshot list",
+		false); err != nil {
+		t.Fatalf("safeCmdOutputWithPBSAuth: %v", err)
+	}
+	if !called {
+		t.Fatal("the injected RunCommand hook was bypassed for an extraEnv path")
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read snapshots.json: %v", err)
+	}
+	if string(data) != diskListStdout {
+		t.Fatalf("artifact mismatch: %q", string(data))
+	}
+}
+
 // Existing suites inject the legacy combined-output hooks; they must keep working.
 func TestLegacyRunCommandDepStillFeedsArtifact(t *testing.T) {
 	deps := CollectorDeps{

--- a/internal/backup/collector_stderr_isolation_test.go
+++ b/internal/backup/collector_stderr_isolation_test.go
@@ -1,0 +1,158 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// Real-world reproduction: `proxmox-backup-manager disk list --output-format=json`
+// prints smartctl failures on stderr while emitting valid JSON on stdout. Merging the
+// two streams into the collected artifact leaves a file that no JSON parser accepts.
+const smartctlStderrNoise = "failed to gather smart data for /dev/sde – command \"smartctl\" \"-H\" \"-A\" \"-j\" \"/dev/sde\" failed - status code: 1 - no error message\n"
+
+const diskListStdout = "[\n  {\n    \"name\": \"sde\",\n    \"used\": \"filesystem\"\n  }\n]\n"
+
+func newStderrNoiseCollector(t *testing.T, stdout, stderr string, runErr error) *Collector {
+	t.Helper()
+
+	deps := CollectorDeps{
+		LookPath: func(name string) (string, error) {
+			return "/bin/" + name, nil
+		},
+		RunCommandCaptured: func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+			return []byte(stdout), []byte(stderr), runErr
+		},
+	}
+
+	return NewCollectorWithDeps(newTestLogger(), GetDefaultCollectorConfig(), t.TempDir(), types.ProxmoxBS, false, deps)
+}
+
+func TestSafeCmdOutputKeepsStderrOutOfArtifact(t *testing.T) {
+	collector := newStderrNoiseCollector(t, diskListStdout, smartctlStderrNoise, nil)
+	output := filepath.Join(collector.tempDir, "var/lib/proxsave-info", "commands", "pbs", "disk_list.json")
+
+	err := collector.safeCmdOutput(context.Background(),
+		commandSpec("proxmox-backup-manager", "disk", "list", "--output-format=json"),
+		output,
+		"Disk list",
+		false)
+	if err != nil {
+		t.Fatalf("safeCmdOutput: %v", err)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read disk_list.json: %v", err)
+	}
+	if string(data) != diskListStdout {
+		t.Fatalf("artifact must contain stdout verbatim, got: %q", string(data))
+	}
+	if !json.Valid(data) {
+		t.Fatalf("artifact is not valid JSON: %q", string(data))
+	}
+}
+
+func TestSafeCmdOutputWithPBSAuthKeepsStderrOutOfArtifact(t *testing.T) {
+	collector := newStderrNoiseCollector(t, diskListStdout, smartctlStderrNoise, nil)
+	collector.config.PBSRepository = "root@pam@localhost:store"
+	output := filepath.Join(collector.tempDir, "var/lib/proxsave-info", "commands", "pbs", "snapshots.json")
+
+	err := collector.safeCmdOutputWithPBSAuth(context.Background(),
+		commandSpec("proxmox-backup-client", "snapshot", "list", "--output-format=json"),
+		output,
+		"Snapshot list",
+		false)
+	if err != nil {
+		t.Fatalf("safeCmdOutputWithPBSAuth: %v", err)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read snapshots.json: %v", err)
+	}
+	if string(data) != diskListStdout {
+		t.Fatalf("artifact must contain stdout verbatim, got: %q", string(data))
+	}
+}
+
+func TestSafeCmdOutputForDatastoreKeepsStderrOutOfArtifact(t *testing.T) {
+	collector := newStderrNoiseCollector(t, diskListStdout, smartctlStderrNoise, nil)
+	collector.config.PBSRepository = "root@pam@localhost:store"
+	output := filepath.Join(collector.tempDir, "var/lib/proxsave-info", "commands", "pbs", "namespaces.json")
+
+	err := collector.safeCmdOutputWithPBSAuthForDatastore(context.Background(),
+		commandSpec("proxmox-backup-client", "namespace", "list", "--output-format=json"),
+		output,
+		"Namespace list",
+		"store",
+		false)
+	if err != nil {
+		t.Fatalf("safeCmdOutputWithPBSAuthForDatastore: %v", err)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read namespaces.json: %v", err)
+	}
+	if string(data) != diskListStdout {
+		t.Fatalf("artifact must contain stdout verbatim, got: %q", string(data))
+	}
+}
+
+// Failure diagnostics stay useful: stderr is where the command explains itself, so the
+// summary logged on a non-critical failure must still carry it.
+func TestFailedCommandSummaryStillIncludesStderr(t *testing.T) {
+	collector := newStderrNoiseCollector(t, "", "permission denied\n", errors.New("exit status 1"))
+	result, err := collector.runAndClassifyCommand(context.Background(),
+		commandSpec("proxmox-backup-manager", "disk", "list", "--output-format=json"),
+		commandRunOptions{
+			output:      filepath.Join(collector.tempDir, "var/lib/proxsave-info", "commands", "pbs", "disk_list.json"),
+			description: "Disk list",
+			caller:      "test",
+		})
+	if err != nil {
+		t.Fatalf("runAndClassifyCommand: %v", err)
+	}
+	if result.classification != commandRunNonCriticalFailure {
+		t.Fatalf("expected non-critical failure, got %v", result.classification)
+	}
+	if result.outputSummary != "permission denied" {
+		t.Fatalf("summary must include stderr, got %q", result.outputSummary)
+	}
+}
+
+// Existing suites inject the legacy combined-output hooks; they must keep working.
+func TestLegacyRunCommandDepStillFeedsArtifact(t *testing.T) {
+	deps := CollectorDeps{
+		LookPath: func(name string) (string, error) {
+			return "/bin/" + name, nil
+		},
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte(diskListStdout), nil
+		},
+	}
+	collector := NewCollectorWithDeps(newTestLogger(), GetDefaultCollectorConfig(), t.TempDir(), types.ProxmoxBS, false, deps)
+	output := filepath.Join(collector.tempDir, "var/lib/proxsave-info", "commands", "pbs", "disk_list.json")
+
+	if err := collector.safeCmdOutput(context.Background(),
+		commandSpec("proxmox-backup-manager", "disk", "list", "--output-format=json"),
+		output,
+		"Disk list",
+		false); err != nil {
+		t.Fatalf("safeCmdOutput: %v", err)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read disk_list.json: %v", err)
+	}
+	if string(data) != diskListStdout {
+		t.Fatalf("legacy dep output mismatch: %q", string(data))
+	}
+}

--- a/internal/backup/collector_stderr_isolation_test.go
+++ b/internal/backup/collector_stderr_isolation_test.go
@@ -1,13 +1,16 @@
 package backup
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/types"
 )
 
@@ -124,6 +127,31 @@ func TestFailedCommandSummaryStillIncludesStderr(t *testing.T) {
 	}
 	if result.outputSummary != "permission denied" {
 		t.Fatalf("summary must include stderr, got %q", result.outputSummary)
+	}
+}
+
+// `exit status N` alone says nothing; the datastore enumeration warning has to carry
+// what the command printed on stderr.
+func TestDatastoreEnumerationWarningCarriesStderr(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := logging.New(types.LogLevelDebug, false)
+	logger.SetOutput(buf)
+
+	deps := CollectorDeps{
+		LookPath: func(name string) (string, error) {
+			return "/bin/" + name, nil
+		},
+		RunCommandCaptured: func(ctx context.Context, extraEnv []string, name string, args ...string) ([]byte, []byte, error) {
+			return nil, []byte("permission denied (run as root)\n"), errors.New("exit status 2")
+		},
+	}
+	collector := NewCollectorWithDeps(logger, GetDefaultCollectorConfig(), t.TempDir(), types.ProxmoxBS, false, deps)
+
+	if _, err := collector.getDatastoreList(context.Background()); err != nil {
+		t.Fatalf("getDatastoreList: %v", err)
+	}
+	if !strings.Contains(buf.String(), "permission denied (run as root)") {
+		t.Fatalf("warning must quote stderr, log:\n%s", buf.String())
 	}
 }
 


### PR DESCRIPTION
Automated release PR for `v0.30.0-beta9`.

<!-- release-tag: v0.30.0-beta9 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added dedicated healthchecks/monitoring documentation (model, check families, modes, setup, and troubleshooting).
  * Reworked daemon/dashboard/install/notifications references to point to the new healthchecks guide.
  * Expanded dashboard diagnostics and the healthcheck setup wizard content.

* **Bug Fixes**
  * Improved command output handling to prevent stderr from contaminating saved JSON/artifacts.
  * Diagnostics still include stderr details on failures, while successful outputs remain clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The release updates healthchecks documentation and keeps successful command artifacts clean by separating stderr from stdout.
- Adds a dedicated healthchecks guide and updates related documentation links and diagnostics guidance.
- Captures command stdout and stderr separately, retaining stderr for failure diagnostics while writing only stdout to successful artifacts.
- Updates PBS datastore enumeration and adds regression coverage for stream isolation and injected command runners.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/backup/collector.go | Routes collection through split-stream command execution while preserving merged failure diagnostics and injected-runner precedence. |
| internal/backup/collector_deps.go | Introduces the split stdout/stderr runner and retains compatibility wrappers for callers expecting combined output. |
| internal/backup/collector_pbs_datastore.go | Parses datastore JSON exclusively from stdout while retaining stderr in failure diagnostics. |
| internal/backup/collector_stderr_isolation_test.go | Adds regression coverage for clean artifacts, useful failure diagnostics, and command-runner injection. |
| docs/HEALTHCHECKS.md | Adds the consolidated reference for monitoring concepts, configuration, setup, and troubleshooting. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(backup): never bypass an injected ru..."](https://github.com/tis24dev/proxsave/commit/ab183ab50904e0eed08d4c9bcae2ba4fad284c6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47427070)</sub>

<!-- /greptile_comment -->