### PR TITLE
fix(pbs): ignore built-in notification defaults when config is absent

### DIFF
--- a/internal/backup/collector_pbs_notifications_summary.go
+++ b/internal/backup/collector_pbs_notifications_summary.go
@@ -70,7 +70,7 @@ func (c *Collector) writePBSNotificationSummary(commandsDir string) {
 		priv := summary.ConfigFiles.NotificationsPrivCfg
 
 		if cfg.Status != StatusCollected && cfg.Status != StatusDisabled {
-			if summary.Targets.Total > 0 || sumEndpointTotals(summary.Endpoints) > 0 {
+			if hasCustomNotificationObjects(summary) {
 				summary.Warnings = append(summary.Warnings, "Notification objects detected in snapshots, but notifications.cfg was not collected (check BACKUP_PBS_NOTIFICATIONS and exclusions).")
 			}
 		}
@@ -108,6 +108,12 @@ func (c *Collector) writePBSNotificationSummary(commandsDir string) {
 	if err := c.writeReportFile(filepath.Join(commandsDir, "notifications_summary.json"), out); err != nil {
 		c.logger.Debug("PBS notifications summary write failed: %v", err)
 	}
+}
+
+func hasCustomNotificationObjects(summary pbsNotificationsSummary) bool {
+	return summary.Targets.Custom > 0 ||
+		summary.Matchers.Custom > 0 ||
+		sumEndpointCustom(summary.Endpoints) > 0
 }
 
 func sumEndpointTotals(endpoints map[string]pbsNotificationSnapshotSummary) int {

--- a/internal/backup/collector_pbs_notifications_summary_test.go
+++ b/internal/backup/collector_pbs_notifications_summary_test.go
@@ -1,0 +1,54 @@
+package backup
+
+import "testing"
+
+func TestHasCustomNotificationObjects(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary pbsNotificationsSummary
+		want    bool
+	}{
+		{
+			name: "built-in objects only",
+			summary: pbsNotificationsSummary{
+				Targets:  pbsNotificationSnapshotSummary{Total: 1, BuiltIn: 1},
+				Matchers: pbsNotificationSnapshotSummary{Total: 1, BuiltIn: 1},
+				Endpoints: map[string]pbsNotificationSnapshotSummary{
+					"sendmail": {Total: 1, BuiltIn: 1},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "custom target",
+			summary: pbsNotificationsSummary{
+				Targets: pbsNotificationSnapshotSummary{Total: 2, BuiltIn: 1, Custom: 1},
+			},
+			want: true,
+		},
+		{
+			name: "custom matcher",
+			summary: pbsNotificationsSummary{
+				Matchers: pbsNotificationSnapshotSummary{Total: 2, BuiltIn: 1, Custom: 1},
+			},
+			want: true,
+		},
+		{
+			name: "custom endpoint",
+			summary: pbsNotificationsSummary{
+				Endpoints: map[string]pbsNotificationSnapshotSummary{
+					"smtp": {Total: 1, Custom: 1},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCustomNotificationObjects(tt.summary); got != tt.want {
+				t.Fatalf("hasCustomNotificationObjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- warn about a missing `notifications.cfg` only when snapshot data contains custom notification objects
- include custom matchers in the recoverability check
- cover built-in-only, custom target, custom matcher, and custom endpoint cases

PBS exposes built-in defaults such as `mail-to-root` and `default-matcher` even when no persisted `notifications.cfg` exists. Counting all objects therefore produces a recoverability warning for a configuration that does not exist and does not need restoring.

## Verification
- `go test ./...`

## Summary by Sourcery

Warn about missing PBS notification configuration only when snapshots contain custom notification objects.

Bug Fixes:
- Avoid warnings for missing PBS notification configuration when snapshots contain only built-in notification defaults.
- Detect custom matchers, targets, and endpoints when determining whether notification configuration may need recovery.

Tests:
- Add coverage for built-in-only and custom PBS notification object scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notifications configuration warnings to correctly identify custom targets, matchers, and endpoints.
  * Prevented warnings for configurations containing only built-in notification objects.

* **Tests**
  * Added coverage for configurations with built-in and custom notification objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refines PBS notification recoverability warnings so built-in defaults do not imply that an absent `notifications.cfg` needs restoration.
- Warns only when snapshots contain custom targets, matchers, or endpoints.
- Adds custom matchers to the recoverability check.
- Adds unit coverage for built-in-only and custom-object summary states.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defect identified.

The revised predicate consistently ignores built-in defaults while retaining warnings for custom targets, matchers, and endpoint objects.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/backup/collector_pbs_notifications_summary.go | Replaces total-object warning detection with a focused predicate covering custom targets, matchers, and endpoints; no actionable defect was established. |
| internal/backup/collector_pbs_notifications_summary_test.go | Adds table-driven coverage for built-in-only summaries and each supported category of custom notification object. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pbs): ignore built-in notification d..."](https://github.com/tis24dev/proxsave/commit/1475d8ed10bcb8e5b5d47bce348c36a898471867) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55382026)</sub>

<!-- /greptile_comment -->