### PR TITLE
fix(restore): stop reporting a successful PBS notifications apply that did nothing

### DIFF
--- a/internal/orchestrator/pbs_notifications_api_apply.go
+++ b/internal/orchestrator/pbs_notifications_api_apply.go
@@ -30,21 +30,29 @@ type pbsNotificationDesiredState struct {
 // `notification endpoint gotify create <name> <server> <token> ...`.
 const gotifyTokenRedactIndex = 6
 
-func applyPBSNotificationsViaAPI(ctx context.Context, logger *logging.Logger, stageRoot string, strict bool) error {
+// applyPBSNotificationsViaAPI reports whether it had anything to apply. A backup that
+// carries no notifications.cfg produces applied=false with a nil error: that is not a
+// failure, but the caller must not report it as a successful apply either. The manifest
+// entry that would say whether the file was lost or never existed lives in the ExportOnly
+// proxsave_info category and is not staged, so this distinction cannot be made here.
+func applyPBSNotificationsViaAPI(ctx context.Context, logger *logging.Logger, stageRoot string, strict bool) (applied bool, err error) {
 	desired, present, err := loadPBSNotificationDesiredState(stageRoot, logger)
 	if err != nil || !present {
-		return err
+		return false, err
 	}
 
 	if strict {
 		if err := removeExtraPBSNotificationMatchers(ctx, logger, desired.matchers); err != nil {
-			return err
+			return false, err
 		}
 	}
 	if err := syncPBSNotificationEndpoints(ctx, logger, desired.endpoints, strict); err != nil {
-		return err
+		return false, err
 	}
-	return syncPBSNotificationMatchers(ctx, desired)
+	if err := syncPBSNotificationMatchers(ctx, desired); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func loadPBSNotificationDesiredState(stageRoot string, logger *logging.Logger) (pbsNotificationDesiredState, bool, error) {

--- a/internal/orchestrator/pbs_notifications_api_apply_test.go
+++ b/internal/orchestrator/pbs_notifications_api_apply_test.go
@@ -48,8 +48,12 @@ func TestApplyPBSNotificationsViaAPI_CreatesEndpointAndMatcher(t *testing.T) {
 	restoreCmd = runner
 
 	logger := logging.New(types.LogLevelDebug, false)
-	if err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, false); err != nil {
+	applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, false)
+	if err != nil {
 		t.Fatalf("applyPBSNotificationsViaAPI error: %v", err)
+	}
+	if !applied {
+		t.Fatal("staged notifications.cfg was present, so the apply must report that it ran")
 	}
 
 	want := []string{
@@ -81,5 +85,40 @@ func TestBuildPBSNotificationDesiredState_NilLoggerSkipsMalformedSections(t *tes
 	}
 	if len(desired.matchers) != 0 {
 		t.Fatalf("expected no matchers, got=%v", desired.matchers)
+	}
+}
+
+// A backup that carries no notifications.cfg is not a failure, but it is not an apply
+// either. Before this was distinguished, the caller logged "PBS notifications applied via
+// API" for a run that had touched nothing.
+func TestApplyPBSNotificationsViaAPI_NothingStagedIsNotAnApply(t *testing.T) {
+	origCmd := restoreCmd
+	origFS := restoreFS
+	t.Cleanup(func() {
+		restoreCmd = origCmd
+		restoreFS = origFS
+	})
+
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+
+	runner := &fakeCommandRunner{}
+	restoreCmd = runner
+
+	logger := logging.New(types.LogLevelDebug, false)
+
+	for _, strict := range []bool{false, true} {
+		applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, "/empty-stage", strict)
+		if err != nil {
+			t.Fatalf("strict=%v: an absent notifications.cfg is not an error: %v", strict, err)
+		}
+		if applied {
+			t.Fatalf("strict=%v: nothing was staged, so nothing can have been applied", strict)
+		}
+	}
+
+	if len(runner.calls) != 0 {
+		t.Fatalf("no proxmox-backup-manager command should run with an empty stage, got: %v", runner.calls)
 	}
 }

--- a/internal/orchestrator/pbs_notifications_api_apply_test.go
+++ b/internal/orchestrator/pbs_notifications_api_apply_test.go
@@ -2,8 +2,10 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/tis24dev/proxsave/internal/logging"
@@ -120,5 +122,115 @@ func TestApplyPBSNotificationsViaAPI_NothingStagedIsNotAnApply(t *testing.T) {
 
 	if len(runner.calls) != 0 {
 		t.Fatalf("no proxmox-backup-manager command should run with an empty stage, got: %v", runner.calls)
+	}
+}
+
+// stagePBSNotificationFixture writes a minimal but realistic staged notification config:
+// one smtp endpoint whose password lives in the priv file, and one matcher pointing at it.
+func stagePBSNotificationFixture(t *testing.T, fakeFS *FakeFS, stageRoot string) {
+	t.Helper()
+
+	if err := fakeFS.WriteFile(stageRoot+"/etc/proxmox-backup/notifications.cfg", []byte(
+		"smtp: Gmail-relay\n"+
+			"    recipients user@example.com\n"+
+			"    from-address pbs@example.com\n"+
+			"    server smtp.gmail.com\n"+
+			"    port 587\n"+
+			"    username user\n"+
+			"\n"+
+			"matcher: default-matcher\n"+
+			"    target Gmail-relay\n",
+	), 0o640); err != nil {
+		t.Fatalf("write staged notifications.cfg: %v", err)
+	}
+	if err := fakeFS.WriteFile(stageRoot+"/etc/proxmox-backup/notifications-priv.cfg", []byte(
+		"smtp: Gmail-relay\n"+
+			"    password secret123\n",
+	), 0o600); err != nil {
+		t.Fatalf("write staged notifications-priv.cfg: %v", err)
+	}
+}
+
+// Clean mode is the destructive one: it removes live objects the backup does not contain.
+// It had no coverage at all, so nothing proved the strict branch ran, let alone that a
+// completed run reports applied=true.
+func TestApplyPBSNotificationsViaAPI_StrictRemovesExtrasAndReportsApplied(t *testing.T) {
+	origCmd := restoreCmd
+	origFS := restoreFS
+	t.Cleanup(func() {
+		restoreCmd = origCmd
+		restoreFS = origFS
+	})
+
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+
+	stageRoot := "/stage"
+	stagePBSNotificationFixture(t, fakeFS, stageRoot)
+
+	// A live matcher the backup does not contain: strict mode must remove it.
+	runner := &fakeCommandRunner{
+		outputs: map[string][]byte{
+			"proxmox-backup-manager notification matcher list": []byte(`[{"name":"default-matcher"},{"name":"stale-matcher"}]`),
+		},
+	}
+	restoreCmd = runner
+
+	logger := logging.New(types.LogLevelDebug, false)
+
+	applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, true)
+	if err != nil {
+		t.Fatalf("applyPBSNotificationsViaAPI error: %v", err)
+	}
+	if !applied {
+		t.Fatal("a completed strict apply must report applied=true")
+	}
+
+	joined := strings.Join(runner.calls, "\n")
+	if !strings.Contains(joined, "notification matcher remove stale-matcher") {
+		t.Fatalf("strict mode must remove the matcher missing from the backup, calls:\n%s", joined)
+	}
+	if strings.Contains(joined, "notification matcher remove default-matcher") {
+		t.Fatalf("a matcher present in the backup must be kept, calls:\n%s", joined)
+	}
+}
+
+// applied is only useful if it is trustworthy when things go wrong. Without this, a later
+// refactor could return true alongside an error and no test would notice.
+func TestApplyPBSNotificationsViaAPI_FailureReportsNotApplied(t *testing.T) {
+	origCmd := restoreCmd
+	origFS := restoreFS
+	t.Cleanup(func() {
+		restoreCmd = origCmd
+		restoreFS = origFS
+	})
+
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+
+	stageRoot := "/stage"
+	stagePBSNotificationFixture(t, fakeFS, stageRoot)
+
+	// upsertPBSNotificationMatcher falls back to update when create fails, so both have to
+	// fail for the matcher sync to report an error.
+	boom := errors.New("proxmox-backup-manager exploded")
+	runner := &fakeCommandRunner{
+		errs: map[string]error{
+			"proxmox-backup-manager notification matcher create default-matcher --target Gmail-relay": boom,
+			"proxmox-backup-manager notification matcher update default-matcher --target Gmail-relay": boom,
+		},
+	}
+	restoreCmd = runner
+
+	logger := logging.New(types.LogLevelDebug, false)
+
+	applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, false)
+	if err == nil {
+		t.Fatal("a failing matcher sync must surface an error")
+	}
+	if applied {
+		t.Fatal("a failed apply must not report applied=true")
 	}
 }

--- a/internal/orchestrator/pbs_notifications_api_apply_test.go
+++ b/internal/orchestrator/pbs_notifications_api_apply_test.go
@@ -234,3 +234,62 @@ func TestApplyPBSNotificationsViaAPI_FailureReportsNotApplied(t *testing.T) {
 		t.Fatal("a failed apply must not report applied=true")
 	}
 }
+
+// The two error propagations out of applyPBSNotificationsViaAPI. Neither needs root, a real
+// filesystem or a live PBS: FakeCommandRunner turns the underlying command into a failure.
+func TestApplyPBSNotificationsViaAPI_PropagatesSyncFailures(t *testing.T) {
+	boom := errors.New("proxmox-backup-manager exploded")
+
+	tests := []struct {
+		name   string
+		strict bool
+		errs   map[string]error
+	}{
+		{
+			// strict-only path: removeExtraPBSNotificationMatchers cannot list what is live.
+			name:   "matcher list failure aborts a Clean apply",
+			strict: true,
+			errs: map[string]error{
+				"proxmox-backup-manager notification matcher list": boom,
+			},
+		},
+		{
+			// syncPBSNotificationEndpoints: create fails, and so does the update fallback.
+			name:   "endpoint sync failure aborts the apply",
+			strict: false,
+			errs: map[string]error{
+				"proxmox-backup-manager notification endpoint smtp create Gmail-relay user@example.com --from-address pbs@example.com --server smtp.gmail.com --port 587 --username user --password secret123": boom,
+				"proxmox-backup-manager notification endpoint smtp update Gmail-relay user@example.com --from-address pbs@example.com --server smtp.gmail.com --port 587 --username user --password secret123": boom,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origCmd := restoreCmd
+			origFS := restoreFS
+			t.Cleanup(func() {
+				restoreCmd = origCmd
+				restoreFS = origFS
+			})
+
+			fakeFS := NewFakeFS()
+			t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+			restoreFS = fakeFS
+
+			stageRoot := "/stage"
+			stagePBSNotificationFixture(t, fakeFS, stageRoot)
+
+			restoreCmd = &fakeCommandRunner{errs: tt.errs}
+			logger := logging.New(types.LogLevelDebug, false)
+
+			applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, tt.strict)
+			if err == nil {
+				t.Fatal("the failure must be propagated, not swallowed")
+			}
+			if applied {
+				t.Fatal("an aborted apply must not report applied=true")
+			}
+		})
+	}
+}

--- a/internal/orchestrator/restore_notifications.go
+++ b/internal/orchestrator/restore_notifications.go
@@ -26,6 +26,10 @@ type proxmoxNotificationSection struct {
 
 var sectionHeaderTypePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
+// notificationsApplyGeteuid is a seam so the apply path can be exercised without root,
+// matching haApplyGeteuid (restore_ha.go:21) and pbsAPIApplyGeteuid.
+var notificationsApplyGeteuid = os.Geteuid
+
 func maybeApplyNotificationsFromStage(ctx context.Context, logger *logging.Logger, plan *RestorePlan, stageRoot string, dryRun bool) (err error) {
 	if plan == nil {
 		return nil
@@ -49,7 +53,7 @@ func maybeApplyNotificationsFromStage(ctx context.Context, logger *logging.Logge
 		logger.Debug("Skipping staged notifications apply: non-system filesystem in use")
 		return nil
 	}
-	if os.Geteuid() != 0 {
+	if notificationsApplyGeteuid() != 0 {
 		logger.Warning("Skipping staged notifications apply: requires root privileges")
 		return nil
 	}

--- a/internal/orchestrator/restore_notifications.go
+++ b/internal/orchestrator/restore_notifications.go
@@ -68,15 +68,21 @@ func maybeApplyNotificationsFromStage(ctx context.Context, logger *logging.Logge
 			} else {
 				logger.Warning("PBS notifications API apply unavailable; skipping apply (merge mode): %v", err)
 			}
-		} else if err := applyPBSNotificationsViaAPI(ctx, logger, stageRoot, strict); err != nil {
+		} else if applied, apiErr := applyPBSNotificationsViaAPI(ctx, logger, stageRoot, strict); apiErr != nil {
 			if allowFileFallback {
-				logger.Warning("PBS notifications API apply failed; falling back to file-based apply: %v", err)
+				logger.Warning("PBS notifications API apply failed; falling back to file-based apply: %v", apiErr)
 				if err := applyPBSNotificationsFromStage(ctx, logger, stageRoot); err != nil {
 					return err
 				}
 			} else {
-				logger.Warning("PBS notifications API apply failed; skipping apply (merge mode): %v", err)
+				logger.Warning("PBS notifications API apply failed; skipping apply (merge mode): %v", apiErr)
 			}
+		} else if !applied {
+			// Not an error, and not necessarily a problem: the source host may genuinely
+			// have had no notification config. We cannot tell from here, so state what
+			// happened rather than claim a success. Whether the backup lost the file is
+			// answered at backup time, by the collector warnings on notifications.cfg.
+			logger.Info("PBS notifications: this backup contains no notifications.cfg, so nothing was applied and the live configuration is unchanged")
 		} else {
 			logger.Info("PBS notifications applied via API (%s)", behavior.DisplayName())
 		}

--- a/internal/orchestrator/restore_notifications_noop_test.go
+++ b/internal/orchestrator/restore_notifications_noop_test.go
@@ -1,0 +1,71 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// The whole point of returning `applied` is what the operator reads afterwards. This drives
+// the real entry point, with an empty stage, and asserts the message: before this change the
+// same run logged "PBS notifications applied via API".
+func TestMaybeApplyNotificationsFromStage_EmptyStageDoesNotClaimSuccess(t *testing.T) {
+	origCmd := restoreCmd
+	origFS := restoreFS
+	origEuid := notificationsApplyGeteuid
+	origAPIEuid := pbsAPIApplyGeteuid
+	origVerify := serviceVerifyTimeout
+	t.Cleanup(func() {
+		restoreCmd = origCmd
+		restoreFS = origFS
+		notificationsApplyGeteuid = origEuid
+		pbsAPIApplyGeteuid = origAPIEuid
+		serviceVerifyTimeout = origVerify
+	})
+
+	// maybeApplyNotificationsFromStage and ensurePBSServicesForAPI both refuse to run
+	// against a non-system filesystem, so this exercises the real osFS against a temp dir.
+	// Nothing on the path writes: an empty stage returns before any apply.
+	restoreFS = osFS{}
+	notificationsApplyGeteuid = func() int { return 0 }
+	pbsAPIApplyGeteuid = func() int { return 0 }
+	serviceVerifyTimeout = 50 * time.Millisecond
+
+	restoreCmd = &FakeCommandRunner{
+		Outputs: map[string][]byte{
+			"which systemctl":                          {},
+			"proxmox-backup-manager version":           []byte("proxmox-backup-manager 4.0.0"),
+			"systemctl start proxmox-backup":           {},
+			"systemctl start proxmox-backup-proxy":     {},
+			"systemctl is-active proxmox-backup":       []byte("active"),
+			"systemctl is-active proxmox-backup-proxy": []byte("active"),
+		},
+	}
+
+	logger := logging.New(types.LogLevelDebug, false)
+	var out bytes.Buffer
+	logger.SwapOutput(&out)
+
+	plan := &RestorePlan{
+		SystemType:         SystemTypePBS,
+		StagedCategories:   []Category{{ID: "pbs_notifications"}},
+		PBSRestoreBehavior: PBSRestoreBehaviorMerge,
+	}
+
+	if err := maybeApplyNotificationsFromStage(context.Background(), logger, plan, t.TempDir(), false); err != nil {
+		t.Fatalf("an empty stage is not an error: %v", err)
+	}
+
+	logged := out.String()
+	if !strings.Contains(logged, "this backup contains no notifications.cfg") {
+		t.Fatalf("the operator must be told nothing was applied, got:\n%s", logged)
+	}
+	if strings.Contains(logged, "PBS notifications applied via API") {
+		t.Fatalf("nothing was applied, so success must not be claimed, got:\n%s", logged)
+	}
+}

--- a/internal/orchestrator/restore_notifications_noop_test.go
+++ b/internal/orchestrator/restore_notifications_noop_test.go
@@ -3,6 +3,9 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -67,5 +70,147 @@ func TestMaybeApplyNotificationsFromStage_EmptyStageDoesNotClaimSuccess(t *testi
 	}
 	if strings.Contains(logged, "PBS notifications applied via API") {
 		t.Fatalf("nothing was applied, so success must not be claimed, got:\n%s", logged)
+	}
+}
+
+// Merge mode has no file-based fallback (allowFileFallback is Clean-only), so an API failure
+// there only logs and returns. That arm writes nothing, which is what makes it safe to drive
+// against the real osFS the surrounding guards insist on.
+func TestMaybeApplyNotificationsFromStage_MergeModeSkipsOnAPIFailure(t *testing.T) {
+	origCmd := restoreCmd
+	origFS := restoreFS
+	origEuid := notificationsApplyGeteuid
+	origAPIEuid := pbsAPIApplyGeteuid
+	origVerify := serviceVerifyTimeout
+	t.Cleanup(func() {
+		restoreCmd = origCmd
+		restoreFS = origFS
+		notificationsApplyGeteuid = origEuid
+		pbsAPIApplyGeteuid = origAPIEuid
+		serviceVerifyTimeout = origVerify
+	})
+
+	restoreFS = osFS{}
+	notificationsApplyGeteuid = func() int { return 0 }
+	pbsAPIApplyGeteuid = func() int { return 0 }
+	serviceVerifyTimeout = 50 * time.Millisecond
+
+	stageRoot := t.TempDir()
+	cfgDir := filepath.Join(stageRoot, "etc", "proxmox-backup")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatalf("mkdir staged config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "notifications.cfg"), []byte(
+		"matcher: default-matcher\n"+
+			"    target mail-to-root\n",
+	), 0o640); err != nil {
+		t.Fatalf("write staged notifications.cfg: %v", err)
+	}
+
+	boom := errors.New("proxmox-backup-manager exploded")
+	restoreCmd = &FakeCommandRunner{
+		Outputs: map[string][]byte{
+			"which systemctl":                          {},
+			"proxmox-backup-manager version":           []byte("proxmox-backup-manager 4.0.0"),
+			"systemctl start proxmox-backup":           {},
+			"systemctl start proxmox-backup-proxy":     {},
+			"systemctl is-active proxmox-backup":       []byte("active"),
+			"systemctl is-active proxmox-backup-proxy": []byte("active"),
+		},
+		Errors: map[string]error{
+			"proxmox-backup-manager notification matcher create default-matcher --target mail-to-root": boom,
+			"proxmox-backup-manager notification matcher update default-matcher --target mail-to-root": boom,
+		},
+	}
+
+	logger := logging.New(types.LogLevelDebug, false)
+	var out bytes.Buffer
+	logger.SwapOutput(&out)
+
+	plan := &RestorePlan{
+		SystemType:         SystemTypePBS,
+		StagedCategories:   []Category{{ID: "pbs_notifications"}},
+		PBSRestoreBehavior: PBSRestoreBehaviorMerge,
+	}
+
+	// Merge mode swallows the failure by design: the run continues, nothing is written.
+	if err := maybeApplyNotificationsFromStage(context.Background(), logger, plan, stageRoot, false); err != nil {
+		t.Fatalf("merge mode must not abort the restore: %v", err)
+	}
+
+	logged := out.String()
+	if !strings.Contains(logged, "skipping apply (merge mode)") {
+		t.Fatalf("the operator must be told the apply was skipped, got:\n%s", logged)
+	}
+	if strings.Contains(logged, "applied via API") || strings.Contains(logged, "contains no notifications.cfg") {
+		t.Fatalf("a failed apply must not read as success or as an empty stage, got:\n%s", logged)
+	}
+}
+
+// The success arm, for symmetry: with a real staged config and every command succeeding, the
+// operator must still read the "applied via API" line. Asserting only the no-op line would
+// leave nothing proving the change did not silence the success case too.
+func TestMaybeApplyNotificationsFromStage_AppliedReportsSuccess(t *testing.T) {
+	origCmd := restoreCmd
+	origFS := restoreFS
+	origEuid := notificationsApplyGeteuid
+	origAPIEuid := pbsAPIApplyGeteuid
+	origVerify := serviceVerifyTimeout
+	t.Cleanup(func() {
+		restoreCmd = origCmd
+		restoreFS = origFS
+		notificationsApplyGeteuid = origEuid
+		pbsAPIApplyGeteuid = origAPIEuid
+		serviceVerifyTimeout = origVerify
+	})
+
+	restoreFS = osFS{}
+	notificationsApplyGeteuid = func() int { return 0 }
+	pbsAPIApplyGeteuid = func() int { return 0 }
+	serviceVerifyTimeout = 50 * time.Millisecond
+
+	stageRoot := t.TempDir()
+	cfgDir := filepath.Join(stageRoot, "etc", "proxmox-backup")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatalf("mkdir staged config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "notifications.cfg"), []byte(
+		"matcher: default-matcher\n"+
+			"    target mail-to-root\n",
+	), 0o640); err != nil {
+		t.Fatalf("write staged notifications.cfg: %v", err)
+	}
+
+	restoreCmd = &FakeCommandRunner{
+		Outputs: map[string][]byte{
+			"which systemctl":                          {},
+			"proxmox-backup-manager version":           []byte("proxmox-backup-manager 4.0.0"),
+			"systemctl start proxmox-backup":           {},
+			"systemctl start proxmox-backup-proxy":     {},
+			"systemctl is-active proxmox-backup":       []byte("active"),
+			"systemctl is-active proxmox-backup-proxy": []byte("active"),
+		},
+	}
+
+	logger := logging.New(types.LogLevelDebug, false)
+	var out bytes.Buffer
+	logger.SwapOutput(&out)
+
+	plan := &RestorePlan{
+		SystemType:         SystemTypePBS,
+		StagedCategories:   []Category{{ID: "pbs_notifications"}},
+		PBSRestoreBehavior: PBSRestoreBehaviorMerge,
+	}
+
+	if err := maybeApplyNotificationsFromStage(context.Background(), logger, plan, stageRoot, false); err != nil {
+		t.Fatalf("a clean apply must not error: %v", err)
+	}
+
+	logged := out.String()
+	if !strings.Contains(logged, "PBS notifications applied via API") {
+		t.Fatalf("a real apply must still report success, got:\n%s", logged)
+	}
+	if strings.Contains(logged, "contains no notifications.cfg") {
+		t.Fatalf("something was applied, so the no-op line must not appear, got:\n%s", logged)
 	}
 }


### PR DESCRIPTION
## Summary

`applyPBSNotificationsViaAPI` returned `nil` when the staged tree carried no `notifications.cfg`, which is the same value it returns after a successful apply. The caller could not tell the two apart and logged:

```
PBS notifications applied via API (%s)
```

for a run that had touched nothing.

That matters because a backup taken while `notifications.cfg` was excluded produces exactly this state. The one case the collector warnings catch at backup time (#287) was being silently blessed at restore time.

Found while investigating #287; deliberately left out of it because it changes restore semantics rather than collector output.

## What changed

`applyPBSNotificationsViaAPI` now reports whether it had anything to apply, and the caller says so plainly instead of claiming success.

## Why this is an Info and not a Warning

The source host may genuinely have had no notification config, and nothing reachable from the apply step can tell that apart from a backup that lost the file. Warning would assert a fault that cannot be established here, and would promote the exit code on every restore of a host that never configured notifications. That is the same false-positive trap #287 removed from the collector side, seen from the other end.

## Why the manifest cannot answer it

`ManifestEntry.Status` for `notifications.cfg` is exactly the missing datum, and it ships in `manifest.json`. But `manifest.json` belongs to the `proxsave_info` category, which is `ExportOnly`, and `splitRestoreCategories` (`internal/orchestrator/staging.go:36-49`) routes `ExportOnly` categories away from the stage. The stage is populated from `plan.StagedCategories` only (`restore_workflow_ui_extract.go:254`), so `stageRoot/manifest.json` does not exist.

It *is* reachable from `exportRoot`, which is populated at `restore_workflow_ui_run.go:102`, before the staged apply at `:108`, and there is precedent for reading it (`readPVEPoolsFromExportUserCfg`, `pve_safe_apply_pools.go:23-24`). But `exportCategories()` returns early when no export-only category was selected (`restore_workflow_ui_extract.go:148-150`), leaving `exportRoot` empty. A user restoring only `pbs_notifications` has no manifest at all.

So the distinction would be available intermittently at best, for a cross-phase coupling that does not exist today. It is left to the backup side, where the host is still present to answer it. This change does not preclude adding it later.

## Scope

The file-based fallback (`applyConfigFileFromStage`) and the PVE path were already honest: they skip at debug level and claim nothing. Untouched.

Not addressed here, noted for later: in Clean mode a backup without `notifications.cfg` leaves the live configuration intact rather than clearing it. Arguable in both directions, and a semantic change rather than a correctness fix.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` clean
- `golangci-lint run internal/orchestrator/...` reports 0 issues
- New regression test covers both `strict` values and asserts that no `proxmox-backup-manager` command runs against an empty stage

## Summary by Sourcery

Report PBS notification restores accurately when a backup contains no notification configuration.

Bug Fixes:
- Prevent restores from reporting PBS notifications as successfully applied when the staged backup contains no notifications.cfg.
- Preserve accurate handling of failed and completed PBS notification API applies.

Enhancements:
- Make the PBS notification API restore path distinguish between no-op, successful, and failed applies.
- Report absent notification configuration as an informational no-op while leaving the live configuration unchanged.

Tests:
- Add coverage for absent staged configuration, strict cleanup, successful applies, command failures, and restore-level logging.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR distinguishes an absent staged PBS notification configuration from a completed API apply and reports the no-op state accurately.
- Changes the PBS notification API apply function to return an applied-status boolean.
- Adds operator-facing no-op logging for an absent `notifications.cfg`.
- Adds tests for absent staging input, strict reconciliation, failures, and end-to-end logging.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a present configuration with no usable sections still produces the false-success report this change is intended to eliminate.

An empty or comment-only staged notifications.cfg parses into an empty desired state, executes no mutation commands in Merge mode, and nevertheless returns applied=true, so the caller still reports a successful API apply.

**Files Needing Attention:** internal/orchestrator/pbs_notifications_api_apply.go, internal/orchestrator/restore_notifications.go

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/pbs_notifications_api_apply.go | Adds an applied-status result to distinguish an absent staged configuration from a completed synchronization. |
| internal/orchestrator/restore_notifications.go | Uses the applied-status result to select between no-op and successful-apply logging. |
| internal/orchestrator/pbs_notifications_api_apply_test.go | Expands unit coverage for absent input, strict reconciliation, successful application, and command failures. |
| internal/orchestrator/restore_notifications_noop_test.go | Adds workflow-level coverage for no-op, failure, and successful PBS notification logging. |

</details>

<sub>Reviews (4): Last reviewed commit: ["test(restore): cover the notification ap..."](https://github.com/tis24dev/proxsave/commit/8bb175ad6fa23bf86119d5e2279c3066a44a4e9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56427127)</sub>

<!-- /greptile_comment -->