### PR TITLE
fix(pbs): stop claiming more than the evidence supports, in both directions

### DIFF
--- a/internal/backup/collector_pbs_notifications_evidence_test.go
+++ b/internal/backup/collector_pbs_notifications_evidence_test.go
@@ -1,0 +1,241 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeListing(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func evidenceCollector(t *testing.T) *Collector {
+	t.Helper()
+	return &Collector{
+		logger:  newTestLogger(),
+		tempDir: t.TempDir(),
+		config:  &CollectorConfig{BackupPBSNotifications: true, BackupPBSNotificationsPriv: true},
+	}
+}
+
+// The test the design record named and nobody wrote. One readable-and-empty smtp listing
+// used to license an affirmative claim about gotify and webhook, whose listings were never
+// captured at all.
+func TestWritePBSNotificationSummary_PrivWarnsWhenEvidenceIncomplete(t *testing.T) {
+	c := evidenceCollector(t)
+	c.pbsManifest = map[string]ManifestEntry{
+		"notifications.cfg":      {Status: StatusCollected},
+		"notifications-priv.cfg": {Status: StatusSkipped},
+	}
+
+	dir := t.TempDir()
+	// smtp readable and empty. gotify, webhook and targets deliberately absent.
+	writeListing(t, dir, "notification_endpoints_smtp.json", `{"data":[]}`)
+
+	s := pbsNotificationsSummary{Enabled: true, Endpoints: map[string]pbsNotificationSnapshotSummary{}}
+	s.ConfigFiles = &pbsNotificationsConfigFilesSummary{
+		NotificationsCfg:     c.pbsManifest["notifications.cfg"],
+		NotificationsPrivCfg: c.pbsManifest["notifications-priv.cfg"],
+	}
+	s.Targets = summarizePBSNotificationSnapshot(filepath.Join(dir, "notification_targets.json"))
+	for _, typ := range pbsNotificationEndpointTypes {
+		s.Endpoints[typ] = summarizePBSNotificationSnapshot(filepath.Join(dir, "notification_endpoints_"+typ+".json"))
+	}
+
+	c.appendPBSNotificationPrivFindings(&s)
+
+	if len(s.Warnings) != 1 {
+		t.Fatalf("incomplete evidence must warn, got warnings=%v notes=%v", s.Warnings, s.Notes)
+	}
+	if !strings.Contains(s.Warnings[0], "gotify or webhook") {
+		t.Fatalf("the warning must name the kinds nothing accounts for, got: %s", s.Warnings[0])
+	}
+	// Load-bearing: asserting the ABSENCE of the affirmative clause makes this unfoolable
+	// by rewording.
+	for _, line := range append(append([]string{}, s.Warnings...), s.Notes...) {
+		if strings.Contains(line, "so no secret was lost") {
+			t.Fatalf("nothing may claim no secret was lost here, got: %s", line)
+		}
+	}
+}
+
+// The targets listing is the union of the four endpoint kinds and carries each entry's
+// type, so one readable targets listing accounts for kinds whose own listing is missing.
+// This is what makes PBS 3.2, which has no webhook list command at all, reach a complete
+// answer without reading a version string.
+func TestPBSSecretEvidence_TargetsUnionCoversUnreadKinds(t *testing.T) {
+	c := evidenceCollector(t)
+	dir := t.TempDir()
+	writeListing(t, dir, "notification_targets.json",
+		`{"data":[{"name":"mail-to-root","origin":"builtin","type":"sendmail"}]}`)
+
+	s := summaryWith(StatusCollected, StatusSkipped)
+	s.Enabled = true
+	s.Targets = summarizePBSNotificationSnapshot(filepath.Join(dir, "notification_targets.json"))
+
+	c.appendPBSNotificationPrivFindings(&s)
+
+	if len(s.Warnings) != 0 {
+		t.Fatalf("the targets union accounts for every kind, so nothing is unknown: %v", s.Warnings)
+	}
+	if len(s.Notes) != 1 || !strings.Contains(s.Notes[0], "verified from the notification target listing") {
+		t.Fatalf("the note must name the source of the claim, got: %v", s.Notes)
+	}
+}
+
+// An unknown type in the targets listing may itself be secret-capable — webhook was added
+// in PBS 3.3 — so it must veto the union rather than be silently excluded from a count we
+// are about to call complete.
+func TestPBSSecretEvidence_UnknownTargetTypeVetoesTheUnion(t *testing.T) {
+	c := evidenceCollector(t)
+	dir := t.TempDir()
+	writeListing(t, dir, "notification_targets.json",
+		`{"data":[{"name":"x","origin":"user-created","type":"ntfy"}]}`)
+
+	s := summaryWith(StatusCollected, StatusSkipped)
+	s.Enabled = true
+	s.Targets = summarizePBSNotificationSnapshot(filepath.Join(dir, "notification_targets.json"))
+
+	c.appendPBSNotificationPrivFindings(&s)
+
+	if len(s.Warnings) != 1 {
+		t.Fatalf("an unknown kind must not be counted as covered, got warnings=%v notes=%v", s.Warnings, s.Notes)
+	}
+}
+
+// The union supplements the per-kind listings and must never lower an observation.
+func TestPBSSecretEvidence_TargetsNeverLowerAnObservation(t *testing.T) {
+	c := evidenceCollector(t)
+	s := summaryWith(StatusCollected, StatusSkipped)
+	s.Enabled = true
+	s.Targets = pbsNotificationSnapshotSummary{Present: true, Total: 1, ByType: map[string]int{"sendmail": 1}}
+	s.Endpoints = map[string]pbsNotificationSnapshotSummary{
+		"smtp": {Present: true, Total: 2},
+	}
+
+	c.appendPBSNotificationPrivFindings(&s)
+
+	if len(s.Warnings) != 1 || !strings.Contains(s.Warnings[0], "2 secret-capable") {
+		t.Fatalf("the per-kind observation must survive the union, got warnings=%v notes=%v", s.Warnings, s.Notes)
+	}
+}
+
+// A zero-byte listing is a truncated or redirected-to-nothing file, never proof that PBS
+// has no objects of that kind. proxmox-router prints "[]" for a genuinely empty list.
+func TestSummarizePBSNotificationSnapshot_EmptyBodyIsUnusable(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name       string
+		body       string
+		wantUsable bool
+	}{
+		{"zero bytes", "", false},
+		{"whitespace only", "   \n\t\n", false},
+		{"empty json list", "[]", true},
+		{"empty data envelope", `{"data":[]}`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, strings.ReplaceAll(tt.name, " ", "_")+".json")
+			writeListing(t, dir, filepath.Base(path), tt.body)
+			got := summarizePBSNotificationSnapshot(path)
+			if got.usable() != tt.wantUsable {
+				t.Fatalf("usable()=%v want %v (%+v)", got.usable(), tt.wantUsable, got)
+			}
+			if !tt.wantUsable && got.Error == "" {
+				t.Fatal("an unusable listing must carry the reason")
+			}
+		})
+	}
+}
+
+// An incomplete survey can only undercount, so the number must be presented as a floor.
+func TestPBSNotificationPrivFindings_IncompleteSurveyReportsAFloor(t *testing.T) {
+	c := evidenceCollector(t)
+	s := summaryWith(StatusCollected, StatusSkipped)
+	s.Enabled = true
+	s.Endpoints = map[string]pbsNotificationSnapshotSummary{
+		"smtp": {Present: true, Total: 2},
+	}
+
+	c.appendPBSNotificationPrivFindings(&s)
+
+	if len(s.Warnings) != 1 || !strings.Contains(s.Warnings[0], "at least 2") {
+		t.Fatalf("an incomplete survey must say the count is a floor, got: %v", s.Warnings)
+	}
+}
+
+// A dry run attempts no listing command, so every listing is absent by construction. A
+// warning about secret loss there is exit-code-bearing noise about a run in which nothing
+// was tried.
+func TestPBSNotificationPrivFindings_DryRunSaysNothing(t *testing.T) {
+	c := evidenceCollector(t)
+	c.dryRun = true
+	s := summaryWith(StatusCollected, StatusSkipped)
+	s.Enabled = true
+
+	c.appendPBSNotificationPrivFindings(&s)
+
+	if len(s.Warnings) != 0 || len(s.Notes) != 0 {
+		t.Fatalf("a dry run must say nothing, got warnings=%v notes=%v", s.Warnings, s.Notes)
+	}
+}
+
+// An empty Status means the manifest brick never ran, not that collection was skipped.
+// Falling through emits a finding whose premise is fabricated.
+func TestPBSNotificationPrivFindings_EmptyStatusSaysNothing(t *testing.T) {
+	c := evidenceCollector(t)
+	s := summaryWith(StatusCollected, "")
+	s.Enabled = true
+	s.Endpoints = map[string]pbsNotificationSnapshotSummary{"smtp": {Present: true, Total: 0}}
+
+	c.appendPBSNotificationPrivFindings(&s)
+
+	if len(s.Warnings) != 0 || len(s.Notes) != 0 {
+		t.Fatalf("a missing manifest entry is not a collection status, got warnings=%v notes=%v", s.Warnings, s.Notes)
+	}
+}
+
+// The PBS 3.2 remark explains webhook and nothing else. Appending it to the other five
+// listings attributed a webhook-specific cause to failures it cannot explain.
+func TestPBSNotificationEvidenceNotes_PBS32RemarkOnlyOnWebhook(t *testing.T) {
+	c := evidenceCollector(t)
+	s := pbsNotificationsSummary{Enabled: true, Endpoints: map[string]pbsNotificationSnapshotSummary{}}
+
+	c.appendPBSNotificationEvidenceNotes(&s)
+
+	var withRemark []string
+	for _, n := range s.Notes {
+		if strings.Contains(n, "webhook list command") {
+			withRemark = append(withRemark, n)
+		}
+	}
+	if len(withRemark) != 1 {
+		t.Fatalf("exactly one note may carry the PBS 3.2 remark, got %d: %v", len(withRemark), s.Notes)
+	}
+	if !strings.Contains(withRemark[0], "webhook endpoint listing") {
+		t.Fatalf("the remark must sit on the webhook note, got: %s", withRemark[0])
+	}
+}
+
+// Mirror of the origin invariant: no entry may fall out of the type accounting either.
+func TestSummarizePBSNotificationSnapshot_TypeBucketsSumToTotal(t *testing.T) {
+	dir := t.TempDir()
+	writeListing(t, dir, "mixed.json",
+		`{"data":[{"name":"a","type":"smtp"},{"name":"b"},{"name":"c","type":"ntfy"},"not-an-object",42]}`)
+
+	got := summarizePBSNotificationSnapshot(filepath.Join(dir, "mixed.json"))
+
+	sum := got.TypeMissing
+	for _, n := range got.ByType {
+		sum += n
+	}
+	if sum != got.Total {
+		t.Fatalf("type buckets sum to %d but Total is %d (%+v)", sum, got.Total, got)
+	}
+}

--- a/internal/backup/collector_pbs_notifications_summary.go
+++ b/internal/backup/collector_pbs_notifications_summary.go
@@ -42,6 +42,22 @@ type pbsNotificationSnapshotSummary struct {
 	OriginMissing      int `json:"origin_missing,omitempty"`
 	OriginUnrecognized int `json:"origin_unrecognized,omitempty"`
 
+	// Type breakdown, read from the per-entry "type" field. Invariant, asserted by
+	// TestSummarizePBSNotificationSnapshot_TypeBucketsSumToTotal:
+	//   sum(ByType) + TypeMissing == Total
+	//
+	// Only the targets listing is ever consulted through these. "notification target list"
+	// is the union of the four endpoint kinds (proxmox-notify api/mod.rs:85-120) and stamps
+	// every entry with its type, so ONE readable targets listing can account for endpoint
+	// kinds whose own listing was never captured -- including on PBS 3.2 and older, where
+	// `notification endpoint webhook list` does not exist and webhook endpoints cannot
+	// exist either.
+	//
+	// TypeMissing exists so that an entry we could not type VETOES that use rather than
+	// silently shrinking a count we are about to call complete.
+	ByType      map[string]int `json:"by_type,omitempty"`
+	TypeMissing int            `json:"type_missing,omitempty"`
+
 	Names []string `json:"names,omitempty"`
 	Error string   `json:"error,omitempty"`
 }
@@ -200,40 +216,77 @@ func (c *Collector) appendPBSNotificationPrivFindings(summary *pbsNotificationsS
 		return
 	}
 
+	// A dry run executes no listing command, so every listing is absent BY CONSTRUCTION.
+	// The status below is real, but any sentence about secret loss would rest on evidence
+	// nobody attempted to gather -- and today that produces an exit-code-bearing warning
+	// about a run in which nothing was attempted. appendPBSNotificationEvidenceNotes
+	// already carries this guard; this closes the asymmetry.
+	if c.dryRun {
+		return
+	}
+
+	// An empty Status is not a status. It arises from a missing c.pbsManifest key, which
+	// means the manifest brick did not run, NOT that collection was skipped. Falling
+	// through would emit a finding whose premise ("was not collected (unknown status)") is
+	// fabricated. Note this is NOT covered by a !summary.Enabled guard: the hazard occurs
+	// when BACKUP_PBS_NOTIFICATIONS is TRUE.
+	if strings.TrimSpace(string(priv.Status)) == "" {
+		return
+	}
+
 	// What losing this file actually costs, per endpoint kind: the gotify token is a
 	// required positional for the restore path, which skips the endpoint outright without
-	// it (pbs_notifications_api_apply.go:180-196). smtp and webhook take their positional
-	// from the public config, so they come back looking fine and fail when they first send.
+	// it (pbs_notifications_api_apply.go). smtp and webhook take their positional from the
+	// public config, so they come back looking fine and fail when they first send.
 	consequence := "Gotify endpoints would be dropped by the restore path because their token lives in that file; smtp and webhook endpoints would be recreated without their password or secrets and fail silently the first time they try to send."
 
-	observed, evidenceUsable := pbsSecretCapableEndpointEvidence(*summary)
+	ev := pbsSecretCapableEndpointEvidence(*summary)
 
 	if priv.Status == StatusNotFound {
 		// PBS writes a private section whenever a secret-capable endpoint is created, even
 		// when it carries no secret, so endpoints without the file means we looked in the
 		// wrong place rather than that there was nothing to collect.
-		if observed > 0 {
+		if ev.Observed > 0 {
 			summary.Notes = append(summary.Notes, fmt.Sprintf(
-				"%d secret-capable notification endpoint(s) are configured, but %s was not found. %s",
-				observed, path, consequence))
+				"%s secret-capable notification endpoint(s) are configured, but %s was not found. %s",
+				ev.countPhrase(), path, consequence))
 		}
 		return
 	}
 
 	// StatusSkipped, StatusFailed, and any status added later.
 	switch {
-	case observed > 0:
+	case ev.Observed > 0:
+		// A positive observation is sound whether or not the survey was complete, because
+		// an incomplete survey can only undercount -- countPhrase says so out loud instead
+		// of presenting a floor as a total.
 		summary.Warnings = append(summary.Warnings, fmt.Sprintf(
-			"%s was not collected (%s) while %d secret-capable endpoint(s) are configured. %s",
-			path, pbsNotificationStatusDetail(priv), observed, consequence))
-	case !evidenceUsable:
+			"%s was not collected (%s) while %s secret-capable endpoint(s) are configured. %s",
+			path, pbsNotificationStatusDetail(priv), ev.countPhrase(), consequence))
+
+	case ev.Complete:
+		// The ONLY shape of evidence that earns an affirmative sentence: every
+		// secret-capable kind accounted for by a listing we actually read, and every one of
+		// them empty. Naming the source makes the claim auditable from the JSON artifact.
+		summary.Notes = append(summary.Notes, fmt.Sprintf(
+			"%s was not collected (%s), but no smtp, gotify or webhook endpoint is configured (verified from %s), so no secret was lost.",
+			path, pbsNotificationStatusDetail(priv), ev.sourcePhrase()))
+
+	case len(ev.Verified) == 0:
 		summary.Warnings = append(summary.Warnings, fmt.Sprintf(
 			"%s was not collected (%s) and no endpoint listing could be read, so whether any secret was lost is unknown. %s",
 			path, pbsNotificationStatusDetail(priv), consequence))
+
 	default:
-		summary.Notes = append(summary.Notes, fmt.Sprintf(
-			"%s was not collected (%s), but no smtp, gotify or webhook endpoint is configured, so no secret was lost.",
-			path, pbsNotificationStatusDetail(priv)))
+		// WAS THE BUG. Partial evidence: state the partition, draw no conclusion, and carry
+		// the same severity as the no-evidence arm above -- the question is equally
+		// unanswered, and a single readable listing downgrading it to a Note is exactly the
+		// defect. persisted() already states the mirror rule ("an origin we could not read
+		// must not raise an alarm"); the missing half is that a listing we could not read
+		// must not SILENCE one.
+		summary.Warnings = append(summary.Warnings, fmt.Sprintf(
+			"%s was not collected (%s). Endpoint evidence is incomplete: %s, so whether any secret was lost is unknown. %s",
+			path, pbsNotificationStatusDetail(priv), ev.incompleteClause(), consequence))
 	}
 }
 
@@ -245,24 +298,43 @@ func (c *Collector) appendPBSNotificationEvidenceNotes(summary *pbsNotifications
 	}
 
 	listings := []struct {
-		name string
-		snap pbsNotificationSnapshotSummary
+		name      string
+		isWebhook bool
+		snap      pbsNotificationSnapshotSummary
 	}{
-		{"targets", summary.Targets},
-		{"matchers", summary.Matchers},
+		{name: "targets", snap: summary.Targets},
+		{name: "matchers", snap: summary.Matchers},
 	}
 	for _, typ := range pbsNotificationEndpointTypes {
 		listings = append(listings, struct {
-			name string
-			snap pbsNotificationSnapshotSummary
-		}{fmt.Sprintf("%s endpoint", typ), summary.Endpoints[typ]})
+			name      string
+			isWebhook bool
+			snap      pbsNotificationSnapshotSummary
+		}{
+			name:      fmt.Sprintf("%s endpoint", typ),
+			isWebhook: typ == "webhook",
+			snap:      summary.Endpoints[typ],
+		})
 	}
 
 	for _, l := range listings {
 		switch {
-		case !l.snap.Present:
+		case !l.snap.Present && l.snap.Error != "":
+			// Was reported with the generic "was not captured" text because the !Present
+			// case came first, so the read error never reached the operator and survived
+			// only inside the JSON artifact. A specific failure reported as a generic one
+			// is the same defect class in miniature.
 			summary.Notes = append(summary.Notes, fmt.Sprintf(
-				"Notification %s listing was not captured, so its contents are unknown. On PBS 3.2 and older this is expected for webhook, which has no list command there.", l.name))
+				"Notification %s listing could not be read (%s), so its contents are unknown.", l.name, l.snap.Error))
+		case !l.snap.Present:
+			note := fmt.Sprintf("Notification %s listing was not captured, so its contents are unknown.", l.name)
+			// The PBS 3.2 remark belongs to webhook and to nothing else. Appending it to
+			// the targets, matchers, smtp, sendmail and gotify notes attributed a
+			// webhook-specific cause to five listings it cannot explain.
+			if l.isWebhook {
+				note += " On PBS 3.2 and older this is expected: there is no webhook list command there."
+			}
+			summary.Notes = append(summary.Notes, note)
 		case l.snap.Error != "":
 			summary.Notes = append(summary.Notes, fmt.Sprintf(
 				"Notification %s listing could not be read (%s), so its contents are unknown.", l.name, l.snap.Error))
@@ -288,24 +360,155 @@ func pbsPersistedObjectCount(summary pbsNotificationsSummary) int {
 	return total
 }
 
-// pbsSecretCapableEndpointEvidence reports how many smtp, gotify and webhook endpoints were
-// observed, and whether any of those listings could actually be read.
+// pbsSecretEvidence answers "could a secret have been lost" as evidence rather than as a
+// conclusion, so the consumer can say what it actually knows.
 //
-// evidenceUsable stays true as long as one of them was readable. PBS 3.2 and older have no
-// "notification endpoint webhook list" command, so requiring all three would leave this
-// permanently false there and warn on every run.
-func pbsSecretCapableEndpointEvidence(summary pbsNotificationsSummary) (observed int, evidenceUsable bool) {
+// Observed is exact when Complete is true and a FLOOR when it is false: every source that
+// contributes is a listing that parsed, and a listing we could not read can only hide
+// endpoints, never invent them.
+type pbsSecretEvidence struct {
+	Observed int
+	Complete bool     // every secret-capable kind was accounted for by a listing we read
+	Verified []string // secret-capable kinds a readable listing accounted for
+	Unknown  []string // secret-capable kinds nothing accounted for
+
+	fromTargets   bool
+	fromEndpoints bool
+}
+
+// pbsSecretCapableEndpointEvidence reports how many smtp, gotify and webhook endpoints were
+// observed and, crucially, whether that count covers all three kinds.
+//
+// The previous version set a single evidenceUsable flag from ANY readable listing, so one
+// readable-and-empty smtp listing licensed an affirmative claim about gotify and webhook.
+// A missing map key was worse: the `!ok` branch skipped the kind outright, making "webhook
+// was never captured" indistinguishable from "webhook was read and empty".
+//
+// The targets listing SUPPLEMENTS the per-kind listings and never overrides them. Taking
+// the maximum per kind means a targets listing that under-reports can only ever fail to ADD
+// evidence, never SUBTRACT it. That is the one direction that matters here, and it is the
+// direction the old flag failed in.
+//
+// PBS 3.2 and older have no `notification endpoint webhook list` command (upstream
+// src/api2/config/notifications/webhook.rs first appears 2024-11-26), so Endpoints["webhook"]
+// is permanently unusable there. The targets union covers webhook there BY CONSTRUCTION --
+// webhook endpoints cannot exist on 3.2, so they cannot be missing from the union -- which
+// is why this reaches Complete without reading a version string.
+func pbsSecretCapableEndpointEvidence(summary pbsNotificationsSummary) pbsSecretEvidence {
+	unionCovers := pbsTargetsCoverEndpointKinds(summary.Targets)
+
+	ev := pbsSecretEvidence{Complete: true}
 	for _, typ := range pbsSecretCapableEndpointTypes {
-		s, ok := summary.Endpoints[typ]
-		if !ok {
+		observed, covered := 0, false
+
+		if s, ok := summary.Endpoints[typ]; ok && s.usable() {
+			// Total is only assigned after every error return, so an unusable listing can
+			// never contribute a count.
+			observed = s.Total
+			covered = true
+			ev.fromEndpoints = true
+		}
+		if unionCovers {
+			if n := summary.Targets.ByType[typ]; n > observed {
+				observed = n
+			}
+			covered = true
+			ev.fromTargets = true
+		}
+
+		ev.Observed += observed
+		if covered {
+			ev.Verified = append(ev.Verified, typ)
 			continue
 		}
-		if s.usable() {
-			evidenceUsable = true
-		}
-		observed += s.Total
+		ev.Complete = false
+		ev.Unknown = append(ev.Unknown, typ)
 	}
-	return observed, evidenceUsable
+	return ev
+}
+
+// pbsTargetsCoverEndpointKinds reports whether the targets listing may stand in for the
+// per-kind endpoint listings. Every veto below closes a way the union could quietly
+// under-report a secret-capable endpoint, which is the only failure direction that matters:
+// this predicate is what licenses an affirmative "no secret was lost".
+func pbsTargetsCoverEndpointKinds(targets pbsNotificationSnapshotSummary) bool {
+	if !targets.usable() {
+		return false
+	}
+	if targets.TypeMissing > 0 {
+		// An entry we could not type might be the very endpoint we are about to deny.
+		return false
+	}
+	if targets.Total == 0 {
+		// PBS injects its pristine built-ins into every listing from a compiled-in default
+		// set even when notifications.cfg does not exist, so a valid but empty targets
+		// listing cannot occur on a live host. Fall back rather than build a reassurance on
+		// a file we have ourselves declared impossible.
+		return false
+	}
+	for typ := range targets.ByType {
+		if !containsPBSString(pbsNotificationEndpointTypes, typ) {
+			// A kind we do not know about may be secret-capable -- webhook itself was added
+			// in PBS 3.3. Excluding it from the count while calling that count complete is
+			// precisely the failure the old evidenceUsable flag made.
+			return false
+		}
+	}
+	return true
+}
+
+// countPhrase keeps the number honest: an incomplete survey can only ever floor the count.
+func (e pbsSecretEvidence) countPhrase() string {
+	if e.Complete {
+		return fmt.Sprintf("%d", e.Observed)
+	}
+	return fmt.Sprintf("at least %d", e.Observed)
+}
+
+// sourcePhrase names the listing the affirmative claim rests on, so the sentence can be
+// audited against notifications_summary.json.
+func (e pbsSecretEvidence) sourcePhrase() string {
+	switch {
+	case e.fromTargets && e.fromEndpoints:
+		return "the notification target and endpoint listings"
+	case e.fromTargets:
+		return "the notification target listing"
+	default:
+		return "the smtp, gotify and webhook endpoint listings"
+	}
+}
+
+// incompleteClause states the evidence and draws no conclusion. It deliberately makes NO
+// claim about WHY a listing is missing: proxsave cannot tell "the command does not exist on
+// this PBS version" from "the command failed" from "an exclude pattern swallowed the output"
+// -- captureCommandOutput discards the whole commandRunResult -- and several distinct causes
+// converge on the same observable.
+func (e pbsSecretEvidence) incompleteClause() string {
+	return fmt.Sprintf("%s shows none configured, and no readable listing accounts for %s",
+		joinPBSAnd(e.Verified), joinPBSOr(e.Unknown))
+}
+
+func containsPBSString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func joinPBSAnd(items []string) string { return joinPBSList(items, " and ") }
+func joinPBSOr(items []string) string  { return joinPBSList(items, " or ") }
+
+func joinPBSList(items []string, last string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + last + items[len(items)-1]
+	}
 }
 
 // pbsNotificationsPrivDisableHint mirrors collectPBSManifestNotificationsPriv: when the
@@ -357,6 +560,11 @@ func summarizePBSNotificationSnapshot(path string) pbsNotificationSnapshotSummar
 
 	trimmed := strings.TrimSpace(string(raw))
 	if trimmed == "" {
+		// proxmox-router prints "[]" for an empty list, so a zero-byte or whitespace-only
+		// body is a truncated, half-written or redirected-to-nothing file -- never proof
+		// that PBS has no objects of this kind. Returning it with Error=="" made usable()
+		// true with Total 0, i.e. a zero-byte file read as positive evidence of absence.
+		summary.Error = "empty output"
 		return summary
 	}
 
@@ -386,14 +594,25 @@ func summarizePBSNotificationSnapshot(path string) pbsNotificationSnapshotSummar
 		entry, ok := item.(map[string]any)
 		if !ok {
 			// Keep the buckets summing to Total: a shape we cannot read must not vanish
-			// from the accounting.
+			// from the accounting, in either dimension.
 			summary.OriginUnrecognized++
+			summary.TypeMissing++
 			continue
 		}
 
 		name := firstString(entry, "name", "id", "target", "matcher")
 		if name != "" {
 			names = append(names, name)
+		}
+
+		// Exact match, lowercased, same discipline as the origin vocabulary below.
+		if typ := strings.ToLower(strings.TrimSpace(firstString(entry, "type"))); typ != "" {
+			if summary.ByType == nil {
+				summary.ByType = make(map[string]int)
+			}
+			summary.ByType[typ]++
+		} else {
+			summary.TypeMissing++
 		}
 
 		// Exact match rather than substring: "modified-builtin" contains "builtin", so any

--- a/internal/orchestrator/pbs_notifications_api_apply.go
+++ b/internal/orchestrator/pbs_notifications_api_apply.go
@@ -30,63 +30,132 @@ type pbsNotificationDesiredState struct {
 // `notification endpoint gotify create <name> <server> <token> ...`.
 const gotifyTokenRedactIndex = 6
 
-// applyPBSNotificationsViaAPI reports whether it had anything to apply. A backup that
-// carries no notifications.cfg produces applied=false with a nil error: that is not a
-// failure, but the caller must not report it as a successful apply either. The manifest
-// entry that would say whether the file was lost or never existed lives in the ExportOnly
-// proxsave_info category and is not staged, so this distinction cannot be made here.
-func applyPBSNotificationsViaAPI(ctx context.Context, logger *logging.Logger, stageRoot string, strict bool) (applied bool, err error) {
-	desired, present, err := loadPBSNotificationDesiredState(stageRoot, logger)
-	if err != nil || !present {
-		return false, err
-	}
+// pbsNotificationApplyReport is an ACCOUNT of what the apply observed and what it did, not
+// a verdict on whether it "succeeded". There is deliberately no succeeded/applied field:
+// the presence of an input is never evidence that an operation occurred, and several facts
+// are true simultaneously -- the file was staged AND it was empty AND three live objects
+// were deleted. No bool carries that; the caller phrases the operator sentence from these
+// counters.
+//
+// WHERE THE COUNTERS LIVE, and why not in runPBSManagerRedacted:
+//  1. That choke point is shared with the sibling appliers driven from the same ctx, so a
+//     counter there collects their commands too.
+//  2. It cannot separate a mutating call from a read-only one without sniffing argv for
+//     "create"/"update"/"remove" -- inferring intent from a string is the same class of
+//     unfounded affirmation this change removes.
+//  3. upsertPBSNotificationEndpoint issues create and, on failure, update: one logical
+//     change, two commands. A command counter double-counts and counts the FAILED create
+//     as work.
+//  4. Clean mode with an empty staged cfg issues read-only list commands and mutates
+//     nothing; "commands ran" is not a usable proxy for "work done".
+//
+// Every mutating counter below is incremented only AFTER proxmox-backup-manager
+// acknowledged the command.
+type pbsNotificationApplyReport struct {
+	staged      bool // etc/proxmox-backup/notifications.cfg existed in the stage
+	stagedEmpty bool // ...and its content was empty or whitespace-only
+	sections    int  // section headers parseProxmoxNotificationSections recognised
+	planned     int  // endpoints + matchers the desired state actually names
 
+	droppedUnknownType int
+	droppedIncomplete  int
+	droppedTypes       []string // endpoint kinds that lost at least one section
+
+	endpointsUpserted int
+	matchersUpserted  int
+	removed           []string // objects deleted, named: "matcher:x", "smtp:y"
+	removeFailed      []string // objects PBS refused to delete (left in place)
+	removalsSkipped   []string // endpoint kinds whose Clean removal pass was not run
+}
+
+// mutated reports whether at least one mutating command was acknowledged. This is the
+// predicate the old `applied` bool was pretending to be.
+//
+// It is deliberately NOT "the live state now differs": an update that rewrites identical
+// values is counted, because we cannot observe the difference and must not claim to. The
+// caller therefore says "applied", with counts, and never "changed".
+func (r pbsNotificationApplyReport) mutated() bool {
+	return r.endpointsUpserted > 0 || r.matchersUpserted > 0 || len(r.removed) > 0
+}
+
+func (r pbsNotificationApplyReport) dropped() int {
+	return r.droppedUnknownType + r.droppedIncomplete
+}
+
+func applyPBSNotificationsViaAPI(ctx context.Context, logger *logging.Logger, stageRoot string, strict bool) (pbsNotificationApplyReport, error) {
+	var rep pbsNotificationApplyReport
+
+	desired, err := loadPBSNotificationDesiredState(stageRoot, logger, &rep)
+	if err != nil || !rep.staged {
+		return rep, err
+	}
+	rep.planned = len(desired.endpoints) + len(desired.matchers)
+
+	// Clean mode still runs on an empty desired state: the removals are REAL WORK and must
+	// be counted, not short-circuited, or a run that deleted everything would report
+	// "nothing was applied". Whether Clean should be ALLOWED to wipe a live configuration
+	// on the authority of a staged file that names nothing is a policy question this change
+	// deliberately does not answer -- it makes the wipe visible and warns that its only
+	// evidence was such a file.
 	if strict {
-		if err := removeExtraPBSNotificationMatchers(ctx, logger, desired.matchers); err != nil {
-			return false, err
+		if err := removeExtraPBSNotificationMatchers(ctx, logger, desired.matchers, &rep); err != nil {
+			return rep, err
 		}
 	}
-	if err := syncPBSNotificationEndpoints(ctx, logger, desired.endpoints, strict); err != nil {
-		return false, err
+	if err := syncPBSNotificationEndpoints(ctx, logger, desired.endpoints, strict, &rep); err != nil {
+		return rep, err
 	}
-	if err := syncPBSNotificationMatchers(ctx, desired); err != nil {
-		return false, err
+	if err := syncPBSNotificationMatchers(ctx, desired, &rep); err != nil {
+		return rep, err
 	}
-	return true, nil
+	// No error is synthesised from rep.removeFailed here. That would make err != nil mean
+	// two different things -- "aborted mid-flight" and "completed but could not finish
+	// cleanup" -- and the caller's partial-apply sentence would then be false on a fully
+	// successful Clean.
+	return rep, nil
 }
 
-func loadPBSNotificationDesiredState(stageRoot string, logger *logging.Logger) (pbsNotificationDesiredState, bool, error) {
-	cfgSections, privSections, present, err := readPBSNotificationStageSections(stageRoot)
-	if err != nil || !present {
-		return pbsNotificationDesiredState{}, present, err
+func loadPBSNotificationDesiredState(stageRoot string, logger *logging.Logger, rep *pbsNotificationApplyReport) (pbsNotificationDesiredState, error) {
+	cfgSections, privSections, err := readPBSNotificationStageSections(stageRoot, rep)
+	if err != nil || !rep.staged {
+		return pbsNotificationDesiredState{}, err
 	}
-
-	desired := buildPBSNotificationDesiredState(cfgSections, privSections, logger)
-	return desired, true, nil
+	return buildPBSNotificationDesiredState(cfgSections, privSections, logger, rep), nil
 }
 
-func readPBSNotificationStageSections(stageRoot string) ([]proxmoxNotificationSection, []proxmoxNotificationSection, bool, error) {
+func readPBSNotificationStageSections(stageRoot string, rep *pbsNotificationApplyReport) ([]proxmoxNotificationSection, []proxmoxNotificationSection, error) {
 	cfgRaw, cfgPresent, err := readStageFileOptional(stageRoot, "etc/proxmox-backup/notifications.cfg")
+	// NOTE: on a non-ENOENT read error readStageFileOptional returns (present=false, err!=nil),
+	// so rep.staged stays false AND err is non-nil. The caller must therefore never print the
+	// "!staged" sentence on the error path, or an unreadable staged file gets reported as
+	// "this backup contains no notifications.cfg".
+	rep.staged = cfgPresent
 	if err != nil || !cfgPresent {
-		return nil, nil, cfgPresent, err
+		return nil, nil, err
 	}
+	// readStageFileOptional trims, so "" here means the staged file was empty or
+	// whitespace-only. This is the single fact the old `present` bool folded into "the file
+	// exists, therefore we have a desired state", and the whole of the bug hangs off it.
+	rep.stagedEmpty = cfgRaw == ""
+
 	privRaw, _, err := readStageFileOptional(stageRoot, "etc/proxmox-backup/notifications-priv.cfg")
 	if err != nil {
-		return nil, nil, true, err
+		return nil, nil, err
 	}
 
 	cfgSections, err := parseProxmoxNotificationSections(cfgRaw)
 	if err != nil {
-		return nil, nil, true, fmt.Errorf("parse staged notifications.cfg: %w", err)
+		return nil, nil, fmt.Errorf("parse staged notifications.cfg: %w", err)
 	}
 	privSections, err := parseProxmoxNotificationSections(privRaw)
 	if err != nil {
-		return nil, nil, true, fmt.Errorf("parse staged notifications-priv.cfg: %w", err)
+		return nil, nil, fmt.Errorf("parse staged notifications-priv.cfg: %w", err)
 	}
-	return cfgSections, privSections, true, nil
+	rep.sections = len(cfgSections)
+	return cfgSections, privSections, nil
 }
 
-func buildPBSNotificationDesiredState(cfgSections, privSections []proxmoxNotificationSection, logger *logging.Logger) pbsNotificationDesiredState {
+func buildPBSNotificationDesiredState(cfgSections, privSections []proxmoxNotificationSection, logger *logging.Logger, rep *pbsNotificationApplyReport) pbsNotificationDesiredState {
 	privByKey, privRedactFlagsByKey := pbsNotificationPrivMaps(privSections)
 	desired := pbsNotificationDesiredState{matchers: make(map[string]proxmoxNotificationSection)}
 
@@ -98,20 +167,47 @@ func buildPBSNotificationDesiredState(cfgSections, privSections []proxmoxNotific
 		}
 		switch typ {
 		case "smtp", "sendmail", "gotify", "webhook":
-			if endpoint, ok := buildPBSNotificationEndpoint(section, privByKey, privRedactFlagsByKey, logger); ok {
-				desired.endpoints = append(desired.endpoints, endpoint)
+			endpoint, ok := buildPBSNotificationEndpoint(section, privByKey, privRedactFlagsByKey, logger)
+			if !ok {
+				// buildPBSNotificationEndpoint already warned with the specific missing
+				// field. Record the KIND as well: in Clean mode a kind that lost a section
+				// has an incomplete desired set, so "live but not desired" no longer means
+				// "absent from the backup".
+				rep.droppedIncomplete++
+				rep.droppedTypes = appendUniquePBSString(rep.droppedTypes, typ)
+				continue
 			}
+			desired.endpoints = append(desired.endpoints, endpoint)
 		case "matcher":
 			desired.matchers[name] = section
 		default:
 			if logger != nil {
 				logger.Warning("PBS notifications API apply: unknown section %q (%s); skipping", typ, name)
 			}
+			rep.droppedUnknownType++
 		}
 	}
 
 	desired.matcherNames = sortedPBSMatcherNames(desired.matchers)
 	return desired
+}
+
+func appendUniquePBSString(items []string, want string) []string {
+	for _, item := range items {
+		if item == want {
+			return items
+		}
+	}
+	return append(items, want)
+}
+
+func containsPBSApplyString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 func pbsNotificationPrivMaps(sections []proxmoxNotificationSection) (map[string][]proxmoxNotificationEntry, map[string][]string) {
@@ -219,7 +315,7 @@ func sortedPBSMatcherNames(matchers map[string]proxmoxNotificationSection) []str
 	return names
 }
 
-func removeExtraPBSNotificationMatchers(ctx context.Context, logger *logging.Logger, desired map[string]proxmoxNotificationSection) error {
+func removeExtraPBSNotificationMatchers(ctx context.Context, logger *logging.Logger, desired map[string]proxmoxNotificationSection, rep *pbsNotificationApplyReport) error {
 	current, err := listPBSNotificationIDs(ctx, "matcher", "list")
 	if err != nil {
 		return err
@@ -229,21 +325,36 @@ func removeExtraPBSNotificationMatchers(ctx context.Context, logger *logging.Log
 			continue
 		}
 		if _, err := runPBSManager(ctx, "notification", "matcher", "remove", name); err != nil {
-			logger.Warning("PBS notifications API apply: matcher remove %s failed (continuing): %v", name, err)
+			// The nil guard the rest of this file already uses and this loop did not:
+			// logWithLabel locks a mutex on the receiver with no nil-receiver check, so a
+			// nil logger panics here rather than no-opping.
+			if logger != nil {
+				logger.Warning("PBS notifications API apply: matcher remove %s failed (continuing): %v", name, err)
+			}
+			rep.removeFailed = append(rep.removeFailed, "matcher:"+name)
+			continue
 		}
+		rep.removed = append(rep.removed, "matcher:"+name)
 	}
 	return nil
 }
 
-func syncPBSNotificationEndpoints(ctx context.Context, logger *logging.Logger, endpoints []pbsNotificationEndpointSection, strict bool) error {
+func syncPBSNotificationEndpoints(ctx context.Context, logger *logging.Logger, endpoints []pbsNotificationEndpointSection, strict bool, rep *pbsNotificationApplyReport) error {
 	for _, typ := range []string{"smtp", "sendmail", "gotify", "webhook"} {
 		desired := pbsEndpointsByName(endpoints, typ)
 		if strict {
-			if err := removeExtraPBSNotificationEndpoints(ctx, logger, typ, desired); err != nil {
+			// A kind whose staged section we could not REBUILD has an incomplete desired
+			// set, so "live but not in desired" stops meaning "absent from the backup" and
+			// starts meaning "we failed to translate it". Deleting on that evidence
+			// destroys configuration the backup DID contain and cannot restore. Leaving
+			// stale objects is recoverable by hand; deleting a live endpoint is not.
+			if containsPBSApplyString(rep.droppedTypes, typ) {
+				rep.removalsSkipped = appendUniquePBSString(rep.removalsSkipped, typ)
+			} else if err := removeExtraPBSNotificationEndpoints(ctx, logger, typ, desired, rep); err != nil {
 				return err
 			}
 		}
-		if err := upsertPBSNotificationEndpoints(ctx, typ, desired); err != nil {
+		if err := upsertPBSNotificationEndpoints(ctx, typ, desired, rep); err != nil {
 			return err
 		}
 	}
@@ -264,7 +375,7 @@ func pbsEndpointsByName(endpoints []pbsNotificationEndpointSection, typ string) 
 	return desired
 }
 
-func removeExtraPBSNotificationEndpoints(ctx context.Context, logger *logging.Logger, typ string, desired map[string]pbsNotificationEndpointSection) error {
+func removeExtraPBSNotificationEndpoints(ctx context.Context, logger *logging.Logger, typ string, desired map[string]pbsNotificationEndpointSection, rep *pbsNotificationApplyReport) error {
 	current, err := listPBSNotificationIDs(ctx, "endpoint", typ, "list")
 	if err != nil {
 		return err
@@ -274,18 +385,26 @@ func removeExtraPBSNotificationEndpoints(ctx context.Context, logger *logging.Lo
 			continue
 		}
 		if _, err := runPBSManager(ctx, "notification", "endpoint", typ, "remove", name); err != nil {
-			logger.Warning("PBS notifications API apply: endpoint remove %s:%s failed (continuing): %v", typ, name, err)
+			if logger != nil {
+				logger.Warning("PBS notifications API apply: endpoint remove %s:%s failed (continuing): %v", typ, name, err)
+			}
+			rep.removeFailed = append(rep.removeFailed, typ+":"+name)
+			continue
 		}
+		rep.removed = append(rep.removed, typ+":"+name)
 	}
 	return nil
 }
 
-func upsertPBSNotificationEndpoints(ctx context.Context, typ string, desired map[string]pbsNotificationEndpointSection) error {
-	names := sortedPBSEndpointNames(desired)
-	for _, name := range names {
+// The leaves (upsertPBSNotificationEndpoint / upsertPBSNotificationMatcher) stay pure:
+// counting happens in the loop, AFTER the error check, so the create-then-update fallback
+// counts once and a failure counts zero.
+func upsertPBSNotificationEndpoints(ctx context.Context, typ string, desired map[string]pbsNotificationEndpointSection, rep *pbsNotificationApplyReport) error {
+	for _, name := range sortedPBSEndpointNames(desired) {
 		if err := upsertPBSNotificationEndpoint(ctx, typ, name, desired[name]); err != nil {
 			return err
 		}
+		rep.endpointsUpserted++
 	}
 	return nil
 }
@@ -313,11 +432,12 @@ func upsertPBSNotificationEndpoint(ctx context.Context, typ, name string, endpoi
 	return nil
 }
 
-func syncPBSNotificationMatchers(ctx context.Context, desired pbsNotificationDesiredState) error {
+func syncPBSNotificationMatchers(ctx context.Context, desired pbsNotificationDesiredState, rep *pbsNotificationApplyReport) error {
 	for _, name := range desired.matcherNames {
 		if err := upsertPBSNotificationMatcher(ctx, name, desired.matchers[name]); err != nil {
 			return err
 		}
+		rep.matchersUpserted++
 	}
 	return nil
 }

--- a/internal/orchestrator/pbs_notifications_api_apply_test.go
+++ b/internal/orchestrator/pbs_notifications_api_apply_test.go
@@ -50,11 +50,11 @@ func TestApplyPBSNotificationsViaAPI_CreatesEndpointAndMatcher(t *testing.T) {
 	restoreCmd = runner
 
 	logger := logging.New(types.LogLevelDebug, false)
-	applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, false)
+	rep, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, false)
 	if err != nil {
 		t.Fatalf("applyPBSNotificationsViaAPI error: %v", err)
 	}
-	if !applied {
+	if !rep.mutated() {
 		t.Fatal("staged notifications.cfg was present, so the apply must report that it ran")
 	}
 
@@ -81,7 +81,7 @@ func TestBuildPBSNotificationDesiredState_NilLoggerSkipsMalformedSections(t *tes
 		},
 	}
 
-	desired := buildPBSNotificationDesiredState(cfgSections, nil, nil)
+	desired := buildPBSNotificationDesiredState(cfgSections, nil, nil, &pbsNotificationApplyReport{})
 	if len(desired.endpoints) != 0 {
 		t.Fatalf("expected malformed endpoints to be skipped, got=%v", desired.endpoints)
 	}
@@ -111,11 +111,11 @@ func TestApplyPBSNotificationsViaAPI_NothingStagedIsNotAnApply(t *testing.T) {
 	logger := logging.New(types.LogLevelDebug, false)
 
 	for _, strict := range []bool{false, true} {
-		applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, "/empty-stage", strict)
+		rep, err := applyPBSNotificationsViaAPI(context.Background(), logger, "/empty-stage", strict)
 		if err != nil {
 			t.Fatalf("strict=%v: an absent notifications.cfg is not an error: %v", strict, err)
 		}
-		if applied {
+		if rep.mutated() {
 			t.Fatalf("strict=%v: nothing was staged, so nothing can have been applied", strict)
 		}
 	}
@@ -179,11 +179,11 @@ func TestApplyPBSNotificationsViaAPI_StrictRemovesExtrasAndReportsApplied(t *tes
 
 	logger := logging.New(types.LogLevelDebug, false)
 
-	applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, true)
+	rep, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, true)
 	if err != nil {
 		t.Fatalf("applyPBSNotificationsViaAPI error: %v", err)
 	}
-	if !applied {
+	if !rep.mutated() {
 		t.Fatal("a completed strict apply must report applied=true")
 	}
 
@@ -226,12 +226,21 @@ func TestApplyPBSNotificationsViaAPI_FailureReportsNotApplied(t *testing.T) {
 
 	logger := logging.New(types.LogLevelDebug, false)
 
-	applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, false)
+	rep, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, false)
 	if err == nil {
 		t.Fatal("a failing matcher sync must surface an error")
 	}
-	if applied {
-		t.Fatal("a failed apply must not report applied=true")
+	// The report is an account, not a verdict: the smtp endpoint WAS written before the
+	// matcher failed, and hiding that would leave the operator believing the live config is
+	// untouched when it is half-updated.
+	if rep.endpointsUpserted != 1 {
+		t.Fatalf("the endpoint written before the failure must be counted, got %d", rep.endpointsUpserted)
+	}
+	if rep.matchersUpserted != 0 {
+		t.Fatalf("the matcher failed, so it must not be counted, got %d", rep.matchersUpserted)
+	}
+	if !rep.mutated() {
+		t.Fatal("a partially applied run must report that something was written")
 	}
 }
 
@@ -283,11 +292,11 @@ func TestApplyPBSNotificationsViaAPI_PropagatesSyncFailures(t *testing.T) {
 			restoreCmd = &fakeCommandRunner{errs: tt.errs}
 			logger := logging.New(types.LogLevelDebug, false)
 
-			applied, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, tt.strict)
+			rep, err := applyPBSNotificationsViaAPI(context.Background(), logger, stageRoot, tt.strict)
 			if err == nil {
 				t.Fatal("the failure must be propagated, not swallowed")
 			}
-			if applied {
+			if rep.mutated() {
 				t.Fatal("an aborted apply must not report applied=true")
 			}
 		})

--- a/internal/orchestrator/pbs_notifications_apply_report_test.go
+++ b/internal/orchestrator/pbs_notifications_apply_report_test.go
@@ -1,0 +1,257 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func stageCfg(t *testing.T, fakeFS *FakeFS, stageRoot, body string) {
+	t.Helper()
+	if err := fakeFS.WriteFile(stageRoot+"/etc/proxmox-backup/notifications.cfg", []byte(body), 0o640); err != nil {
+		t.Fatalf("write staged notifications.cfg: %v", err)
+	}
+}
+
+func withFakeApplyEnv(t *testing.T, runner *fakeCommandRunner) *FakeFS {
+	t.Helper()
+	origCmd, origFS := restoreCmd, restoreFS
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() {
+		restoreCmd, restoreFS = origCmd, origFS
+		_ = os.RemoveAll(fakeFS.Root)
+	})
+	restoreFS = fakeFS
+	restoreCmd = runner
+	return fakeFS
+}
+
+// The confirmed bug: a staged notifications.cfg that exists but says nothing used to return
+// applied=true after issuing zero commands, and the caller printed "applied via API".
+func TestApplyPBSNotificationsViaAPI_EmptyStagedCfgIsNotAnApply(t *testing.T) {
+	for _, body := range []string{"", "   \n\t\n"} {
+		t.Run("body="+strings.TrimSpace(body)+"|", func(t *testing.T) {
+			runner := &fakeCommandRunner{}
+			fakeFS := withFakeApplyEnv(t, runner)
+			stageCfg(t, fakeFS, "/stage", body)
+
+			rep, err := applyPBSNotificationsViaAPI(context.Background(), logging.New(types.LogLevelDebug, false), "/stage", false)
+			if err != nil {
+				t.Fatalf("an empty staged file is not an error: %v", err)
+			}
+			if !rep.staged {
+				t.Fatal("the file existed, so staged must be true")
+			}
+			if !rep.stagedEmpty {
+				t.Fatal("the file was empty, and that fact is the whole point")
+			}
+			if rep.planned != 0 || rep.mutated() {
+				t.Fatalf("nothing was named and nothing can have been applied, got %+v", rep)
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("no command may run, got: %v", runner.calls)
+			}
+		})
+	}
+}
+
+// Same defect, reached through content that parses to nothing usable.
+func TestApplyPBSNotificationsViaAPI_UnusableSectionsAreNotAnApply(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"comment only", "# only a comment\n"},
+		{"no section header", "this is not a config at all\n"},
+		{"unknown section type", "ntfy: n1\n    server https://example\n"},
+		{"endpoint missing a required field", "smtp: relay\n    server mail.example.com\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeCommandRunner{}
+			fakeFS := withFakeApplyEnv(t, runner)
+			stageCfg(t, fakeFS, "/stage", tt.body)
+
+			rep, err := applyPBSNotificationsViaAPI(context.Background(), logging.New(types.LogLevelDebug, false), "/stage", false)
+			if err != nil {
+				t.Fatalf("unusable content is not an error here: %v", err)
+			}
+			if rep.planned != 0 || rep.mutated() {
+				t.Fatalf("nothing usable was named, got %+v", rep)
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("no command may run, got: %v", runner.calls)
+			}
+		})
+	}
+}
+
+// Clean 1:1 must not delete a live endpoint of a kind whose staged section we failed to
+// rebuild: "live but not desired" then means "we could not translate it", not "the backup
+// lacked it". The fixture is this repo's own PBS shape — mailto-user is not a positional
+// pbsEndpointSinglePositional accepts, so the section is dropped in translation.
+func TestApplyPBSNotificationsViaAPI_CleanSkipsRemovalForKindsWithDroppedSections(t *testing.T) {
+	runner := &fakeCommandRunner{
+		outputs: map[string][]byte{
+			"proxmox-backup-manager notification endpoint smtp list": []byte(`[{"name":"example"},{"name":"other"}]`),
+		},
+	}
+	fakeFS := withFakeApplyEnv(t, runner)
+	stageCfg(t, fakeFS, "/stage", "smtp: example\n    mailto-user root@pam\n    server mail.example.com\n")
+
+	rep, err := applyPBSNotificationsViaAPI(context.Background(), logging.New(types.LogLevelDebug, false), "/stage", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, c := range runner.calls {
+		if strings.Contains(c, "endpoint smtp remove") {
+			t.Fatalf("a kind we failed to translate must not have its live objects deleted, got: %v", runner.calls)
+		}
+	}
+	if len(rep.removalsSkipped) != 1 || rep.removalsSkipped[0] != "smtp" {
+		t.Fatalf("the skipped removal pass must be recorded, got %+v", rep.removalsSkipped)
+	}
+}
+
+// Clean mode with an empty staged file still deletes. That is real work and must be
+// counted, named, and warned about — previously it was logged nowhere at any level.
+func TestApplyPBSNotificationsViaAPI_CleanEmptyStageWipeIsWarned(t *testing.T) {
+	runner := &fakeCommandRunner{
+		outputs: map[string][]byte{
+			"proxmox-backup-manager notification matcher list":       []byte(`[{"name":"m1"},{"name":"m2"}]`),
+			"proxmox-backup-manager notification endpoint smtp list": []byte(`[{"name":"relay"}]`),
+		},
+	}
+	fakeFS := withFakeApplyEnv(t, runner)
+	stageCfg(t, fakeFS, "/stage", "")
+
+	rep, err := applyPBSNotificationsViaAPI(context.Background(), logging.New(types.LogLevelDebug, false), "/stage", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rep.removed) != 3 {
+		t.Fatalf("every deletion must be counted and named, got %v", rep.removed)
+	}
+	if !rep.mutated() {
+		t.Fatal("deleting three live objects is a mutation")
+	}
+
+	var out bytes.Buffer
+	logger := logging.New(types.LogLevelDebug, false)
+	logger.SwapOutput(&out)
+	logPBSNotificationApplyReport(logger, PBSRestoreBehaviorClean, rep)
+
+	logged := out.String()
+	if !strings.Contains(logged, "removed 3 live object(s)") {
+		t.Fatalf("the deletions must be named, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, "on that evidence alone") {
+		t.Fatalf("a wipe authorised by a file naming nothing must be warned, got:\n%s", logged)
+	}
+}
+
+// A create that falls back to update is one logical change, not two. This is why the
+// counters sit at the call sites rather than at the command choke point.
+func TestApplyPBSNotificationsViaAPI_UpsertCountsOnceWhenCreateFallsBackToUpdate(t *testing.T) {
+	runner := &fakeCommandRunner{
+		errs: map[string]error{
+			"proxmox-backup-manager notification endpoint smtp create relay root@pam --server mail.example.com": errors.New("already exists"),
+		},
+	}
+	fakeFS := withFakeApplyEnv(t, runner)
+	stageCfg(t, fakeFS, "/stage", "smtp: relay\n    mailto root@pam\n    server mail.example.com\n")
+
+	rep, err := applyPBSNotificationsViaAPI(context.Background(), logging.New(types.LogLevelDebug, false), "/stage", false)
+	if err != nil {
+		t.Fatalf("the update fallback should succeed: %v", err)
+	}
+	if rep.endpointsUpserted != 1 {
+		t.Fatalf("create-then-update is one change, got %d", rep.endpointsUpserted)
+	}
+}
+
+// The sentence the operator reads is the artifact this whole change is about, so it is
+// asserted directly, at the caller, for every outcome.
+func TestMaybeApplyNotificationsFromStage_PBSSentences(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string // "" means: stage no file at all
+		stageFile   bool
+		wantContain string
+		wantAbsent  string
+	}{
+		{name: "no file staged", stageFile: false, wantContain: "contains no notifications.cfg", wantAbsent: "applied via API"},
+		{name: "staged but empty", stageFile: true, body: "", wantContain: "the staged notifications.cfg is empty", wantAbsent: "applied via API"},
+		{name: "no section recognised", stageFile: true, body: "# only a comment\n", wantContain: "no section header was recognised", wantAbsent: "applied via API"},
+		{name: "all sections skipped", stageFile: true, body: "ntfy: n1\n    server https://example\n", wantContain: "staged section(s) were skipped", wantAbsent: "applied via API"},
+		{name: "real apply", stageFile: true, body: "matcher: default-matcher\n    target mail-to-root\n", wantContain: "applied via API", wantAbsent: "contains no notifications.cfg"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origCmd, origFS := restoreCmd, restoreFS
+			origEuid, origAPIEuid, origVerify := notificationsApplyGeteuid, pbsAPIApplyGeteuid, serviceVerifyTimeout
+			t.Cleanup(func() {
+				restoreCmd, restoreFS = origCmd, origFS
+				notificationsApplyGeteuid, pbsAPIApplyGeteuid = origEuid, origAPIEuid
+				serviceVerifyTimeout = origVerify
+			})
+
+			restoreFS = osFS{}
+			notificationsApplyGeteuid = func() int { return 0 }
+			pbsAPIApplyGeteuid = func() int { return 0 }
+			serviceVerifyTimeout = 50 * time.Millisecond
+
+			stageRoot := t.TempDir()
+			if tt.stageFile {
+				dir := filepath.Join(stageRoot, "etc", "proxmox-backup")
+				if err := os.MkdirAll(dir, 0o700); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "notifications.cfg"), []byte(tt.body), 0o640); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			}
+
+			restoreCmd = &FakeCommandRunner{Outputs: map[string][]byte{
+				"which systemctl":                          {},
+				"proxmox-backup-manager version":           []byte("proxmox-backup-manager 4.0.0"),
+				"systemctl start proxmox-backup":           {},
+				"systemctl start proxmox-backup-proxy":     {},
+				"systemctl is-active proxmox-backup":       []byte("active"),
+				"systemctl is-active proxmox-backup-proxy": []byte("active"),
+			}}
+
+			var out bytes.Buffer
+			logger := logging.New(types.LogLevelDebug, false)
+			logger.SwapOutput(&out)
+
+			plan := &RestorePlan{
+				SystemType:         SystemTypePBS,
+				StagedCategories:   []Category{{ID: "pbs_notifications"}},
+				PBSRestoreBehavior: PBSRestoreBehaviorMerge,
+			}
+
+			if err := maybeApplyNotificationsFromStage(context.Background(), logger, plan, stageRoot, false); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			logged := out.String()
+			if !strings.Contains(logged, tt.wantContain) {
+				t.Fatalf("want %q in the log, got:\n%s", tt.wantContain, logged)
+			}
+			if strings.Contains(logged, tt.wantAbsent) {
+				t.Fatalf("must not say %q, got:\n%s", tt.wantAbsent, logged)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/restore_notifications.go
+++ b/internal/orchestrator/restore_notifications.go
@@ -72,7 +72,20 @@ func maybeApplyNotificationsFromStage(ctx context.Context, logger *logging.Logge
 			} else {
 				logger.Warning("PBS notifications API apply unavailable; skipping apply (merge mode): %v", err)
 			}
-		} else if applied, apiErr := applyPBSNotificationsViaAPI(ctx, logger, stageRoot, strict); apiErr != nil {
+		} else if rep, apiErr := applyPBSNotificationsViaAPI(ctx, logger, stageRoot, strict); apiErr != nil {
+			// Say what was already written BEFORE the failure. The old code returned
+			// applied=false here, and in merge mode the caller then logged "skipping apply
+			// (merge mode)" -- false for a run that had already created half the endpoints.
+			//
+			// This is the ONLY sentence printed on the error path. err != nil here is
+			// always a mid-flight abort, because remove failures are recorded in the report
+			// rather than returned as an error; if that ever changes, this sentence becomes
+			// false on a fully successful Clean and must be split.
+			if rep.mutated() {
+				logger.Warning("PBS notifications: the apply failed after %d object(s) had already been written (endpoints=%d matchers=%d removed=%d); the live configuration is partially updated",
+					rep.endpointsUpserted+rep.matchersUpserted+len(rep.removed),
+					rep.endpointsUpserted, rep.matchersUpserted, len(rep.removed))
+			}
 			if allowFileFallback {
 				logger.Warning("PBS notifications API apply failed; falling back to file-based apply: %v", apiErr)
 				if err := applyPBSNotificationsFromStage(ctx, logger, stageRoot); err != nil {
@@ -81,15 +94,10 @@ func maybeApplyNotificationsFromStage(ctx context.Context, logger *logging.Logge
 			} else {
 				logger.Warning("PBS notifications API apply failed; skipping apply (merge mode): %v", apiErr)
 			}
-		} else if !applied {
-			// Not an error, and not necessarily a problem: the source host may genuinely
-			// have had no notification config. We cannot tell from here, so state what
-			// happened rather than claim a success. Whether the backup lost the file is
-			// answered at backup time, by the collector warnings on notifications.cfg.
-			logger.Info("PBS notifications: this backup contains no notifications.cfg, so nothing was applied and the live configuration is unchanged")
 		} else {
-			logger.Info("PBS notifications applied via API (%s)", behavior.DisplayName())
+			logPBSNotificationApplyReport(logger, behavior, rep)
 		}
+
 	}
 
 	if plan.SystemType.SupportsPVE() && plan.HasCategoryID("pve_notifications") {
@@ -105,6 +113,64 @@ func maybeApplyNotificationsFromStage(ctx context.Context, logger *logging.Logge
 	}
 
 	return nil
+}
+
+// logPBSNotificationApplyReport phrases the operator sentence from what was COUNTED. There
+// is exactly one place in this package that can print "applied via API", and it is gated on
+// mutated(). Called only on the nil-error path: on an error the counters describe a partial
+// apply, not an outcome, and the caller says so separately.
+func logPBSNotificationApplyReport(logger *logging.Logger, behavior PBSRestoreBehavior, rep pbsNotificationApplyReport) {
+	// A deletion is the one thing that must never be implied by a summary line. Successful
+	// removals were previously logged NOWHERE at any level: a Clean restore could delete
+	// every live notification object and produce an entirely empty log. No cause is
+	// asserted -- "not present in the applied configuration" is what we observed;
+	// "absent from the backup" would be false for anything dropped in translation.
+	if len(rep.removed) > 0 {
+		logger.Info("PBS notifications: removed %d live object(s) not present in the applied configuration: %s",
+			len(rep.removed), strings.Join(rep.removed, ", "))
+	}
+	if len(rep.removeFailed) > 0 {
+		logger.Warning("PBS notifications: %d live object(s) could not be removed and were left in place: %s",
+			len(rep.removeFailed), strings.Join(rep.removeFailed, ", "))
+	}
+	if len(rep.removalsSkipped) > 0 {
+		logger.Warning("PBS notifications: Clean 1:1 did not remove stale %s endpoint(s): at least one staged section of that kind could not be rebuilt, so a live endpoint missing from the desired set is not evidence that the backup lacked it",
+			strings.Join(rep.removalsSkipped, ", "))
+	}
+	if rep.dropped() > 0 {
+		logger.Warning("PBS notifications: %d staged section(s) were not applied (%d unknown type, %d missing a required field)",
+			rep.dropped(), rep.droppedUnknownType, rep.droppedIncomplete)
+	}
+
+	if !rep.mutated() {
+		switch {
+		case !rep.staged:
+			logger.Info("PBS notifications: this backup contains no notifications.cfg, so nothing was applied and the live configuration is unchanged")
+		case rep.stagedEmpty:
+			logger.Warning("PBS notifications: the staged notifications.cfg is empty, so nothing was applied and the live configuration is unchanged")
+		case rep.sections == 0:
+			logger.Warning("PBS notifications: no section header was recognised in the staged notifications.cfg, so nothing was applied and the live configuration is unchanged")
+		case rep.planned == 0:
+			logger.Warning("PBS notifications: all %d staged section(s) were skipped, so nothing was applied and the live configuration is unchanged", rep.sections)
+		default:
+			// Defensive: on the nil-error path every planned object issues at least one
+			// command, so this is unreachable. It states what is known rather than assuming
+			// the work happened.
+			logger.Warning("PBS notifications: the staged notifications.cfg named %d object(s) but no command was acknowledged; the live configuration is unchanged", rep.planned)
+		}
+		return
+	}
+
+	logger.Info("PBS notifications applied via API (%s): endpoints=%d matchers=%d removed=%d",
+		behavior.DisplayName(), rep.endpointsUpserted, rep.matchersUpserted, len(rep.removed))
+
+	// A wipe whose only authority was a staged file naming nothing. This covers the EMPTY
+	// file and the non-empty file whose every section was dropped: from the stage those are
+	// the same evidence, and gating on stagedEmpty alone leaves the second one silent.
+	if rep.planned == 0 && len(rep.removed) > 0 {
+		logger.Warning("PBS notifications: the staged notifications.cfg named no endpoint and no matcher, so Clean 1:1 removed all %d live notification object(s) on that evidence alone; if that file should not have been empty, re-run from a verified backup",
+			len(rep.removed))
+	}
 }
 
 func applyPBSNotificationsFromStage(ctx context.Context, logger *logging.Logger, stageRoot string) error {


### PR DESCRIPTION
Fixes the two defects Sourcery and Greptile flagged on #287 and #288, plus a third of the same class found while fixing them. Both reported bugs were reproduced by probe before any code was touched.

All three are the error those PRs existed to remove: **an affirmative claim made on evidence that does not support it.**

## Bug A — partial evidence produced a reassuring note

Flagged 3×: Sourcery on #287, Greptile P1 on #287, Greptile P2 on #290.

`pbsSecretCapableEndpointEvidence` set one `evidenceUsable` flag from **any** readable listing. Probe — smtp readable and empty, gotify and webhook never captured:

```
warnings=[]
notes=[... was not collected (status: skipped), but no smtp, gotify or webhook
       endpoint is configured, so no secret was lost.]
```

Two of three kinds unknown, a fact asserted about all three. A missing map key was worse: the `!ok` branch skipped the kind, making "never captured" indistinguishable from "read and empty".

**Fix:** per-kind coverage, with `notification target list` as a supplement that may only ever *raise* an observation, never lower one. That listing is the union of the four endpoint kinds and stamps each entry with its `type` — which we already collected and discarded. One readable targets listing therefore accounts for kinds whose own listing is missing.

That also settles PBS 3.2, where `notification endpoint webhook list` does not exist: webhook endpoints cannot exist there either, so the union covers it **by construction**, with no version sniffing. Three vetoes stop the union standing in when it might under-report (unusable, any untyped entry, any unknown type).

## Bug B — an empty staged notifications.cfg reported a successful apply

Flagged 2×: Sourcery and Greptile P1 on #288.

`present` was true whenever the **file existed**. Probe, merge mode:

```
body=""                             -> applied=true err=<nil> commands=0
body="# only a comment\n"           -> applied=true err=<nil> commands=0
body="bogus: line without header\n" -> applied=true err=<nil> commands=0
```

The caller then printed `PBS notifications applied via API (Merge)`. #288 existed to stop exactly that.

**Fix:** `applied bool` was the wrong *shape*, not the wrong value — several facts are true at once (the file was staged **and** empty **and** three live objects were deleted). It is now a report counting what PBS acknowledged, incremented at the five mutating call sites rather than at the command choke point, so create-then-update counts once and a failed create counts zero.

## Bug C — a zero-byte listing read as a verified zero

Found while fixing A. An empty file returned `Present:true, Error:"", Total:0` — byte-indistinguishable from "PBS has none of this kind". `proxmox-router` prints `[]` for an empty list, so an empty body is a truncated or redirected-to-nothing file. Now unusable, with a reason.

## Smaller instances of the same thing, also fixed

- A **dry run** warned about secret loss for listings nobody attempted to gather (and that warning carries the exit code).
- An empty `ManifestEntry.Status` produced a finding whose premise — "was not collected (unknown status)" — was fabricated.
- The PBS 3.2 remark was appended to **all six** listing notes, attributing a webhook-specific cause to five listings it cannot explain.
- A listing **read error** was reported with the generic "not captured" text, so the real cause never reached the operator.
- Successful Clean **deletions were logged nowhere at any level**.

## One data-loss path closed

Clean 1:1 no longer removes live endpoints of a kind whose staged section we failed to rebuild. The canonical case: an smtp section keyed on `mailto-user`, which `pbsEndpointSinglePositional` does not accept — so the endpoint was dropped in translation, then deleted as "absent from the backup", and never recreated. That fixture is this repo's own PBS shape from `restore_notifications_test.go`.

## Deliberately not addressed

Whether Clean should be **allowed** to wipe a live configuration on the authority of a staged file naming nothing. That is a policy change, not a correctness fix. This PR makes the wipe visible, counted and warned; the decision stays open.

Also out of scope, recorded in `diagnostics/`: adopting the Clean-removal error class (blocked on origin filtering, since PBS injects its built-ins into every listing), and `--output-format=json` on `listPBSNotificationIDs`.

## Tests

Bug-detecting, not decorative — each fails on the pre-fix code:

- `TestWritePBSNotificationSummary_PrivWarnsWhenEvidenceIncomplete` — asserts the **absence** of "so no secret was lost", so it cannot be fooled by rewording
- `TestPBSSecretEvidence_TargetsUnionCoversUnreadKinds` — the PBS 3.2 proof with no version knowledge
- `TestSummarizePBSNotificationSnapshot_EmptyBodyIsUnusable` — `""` and whitespace unusable, `[]` and `{"data":[]}` usable
- `TestApplyPBSNotificationsViaAPI_EmptyStagedCfgIsNotAnApply` / `_UnusableSectionsAreNotAnApply`
- `TestMaybeApplyNotificationsFromStage_PBSSentences` — asserts the operator sentence itself, which is the artifact #288 was about and which nothing tested
- `TestApplyPBSNotificationsViaAPI_CleanSkipsRemovalForKindsWithDroppedSections` — the data-loss path
- `TestApplyPBSNotificationsViaAPI_CleanEmptyStageWipeIsWarned`
- Plus regression guards: the union never lowers an observation, an unknown target type vetoes it, upsert counts once on the update fallback, type buckets sum to Total

`go build`, `go vet`, `go test ./...` clean; `golangci-lint run internal/backup/... internal/orchestrator/...` reports 0 issues.

## Summary by Sourcery

Make PBS notification backup and restore reporting reflect only what the collected evidence and acknowledged operations actually support.

Bug Fixes:
- Prevent incomplete PBS notification evidence from producing affirmative claims about secret loss or endpoint absence.
- Treat empty or unreadable PBS listings as unusable evidence and report collection failures accurately.
- Prevent Clean restores from deleting live endpoint kinds whose staged sections could not be reconstructed.
- Stop empty or unusable staged notification files from being reported as successful applies.
- Accurately account for acknowledged endpoint, matcher, and deletion operations, including partial applies and create-to-update fallbacks.

Enhancements:
- Make PBS notification diagnostics distinguish complete, partial, and unknown evidence while identifying the source of verified observations.
- Improve restore reporting for skipped sections, failed removals, partial updates, and Clean-mode deletions.
- Limit PBS 3.2 webhook compatibility guidance to webhook listings and suppress misleading dry-run or fabricated-status warnings.

Tests:
- Add regression coverage for incomplete evidence, target-list union coverage, unknown endpoint types, empty listings, dry runs, malformed manifest status, apply accounting, Clean deletion safeguards, and operator-facing restore messages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes PBS notification backup and restore reporting reflect the evidence and mutations actually observed.
- Tracks notification-list coverage per endpoint kind and treats empty listing output as unusable.
- Replaces the apply boolean with detailed mutation, deletion, skipped-section, and cleanup counters.
- Prevents Clean reconciliation from deleting endpoint kinds whose staged sections could not be rebuilt.
- Adds focused regression coverage for incomplete evidence, partial applies, empty stages, deletion reporting, and Clean-mode safeguards.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects established in the changed behavior.

The new evidence model avoids conclusions from partial listings, and the apply report accurately preserves successful mutation and cleanup facts across empty, partial, and Clean reconciliation paths.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/backup/collector_pbs_notifications_summary.go | Adds per-kind evidence coverage, target-union safeguards, truthful incomplete-evidence messages, and empty-output rejection. |
| internal/orchestrator/pbs_notifications_api_apply.go | Replaces the apply boolean with a detailed report and adds fail-closed endpoint cleanup when staged sections cannot be rebuilt. |
| internal/orchestrator/restore_notifications.go | Produces operator-facing messages from acknowledged mutations and explicitly reports partial updates, removals, skipped cleanup, and empty desired states. |
| internal/backup/collector_pbs_notifications_evidence_test.go | Covers incomplete listing evidence, target-union behavior, empty outputs, dry runs, and type accounting. |
| internal/orchestrator/pbs_notifications_apply_report_test.go | Covers empty and unusable stages, Clean deletion safeguards, upsert accounting, and final operator messages. |
| internal/orchestrator/pbs_notifications_api_apply_test.go | Updates API-apply tests for mutation reports and verifies partial operations remain visible. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Staged PBS notifications files] --> B[Parse sections]
  B --> C[Build desired endpoints and matchers]
  C --> D{Clean 1:1?}
  D -->|No| E[Upsert desired objects]
  D -->|Yes| F[Remove extra matchers]
  F --> G{Endpoint kind had dropped sections?}
  G -->|Yes| H[Skip removals for that kind]
  G -->|No| I[Remove extra endpoints]
  H --> E
  I --> E
  E --> J[Count acknowledged mutations]
  J --> K[Report applied, partial, skipped, and removed state]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pbs): stop claiming more than the ev..."](https://github.com/tis24dev/proxsave/commit/98739a46cdb0ca3b04f8ed181c231e6d8610507b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56530505)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Backup collection and archive integrity](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/proxsave/-/docs/backup-collection-and-archives.md)
- Knowledge Base — [Staged platform recovery](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/proxsave/-/docs/staged-platform-recovery.md)
- Knowledge Base — [Proxmox platform integration](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/proxsave/-/docs/proxmox-platform-integration.md)
</details>


<!-- /greptile_comment -->