### PR TITLE
Release v0.34.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # GSD workspace — local-only planning projects, never version-controlled
 /gsd/
 
+# Superpowers design and planning artifacts — local-only, never version-controlled
+/docs/superpowers/
+
 # Build artifacts — compiled binary (root build) and Makefile output dir
 /proxsave
 /build/

--- a/cmd/proxsave/daemon.go
+++ b/cmd/proxsave/daemon.go
@@ -311,19 +311,34 @@ func runDaemon(rt *appRuntime) int {
 }
 
 func (d *daemon) run(ctx context.Context) int {
+	ownershipDone := logging.DebugStart(d.logger, "daemon ownership", "base_dir=%s", d.cfg.BaseDir)
+	releaseOwnership, err := acquireDaemonLock(d.cfg.BaseDir)
+	if err != nil {
+		if errors.Is(err, errDaemonLockHeld) {
+			if pid, pidErr := health.ReadDaemonPID(d.cfg.BaseDir); pidErr == nil && pid > 0 {
+				logging.Warning("daemon: another proxsave daemon is already running (pid=%d) - refusing a second instance so its pid file survives", pid)
+			} else {
+				logging.Warning("daemon: another proxsave daemon already owns %s - refusing a second instance", d.cfg.BaseDir)
+			}
+			ownershipDone(err)
+			return types.ExitBackupSkipped.Int()
+		}
+		logging.Error("daemon: cannot establish single-instance ownership: %v", err)
+		ownershipDone(err)
+		return types.ExitGenericError.Int()
+	}
+	ownershipDone(nil)
+	defer releaseOwnership()
+
 	// The trusted-path gate for the operator scripts, once, before any tick can start
 	// one: a refused path is blanked here with a loud reason (validatePersonalScripts),
 	// so the silent starters below never see it.
 	validatePersonalScripts(d.cfg)
 
-	// SINGLE-INSTANCE guard, before anything below is published: a second daemon would
-	// overwrite .daemon.pid/.daemon_info.json with its own identity and, on exit, DELETE
-	// both, hiding the still-running incumbent from every standalone handoff until a unit
-	// restart - and double-schedule the daily backup while both live. The probe is the
-	// same liveness + /proc cmdline gate the standalone handoff trusts, so a stale file
-	// (dead pid, or a recycled pid belonging to something else) never blocks a restart.
-	// ExitBackupSkipped for the same reason the concurrent-backup skip uses it: nothing
-	// is wrong with the host, the work is simply already owned by another process.
+	// The flock above is authoritative between new daemons. Keep this PID probe while
+	// holding it for rolling compatibility with an older incumbent that publishes its
+	// identity but does not take the lock. The same liveness + /proc cmdline gate the
+	// standalone handoff trusts ensures a stale or recycled PID never blocks a restart.
 	if pid, err := health.ReadDaemonPID(d.cfg.BaseDir); err == nil && pid > 0 && pid != os.Getpid() && daemonAliveProbe(pid) {
 		logging.Warning("daemon: another proxsave daemon is already running (pid=%d) - refusing a second instance so its pid file survives", pid)
 		return types.ExitBackupSkipped.Int()

--- a/cmd/proxsave/daemon.go
+++ b/cmd/proxsave/daemon.go
@@ -316,6 +316,19 @@ func (d *daemon) run(ctx context.Context) int {
 	// so the silent starters below never see it.
 	validatePersonalScripts(d.cfg)
 
+	// SINGLE-INSTANCE guard, before anything below is published: a second daemon would
+	// overwrite .daemon.pid/.daemon_info.json with its own identity and, on exit, DELETE
+	// both, hiding the still-running incumbent from every standalone handoff until a unit
+	// restart - and double-schedule the daily backup while both live. The probe is the
+	// same liveness + /proc cmdline gate the standalone handoff trusts, so a stale file
+	// (dead pid, or a recycled pid belonging to something else) never blocks a restart.
+	// ExitBackupSkipped for the same reason the concurrent-backup skip uses it: nothing
+	// is wrong with the host, the work is simply already owned by another process.
+	if pid, err := health.ReadDaemonPID(d.cfg.BaseDir); err == nil && pid > 0 && pid != os.Getpid() && daemonAliveProbe(pid) {
+		logging.Warning("daemon: another proxsave daemon is already running (pid=%d) - refusing a second instance so its pid file survives", pid)
+		return types.ExitBackupSkipped.Int()
+	}
+
 	// CRITICAL: install the SIGUSR1 handler BEFORE publishing the pidfile below. Go's DEFAULT action
 	// for SIGUSR1 is to TERMINATE the process, and the pidfile is exactly what a standalone backup
 	// run uses to discover us and send SIGUSR1 to hand off its outcome. If the pid became

--- a/cmd/proxsave/daemon_diagnostics.go
+++ b/cmd/proxsave/daemon_diagnostics.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/orchestrator"
+)
+
+// daemonDiagnostics is the single presentation-neutral snapshot consumed by
+// both the plain CLI and the dashboard daemon-status renderers.
+type daemonDiagnostics struct {
+	Mode        string
+	Unit        string
+	Active      string
+	State       health.DaemonState
+	Level       orchestrator.HealthcheckSetupLevel
+	Keyword     string
+	Explanation string
+}
+
+var (
+	daemonDiagnosticsCollector     = collectDaemonDiagnostics
+	daemonStatusUnitInstalledProbe = daemonUnitInstalled
+	daemonStatusActiveStateProbe   = daemonUnitActiveState
+	daemonStatusNow                = time.Now
+)
+
+// collectDaemonDiagnostics owns every probe and verdict used by the two
+// daemon-status frontends. Renderers receive facts; they never recompute them.
+func collectDaemonDiagnostics(ctx context.Context, cfg *config.Config, baseDir string) daemonDiagnostics {
+	mode := "unknown"
+	var interval time.Duration
+	if cfg != nil {
+		mode = cfg.SchedulerMode
+		interval = cfg.HealthcheckHeartbeatInterval
+		if configured := strings.TrimSpace(cfg.BaseDir); configured != "" {
+			baseDir = configured
+		}
+	}
+	if strings.TrimSpace(baseDir) == "" {
+		baseDir, _ = detectedBaseDirOrFallback()
+	}
+
+	unit := "not installed"
+	if daemonStatusUnitInstalledProbe() {
+		unit = "installed"
+	}
+	active := daemonStatusActiveStateProbe(ctx)
+	if active == "" {
+		active = "unknown"
+	}
+
+	state := health.CheckDaemonState(health.DaemonStateInput{
+		BaseDir:           baseDir,
+		SchedulerMode:     mode,
+		HeartbeatInterval: interval,
+		Now:               daemonStatusNow(),
+		Presence:          daemonPresenceProbe(ctx),
+		ProcAlive:         probeProxsaveDaemonAlive,
+		ProcStale:         procBinaryStaleProbe,
+	})
+	level, keyword, explanation := daemonStatusStyle(state)
+	return daemonDiagnostics{
+		Mode:        mode,
+		Unit:        unit,
+		Active:      active,
+		State:       state,
+		Level:       level,
+		Keyword:     keyword,
+		Explanation: explanation,
+	}
+}

--- a/cmd/proxsave/daemon_diagnostics.go
+++ b/cmd/proxsave/daemon_diagnostics.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -110,6 +111,9 @@ func parseProcEffectiveUID(data []byte) (int, error) {
 		uid, err := strconv.ParseUint(fields[2], 10, 32)
 		if err != nil {
 			return 0, fmt.Errorf("parse effective uid %q: %w", fields[2], err)
+		}
+		if strconv.IntSize == 32 && uid > math.MaxInt32 {
+			return 0, fmt.Errorf("effective uid %q exceeds the native int range", fields[2])
 		}
 		return int(uid), nil
 	}

--- a/cmd/proxsave/daemon_diagnostics.go
+++ b/cmd/proxsave/daemon_diagnostics.go
@@ -2,13 +2,24 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/ui/components"
 )
+
+type daemonUIDDiagnostic struct {
+	Value          int
+	Source         string
+	FallbackReason string
+}
 
 // daemonDiagnostics is the single presentation-neutral snapshot consumed by
 // both the plain CLI and the dashboard daemon-status renderers.
@@ -20,6 +31,8 @@ type daemonDiagnostics struct {
 	Level       orchestrator.HealthcheckSetupLevel
 	Keyword     string
 	Explanation string
+	DaemonUID   daemonUIDDiagnostic
+	Scripts     personalScriptsDiagnostics
 }
 
 var (
@@ -27,6 +40,10 @@ var (
 	daemonStatusUnitInstalledProbe = daemonUnitInstalled
 	daemonStatusActiveStateProbe   = daemonUnitActiveState
 	daemonStatusNow                = time.Now
+	daemonProcStatusReadFile       = os.ReadFile
+	daemonCurrentEUID              = os.Geteuid
+	daemonUIDResolver              = resolveDaemonEffectiveUID
+	personalScriptsInspector       = inspectPersonalScripts
 )
 
 // collectDaemonDiagnostics owns every probe and verdict used by the two
@@ -64,6 +81,8 @@ func collectDaemonDiagnostics(ctx context.Context, cfg *config.Config, baseDir s
 		ProcStale:         procBinaryStaleProbe,
 	})
 	level, keyword, explanation := daemonStatusStyle(state)
+	daemonUID := daemonUIDResolver(state)
+	scripts := personalScriptsInspector(cfg, daemonUID.Value)
 	return daemonDiagnostics{
 		Mode:        mode,
 		Unit:        unit,
@@ -72,5 +91,135 @@ func collectDaemonDiagnostics(ctx context.Context, cfg *config.Config, baseDir s
 		Level:       level,
 		Keyword:     keyword,
 		Explanation: explanation,
+		DaemonUID:   daemonUID,
+		Scripts:     scripts,
 	}
+}
+
+// parseProcEffectiveUID reads the second numeric value from Linux's Uid line:
+// real, effective, saved-set, then filesystem UID.
+func parseProcEffectiveUID(data []byte) (int, error) {
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[0] != "Uid:" {
+			continue
+		}
+		if len(fields) < 3 {
+			return 0, fmt.Errorf("malformed Uid line: %q", line)
+		}
+		uid, err := strconv.ParseUint(fields[2], 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("parse effective uid %q: %w", fields[2], err)
+		}
+		return int(uid), nil
+	}
+	return 0, fmt.Errorf("uid line not found")
+}
+
+func readProcessEffectiveUID(pid int) (int, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid daemon pid %d", pid)
+	}
+	path := fmt.Sprintf("/proc/%d/status", pid)
+	data, err := daemonProcStatusReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", path, err)
+	}
+	uid, err := parseProcEffectiveUID(data)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return uid, nil
+}
+
+func resolveDaemonEffectiveUID(state health.DaemonState) daemonUIDDiagnostic {
+	if state.ProcessAlive && state.PID > 0 {
+		uid, err := readProcessEffectiveUID(state.PID)
+		if err == nil {
+			return daemonUIDDiagnostic{Value: uid, Source: "running daemon /proc"}
+		}
+		return daemonUIDDiagnostic{
+			Value:          daemonCurrentEUID(),
+			Source:         "current process",
+			FallbackReason: err.Error(),
+		}
+	}
+	return daemonUIDDiagnostic{
+		Value:          daemonCurrentEUID(),
+		Source:         "current process",
+		FallbackReason: "daemon process is not live or has no PID",
+	}
+}
+
+// logDaemonDiagnostics is the plain CLI renderer for the shared snapshot. The
+// entire visible block is bracketed by the standard debug start/end markers.
+func logDaemonDiagnostics(logger *logging.Logger, diagnostics daemonDiagnostics) {
+	if logger == nil {
+		logger = logging.GetDefaultLogger()
+	}
+	done := logging.DebugStart(logger, "daemon diagnostics", "daemon_uid=%d uid_source=%s",
+		diagnostics.DaemonUID.Value, daemonDiagnosticText(diagnostics.DaemonUID.Source))
+	defer done(nil)
+
+	logger.Info("Daemon status: %s", daemonDiagnosticText(diagnostics.Keyword))
+	logger.Info("Scheduler mode: %s", daemonDiagnosticText(diagnostics.Mode))
+	logger.Info("Daemon service (%s): %s", daemonUnitName, daemonDiagnosticText(diagnostics.Unit))
+	logger.Info("Service state (systemctl is-active): %s", daemonDiagnosticText(diagnostics.Active))
+	if diagnostics.State.HaveInfo {
+		logger.Info("Running version: %s (%s)", daemonDiagnosticText(diagnostics.State.Version), daemonDiagnosticText(diagnostics.State.Commit))
+	}
+	if diagnostics.State.HaveInfo || diagnostics.State.AlignChecked {
+		alignment := "unknown"
+		if diagnostics.State.AlignChecked {
+			if diagnostics.State.Aligned {
+				alignment = "aligned"
+			} else {
+				alignment = "BEHIND (restart needed)"
+			}
+		}
+		logger.Info("Binary alignment: %s", alignment)
+	}
+
+	logPersonalScriptDiagnostic(logger, "Personal pre-run script", diagnostics.Scripts.Pre)
+	logPersonalScriptDiagnostic(logger, "Personal post-run script", diagnostics.Scripts.Post)
+	logging.DebugStep(logger, "daemon diagnostics", "daemon uid: value=%d source=%q fallback_reason=%q",
+		diagnostics.DaemonUID.Value,
+		daemonDiagnosticText(diagnostics.DaemonUID.Source),
+		daemonDiagnosticText(diagnostics.DaemonUID.FallbackReason))
+	logPersonalScriptEvidence(logger, "pre-run", diagnostics.Scripts.Pre)
+	logPersonalScriptEvidence(logger, "post-run", diagnostics.Scripts.Post)
+}
+
+func logPersonalScriptDiagnostic(logger *logging.Logger, label string, diagnostic personalScriptDiagnostic) {
+	path := daemonDiagnosticText(diagnostic.Path)
+	reason := daemonDiagnosticText(diagnostic.Reason)
+	switch diagnostic.State {
+	case personalScriptReady:
+		logger.Info("%s: READY — %s", label, path)
+	case personalScriptRefused:
+		if path == "" {
+			logger.Warning("%s: REFUSED — %s", label, reason)
+			return
+		}
+		logger.Warning("%s: REFUSED — %s — %s", label, path, reason)
+	default:
+		logger.Info("%s: NOT CONFIGURED", label)
+	}
+}
+
+func logPersonalScriptEvidence(logger *logging.Logger, label string, diagnostic personalScriptDiagnostic) {
+	logging.DebugStep(logger, "daemon diagnostics", "%s: key=%q state=%s path=%q daemon_uid=%d",
+		label,
+		daemonDiagnosticText(diagnostic.Key),
+		diagnostic.State,
+		daemonDiagnosticText(diagnostic.Path),
+		diagnostic.DaemonUID)
+	for _, component := range diagnostic.Components {
+		logging.DebugStep(logger, "daemon diagnostics", "%s component: path=%q uid=%d mode=%04o",
+			label, daemonDiagnosticText(component.Path), component.UID, component.Mode.Perm())
+	}
+}
+
+func daemonDiagnosticText(value string) string {
+	return strings.TrimSpace(components.SanitizeText(value))
 }

--- a/cmd/proxsave/daemon_diagnostics.go
+++ b/cmd/proxsave/daemon_diagnostics.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -108,14 +107,14 @@ func parseProcEffectiveUID(data []byte) (int, error) {
 		if len(fields) < 3 {
 			return 0, fmt.Errorf("malformed Uid line: %q", line)
 		}
-		uid, err := strconv.ParseUint(fields[2], 10, 32)
+		uid, err := strconv.Atoi(fields[2])
 		if err != nil {
 			return 0, fmt.Errorf("parse effective uid %q: %w", fields[2], err)
 		}
-		if strconv.IntSize == 32 && uid > math.MaxInt32 {
-			return 0, fmt.Errorf("effective uid %q exceeds the native int range", fields[2])
+		if uid < 0 {
+			return 0, fmt.Errorf("effective uid %q must not be negative", fields[2])
 		}
-		return int(uid), nil
+		return uid, nil
 	}
 	return 0, fmt.Errorf("uid line not found")
 }
@@ -199,13 +198,13 @@ func logPersonalScriptDiagnostic(logger *logging.Logger, label string, diagnosti
 	reason := daemonDiagnosticText(diagnostic.Reason)
 	switch diagnostic.State {
 	case personalScriptReady:
-		logger.Info("%s: READY — %s", label, path)
+		logger.Info("%s: READY (%s)", label, path)
 	case personalScriptRefused:
 		if path == "" {
-			logger.Warning("%s: REFUSED — %s", label, reason)
+			logger.Warning("%s: REFUSED: %s", label, reason)
 			return
 		}
-		logger.Warning("%s: REFUSED — %s — %s", label, path, reason)
+		logger.Warning("%s: REFUSED (%s): %s", label, path, reason)
 	default:
 		logger.Info("%s: NOT CONFIGURED", label)
 	}

--- a/cmd/proxsave/daemon_diagnostics_test.go
+++ b/cmd/proxsave/daemon_diagnostics_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func TestCollectDaemonDiagnosticsBuildsOneSharedSnapshot(t *testing.T) {
+	origInstalled := daemonStatusUnitInstalledProbe
+	origActive := daemonStatusActiveStateProbe
+	origPresence := daemonPresenceProbe
+	origNow := daemonStatusNow
+	t.Cleanup(func() {
+		daemonStatusUnitInstalledProbe = origInstalled
+		daemonStatusActiveStateProbe = origActive
+		daemonPresenceProbe = origPresence
+		daemonStatusNow = origNow
+	})
+
+	daemonStatusUnitInstalledProbe = func() bool { return true }
+	daemonStatusActiveStateProbe = func(context.Context) string { return "active" }
+	daemonPresenceProbe = func(context.Context) health.DaemonPresence {
+		return health.DaemonPresence{Probed: true, Installed: true, Active: true}
+	}
+	daemonStatusNow = func() time.Time { return time.Unix(1_700_000_000, 0) }
+
+	cfg := &config.Config{
+		SchedulerMode:                "daemon",
+		BaseDir:                      t.TempDir(),
+		HealthcheckHeartbeatInterval: time.Minute,
+	}
+	got := collectDaemonDiagnostics(context.Background(), cfg, cfg.BaseDir)
+
+	if got.Mode != "daemon" || got.Unit != "installed" || got.Active != "active" {
+		t.Fatalf("incomplete shared snapshot: %+v", got)
+	}
+	if !got.State.Probed || !got.State.Installed || !got.State.Active {
+		t.Fatalf("health state did not use the shared presence probe: %+v", got.State)
+	}
+	if got.Keyword == "" || got.Explanation == "" {
+		t.Fatalf("shared snapshot is missing its verdict: %+v", got)
+	}
+}
+
+func TestRunDaemonStatusUsesSharedDiagnosticsCollector(t *testing.T) {
+	origCollector := daemonDiagnosticsCollector
+	t.Cleanup(func() { daemonDiagnosticsCollector = origCollector })
+
+	called := 0
+	daemonDiagnosticsCollector = func(context.Context, *config.Config, string) daemonDiagnostics {
+		called++
+		return daemonDiagnostics{
+			Mode:    "daemon",
+			Unit:    "installed",
+			Active:  "active",
+			State:   health.DaemonState{HaveInfo: true, Version: "1.2.3", Commit: "abc", AlignChecked: true, Aligned: true},
+			Level:   1,
+			Keyword: "running",
+		}
+	}
+
+	origLogger := logging.GetDefaultLogger()
+	logger := logging.New(types.LogLevelDebug, false)
+	logging.SetDefaultLogger(logger)
+	t.Cleanup(func() { logging.SetDefaultLogger(origLogger) })
+
+	rt := &appRuntime{
+		ctx:    context.Background(),
+		cfg:    &config.Config{SchedulerMode: "daemon", BaseDir: t.TempDir()},
+		logger: logger,
+	}
+	if code := runDaemonStatus(rt); code != 0 {
+		t.Fatalf("runDaemonStatus exit = %d, want 0", code)
+	}
+	if called != 1 {
+		t.Fatalf("shared collector calls = %d, want 1", called)
+	}
+}

--- a/cmd/proxsave/daemon_lock.go
+++ b/cmd/proxsave/daemon_lock.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const daemonLockFileName = ".daemon.lock"
+
+var errDaemonLockHeld = errors.New("daemon ownership lock is already held")
+
+func acquireDaemonLock(baseDir string) (release func(), err error) {
+	dir := filepath.Join(baseDir, "identity")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create daemon lock directory %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, daemonLockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open daemon lock %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, fmt.Errorf("%w: %s", errDaemonLockHeld, path)
+		}
+		return nil, fmt.Errorf("acquire daemon lock %s: %w", path, err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/cmd/proxsave/daemon_lock.go
+++ b/cmd/proxsave/daemon_lock.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
+
+	"github.com/tis24dev/proxsave/internal/filelock"
 )
 
 const daemonLockFileName = ".daemon.lock"
@@ -18,19 +19,14 @@ func acquireDaemonLock(baseDir string) (release func(), err error) {
 		return nil, fmt.Errorf("create daemon lock directory %s: %w", dir, err)
 	}
 	path := filepath.Join(dir, daemonLockFileName)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("open daemon lock %s: %w", path, err)
+	releaseLock, err := filelock.TryAcquire(path)
+	if errors.Is(err, filelock.ErrHeld) {
+		return nil, fmt.Errorf("%w: %s", errDaemonLockHeld, path)
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		_ = f.Close()
-		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
-			return nil, fmt.Errorf("%w: %s", errDaemonLockHeld, path)
-		}
+	if err != nil {
 		return nil, fmt.Errorf("acquire daemon lock %s: %w", path, err)
 	}
 	return func() {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
+		_ = releaseLock()
 	}, nil
 }

--- a/cmd/proxsave/daemon_setup.go
+++ b/cmd/proxsave/daemon_setup.go
@@ -126,25 +126,7 @@ func cronModeRecordClause(revert cronRevertReport) string {
 // non-zero otherwise, so scripts can gate on it.
 func runDaemonStatus(rt *appRuntime) int {
 	diagnostics := daemonDiagnosticsCollector(rt.ctx, rt.cfg, "")
-
-	logging.Info("Daemon status: %s", diagnostics.Keyword)
-	logging.Info("Scheduler mode: %s", diagnostics.Mode)
-	logging.Info("Daemon service (%s): %s", daemonUnitName, diagnostics.Unit)
-	logging.Info("Service state (systemctl is-active): %s", diagnostics.Active)
-	if diagnostics.State.HaveInfo {
-		logging.Info("Running version: %s (%s)", diagnostics.State.Version, diagnostics.State.Commit)
-	}
-	if diagnostics.State.HaveInfo || diagnostics.State.AlignChecked {
-		align := "unknown"
-		if diagnostics.State.AlignChecked {
-			if diagnostics.State.Aligned {
-				align = "aligned"
-			} else {
-				align = "BEHIND (restart needed)"
-			}
-		}
-		logging.Info("Binary alignment: %s", align)
-	}
+	logDaemonDiagnostics(rt.logger, diagnostics)
 	if diagnostics.Level == orchestrator.HealthcheckSetupLevelOk {
 		return types.ExitSuccess.Int()
 	}

--- a/cmd/proxsave/daemon_setup.go
+++ b/cmd/proxsave/daemon_setup.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/cron"
-	"github.com/tis24dev/proxsave/internal/health"
 	"github.com/tis24dev/proxsave/internal/installer"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/orchestrator"
@@ -126,48 +125,19 @@ func cronModeRecordClause(revert cronRevertReport) string {
 // alignment) - non-interactively, then exits. Exit 0 when the daemon is running and aligned,
 // non-zero otherwise, so scripts can gate on it.
 func runDaemonStatus(rt *appRuntime) int {
-	ctx := rt.ctx
-	mode := "unknown"
-	baseDir := ""
-	var interval time.Duration
-	if rt.cfg != nil {
-		mode = rt.cfg.SchedulerMode
-		interval = rt.cfg.HealthcheckHeartbeatInterval
-		baseDir = strings.TrimSpace(rt.cfg.BaseDir)
-	}
-	if baseDir == "" {
-		baseDir, _ = detectedBaseDirOrFallback()
-	}
-	unit := "not installed"
-	if daemonUnitInstalled() {
-		unit = "installed"
-	}
-	active := daemonUnitActiveState(ctx)
-	if active == "" {
-		active = "unknown"
-	}
-	ds := health.CheckDaemonState(health.DaemonStateInput{
-		BaseDir:           baseDir,
-		SchedulerMode:     mode,
-		HeartbeatInterval: interval,
-		Now:               time.Now(),
-		Presence:          daemonPresenceProbe(ctx),
-		ProcAlive:         probeProxsaveDaemonAlive,
-		ProcStale:         procBinaryStaleProbe,
-	})
-	level, keyword, _ := daemonStatusStyle(ds)
+	diagnostics := daemonDiagnosticsCollector(rt.ctx, rt.cfg, "")
 
-	logging.Info("Daemon status: %s", keyword)
-	logging.Info("Scheduler mode: %s", mode)
-	logging.Info("Daemon service (%s): %s", daemonUnitName, unit)
-	logging.Info("Service state (systemctl is-active): %s", active)
-	if ds.HaveInfo {
-		logging.Info("Running version: %s (%s)", ds.Version, ds.Commit)
+	logging.Info("Daemon status: %s", diagnostics.Keyword)
+	logging.Info("Scheduler mode: %s", diagnostics.Mode)
+	logging.Info("Daemon service (%s): %s", daemonUnitName, diagnostics.Unit)
+	logging.Info("Service state (systemctl is-active): %s", diagnostics.Active)
+	if diagnostics.State.HaveInfo {
+		logging.Info("Running version: %s (%s)", diagnostics.State.Version, diagnostics.State.Commit)
 	}
-	if ds.HaveInfo || ds.AlignChecked {
+	if diagnostics.State.HaveInfo || diagnostics.State.AlignChecked {
 		align := "unknown"
-		if ds.AlignChecked {
-			if ds.Aligned {
+		if diagnostics.State.AlignChecked {
+			if diagnostics.State.Aligned {
 				align = "aligned"
 			} else {
 				align = "BEHIND (restart needed)"
@@ -175,7 +145,7 @@ func runDaemonStatus(rt *appRuntime) int {
 		}
 		logging.Info("Binary alignment: %s", align)
 	}
-	if level == orchestrator.HealthcheckSetupLevelOk {
+	if diagnostics.Level == orchestrator.HealthcheckSetupLevelOk {
 		return types.ExitSuccess.Int()
 	}
 	return types.ExitGenericError.Int()

--- a/cmd/proxsave/daemon_single_instance_test.go
+++ b/cmd/proxsave/daemon_single_instance_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/health"
+)
+
+// A second `proxsave --daemon` used to start with no probe at all: it overwrote
+// .daemon.pid/.daemon_info.json with its own identity and, on exit, DELETED both,
+// leaving the still-running unit daemon undiscoverable - standalone backup handoffs
+// find no live daemon and outcomes go unpinged until a unit restart, and while both
+// run the daily backup is double-scheduled. run() must therefore probe the recorded
+// pid before publishing anything and refuse to start when a live proxsave --daemon
+// already owns it, leaving the incumbent's files untouched.
+func TestDaemonRefusesSecondInstanceAndLeavesTheIncumbentsFilesAlone(t *testing.T) {
+	base := t.TempDir()
+	const incumbent = 424242
+	if err := health.WriteDaemonPID(base, incumbent); err != nil {
+		t.Fatalf("seed incumbent pid: %v", err)
+	}
+	withProbe(t, func(pid int) bool { return pid == incumbent })
+
+	d := &daemon{
+		cfg: &config.Config{BaseDir: base, SchedulerTime: "03:00"},
+		now: time.Now,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan int, 1)
+	go func() { done <- d.run(ctx) }()
+	var code int
+	select {
+	case code = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("run() never returned")
+	}
+
+	if code == 0 {
+		t.Fatal("a second daemon instance exited 0: it ran instead of refusing")
+	}
+	pid, err := health.ReadDaemonPID(base)
+	if err != nil || pid != incumbent {
+		t.Fatalf("the incumbent's pid file was touched: pid=%d err=%v, want %d intact", pid, err, incumbent)
+	}
+}
+
+// A STALE pid file (recorded pid dead, or not a proxsave --daemon) must not block
+// startup: kill -9 skips the removal defer and systemd's restart must still boot.
+func TestDaemonStartsOverAStalePidFile(t *testing.T) {
+	base := t.TempDir()
+	if err := health.WriteDaemonPID(base, 424242); err != nil {
+		t.Fatalf("seed stale pid: %v", err)
+	}
+	withProbe(t, func(pid int) bool { return false })
+
+	d := &daemon{
+		cfg: &config.Config{BaseDir: base, SchedulerTime: "03:00"},
+		now: time.Now,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan int, 1)
+	go func() { done <- d.run(ctx) }()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("run() = %d over a stale pid file, want a normal start and clean stop", code)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("run() never returned")
+	}
+}

--- a/cmd/proxsave/daemon_single_instance_test.go
+++ b/cmd/proxsave/daemon_single_instance_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/types"
 )
 
 // A second `proxsave --daemon` used to start with no probe at all: it overwrote
@@ -40,8 +43,8 @@ func TestDaemonRefusesSecondInstanceAndLeavesTheIncumbentsFilesAlone(t *testing.
 		t.Fatal("run() never returned")
 	}
 
-	if code == 0 {
-		t.Fatal("a second daemon instance exited 0: it ran instead of refusing")
+	if code != types.ExitBackupSkipped.Int() {
+		t.Fatalf("second daemon exit = %d, want %d", code, types.ExitBackupSkipped.Int())
 	}
 	pid, err := health.ReadDaemonPID(base)
 	if err != nil || pid != incumbent {
@@ -74,5 +77,79 @@ func TestDaemonStartsOverAStalePidFile(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("run() never returned")
+	}
+}
+
+func TestConcurrentDaemonCannotPassTheSingleInstanceGate(t *testing.T) {
+	base := t.TempDir()
+	first := &daemon{cfg: &config.Config{BaseDir: base, SchedulerTime: "03:00"}, now: time.Now}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstResult := make(chan int, 1)
+	firstStopped := make(chan struct{})
+	go func() {
+		defer close(firstStopped)
+		firstResult <- first.run(firstCtx)
+	}()
+	t.Cleanup(func() {
+		cancelFirst()
+		select {
+		case <-firstStopped:
+		case <-time.After(10 * time.Second):
+			t.Error("first daemon did not stop")
+		}
+	})
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		pid, err := health.ReadDaemonPID(base)
+		if err == nil && pid == os.Getpid() {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("first daemon never published its pid: pid=%d err=%v", pid, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	second := &daemon{cfg: &config.Config{BaseDir: base, SchedulerTime: "03:00"}, now: time.Now}
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	cancelSecond()
+	if code := second.run(secondCtx); code != types.ExitBackupSkipped.Int() {
+		t.Fatalf("second daemon exit = %d, want %d", code, types.ExitBackupSkipped.Int())
+	}
+	pid, err := health.ReadDaemonPID(base)
+	if err != nil || pid != os.Getpid() {
+		t.Fatalf("second daemon disturbed incumbent pid: pid=%d err=%v", pid, err)
+	}
+
+	cancelFirst()
+	select {
+	case code := <-firstResult:
+		if code != types.ExitSuccess.Int() {
+			t.Fatalf("first daemon exit = %d, want success", code)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("first daemon did not return")
+	}
+
+	successor := &daemon{cfg: &config.Config{BaseDir: base, SchedulerTime: "03:00"}, now: time.Now}
+	successorCtx, cancelSuccessor := context.WithCancel(context.Background())
+	cancelSuccessor()
+	if code := successor.run(successorCtx); code != types.ExitSuccess.Int() {
+		t.Fatalf("successor daemon exit = %d after release, want success", code)
+	}
+}
+
+func TestDaemonFailsClosedWhenOwnershipCannotBeEstablished(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "base-file")
+	if err := os.WriteFile(base, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("create base file: %v", err)
+	}
+	d := &daemon{cfg: &config.Config{BaseDir: base, SchedulerTime: "03:00"}, now: time.Now}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if code := d.run(ctx); code != types.ExitGenericError.Int() {
+		t.Fatalf("run() = %d when ownership is unknown, want %d", code, types.ExitGenericError.Int())
 	}
 }

--- a/cmd/proxsave/daemon_status_cli_test.go
+++ b/cmd/proxsave/daemon_status_cli_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -27,6 +28,23 @@ func TestParseProcEffectiveUIDUsesTheEffectiveColumn(t *testing.T) {
 	}
 	if uid != 1001 {
 		t.Fatalf("effective uid = %d, want 1001", uid)
+	}
+}
+
+func TestParseProcEffectiveUIDHandlesMaximumLinuxUIDWithoutOverflow(t *testing.T) {
+	data := []byte("Uid:\t0\t4294967295\t0\t0\n")
+	uid, err := parseProcEffectiveUID(data)
+	if strconv.IntSize == 32 {
+		if err == nil {
+			t.Fatalf("effective uid overflowed native int as %d", uid)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("parse maximum Linux uid: %v", err)
+	}
+	if uint64(uid) != 4294967295 {
+		t.Fatalf("effective uid = %d, want 4294967295", uid)
 	}
 }
 

--- a/cmd/proxsave/daemon_status_cli_test.go
+++ b/cmd/proxsave/daemon_status_cli_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/health"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/orchestrator"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func TestParseProcEffectiveUIDUsesTheEffectiveColumn(t *testing.T) {
+	data := []byte("Name:\tproxsave\nUid:\t1000\t1001\t1002\t1003\n")
+	uid, err := parseProcEffectiveUID(data)
+	if err != nil {
+		t.Fatalf("parse effective uid: %v", err)
+	}
+	if uid != 1001 {
+		t.Fatalf("effective uid = %d, want 1001", uid)
+	}
+}
+
+func TestParseProcEffectiveUIDRejectsMissingAndMalformedData(t *testing.T) {
+	for name, data := range map[string]string{
+		"missing":     "Name:\tproxsave\n",
+		"too short":   "Uid:\t1000\n",
+		"not numeric": "Uid:\t1000\toperator\t1002\t1003\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseProcEffectiveUID([]byte(data)); err == nil {
+				t.Fatalf("parseProcEffectiveUID(%q) unexpectedly succeeded", data)
+			}
+		})
+	}
+}
+
+func TestResolveDaemonEffectiveUIDUsesLiveProcessAndFallsBack(t *testing.T) {
+	origRead := daemonProcStatusReadFile
+	origEUID := daemonCurrentEUID
+	t.Cleanup(func() {
+		daemonProcStatusReadFile = origRead
+		daemonCurrentEUID = origEUID
+	})
+
+	daemonCurrentEUID = func() int { return 9001 }
+	t.Run("live pid", func(t *testing.T) {
+		daemonProcStatusReadFile = func(path string) ([]byte, error) {
+			if path != "/proc/42/status" {
+				t.Fatalf("status path = %q", path)
+			}
+			return []byte("Uid:\t1000\t1001\t1002\t1003\n"), nil
+		}
+		got := resolveDaemonEffectiveUID(health.DaemonState{ProcessAlive: true, PID: 42})
+		if got.Value != 1001 || got.Source != "running daemon /proc" || got.FallbackReason != "" {
+			t.Fatalf("unexpected live daemon uid: %+v", got)
+		}
+	})
+
+	t.Run("proc read failure", func(t *testing.T) {
+		daemonProcStatusReadFile = func(string) ([]byte, error) { return nil, errors.New("permission denied") }
+		got := resolveDaemonEffectiveUID(health.DaemonState{ProcessAlive: true, PID: 42})
+		if got.Value != 9001 || got.Source != "current process" || !strings.Contains(got.FallbackReason, "permission denied") {
+			t.Fatalf("unexpected read fallback: %+v", got)
+		}
+	})
+
+	t.Run("no live pid", func(t *testing.T) {
+		read := false
+		daemonProcStatusReadFile = func(string) ([]byte, error) {
+			read = true
+			return nil, nil
+		}
+		got := resolveDaemonEffectiveUID(health.DaemonState{})
+		if read {
+			t.Fatal("read /proc without a live daemon pid")
+		}
+		if got.Value != 9001 || got.Source != "current process" || !strings.Contains(got.FallbackReason, "not live") {
+			t.Fatalf("unexpected no-pid fallback: %+v", got)
+		}
+	})
+}
+
+func TestCollectDaemonDiagnosticsInspectsScriptsWithResolvedUID(t *testing.T) {
+	origUID := daemonUIDResolver
+	origScripts := personalScriptsInspector
+	origInstalled := daemonStatusUnitInstalledProbe
+	origActive := daemonStatusActiveStateProbe
+	origPresence := daemonPresenceProbe
+	t.Cleanup(func() {
+		daemonUIDResolver = origUID
+		personalScriptsInspector = origScripts
+		daemonStatusUnitInstalledProbe = origInstalled
+		daemonStatusActiveStateProbe = origActive
+		daemonPresenceProbe = origPresence
+	})
+
+	daemonStatusUnitInstalledProbe = func() bool { return true }
+	daemonStatusActiveStateProbe = func(context.Context) string { return "active" }
+	daemonPresenceProbe = func(context.Context) health.DaemonPresence {
+		return health.DaemonPresence{Probed: true, Installed: true, Active: true}
+	}
+	daemonUIDResolver = func(health.DaemonState) daemonUIDDiagnostic {
+		return daemonUIDDiagnostic{Value: 4242, Source: "test daemon"}
+	}
+	inspections := 0
+	personalScriptsInspector = func(cfg *config.Config, uid int) personalScriptsDiagnostics {
+		inspections++
+		if uid != 4242 || cfg.PersonalScriptPreRun != "/pre" || cfg.PersonalScriptPostRun != "/post" {
+			t.Fatalf("inspector input: uid=%d cfg=%+v", uid, cfg)
+		}
+		return personalScriptsDiagnostics{
+			Pre:  personalScriptDiagnostic{Key: "PERSONAL_SCRIPT_PRE_RUN", Path: "/pre", State: personalScriptReady, DaemonUID: uid},
+			Post: personalScriptDiagnostic{Key: "PERSONAL_SCRIPT_POST_RUN", Path: "/post", State: personalScriptRefused, Reason: "unsafe", DaemonUID: uid},
+		}
+	}
+
+	cfg := &config.Config{
+		SchedulerMode:         "daemon",
+		BaseDir:               t.TempDir(),
+		PersonalScriptPreRun:  "/pre",
+		PersonalScriptPostRun: "/post",
+	}
+	got := collectDaemonDiagnostics(context.Background(), cfg, cfg.BaseDir)
+	if inspections != 1 {
+		t.Fatalf("script inspections = %d, want 1", inspections)
+	}
+	if got.DaemonUID.Value != 4242 || got.Scripts.Pre.State != personalScriptReady || got.Scripts.Post.State != personalScriptRefused {
+		t.Fatalf("collector omitted shared script diagnostics: %+v", got)
+	}
+}
+
+func TestLogDaemonDiagnosticsUsesStandardEnvelopeAndSeverity(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "executed")
+	script := writePersonalScript(t, dir, "must-not-run.sh", "touch "+marker)
+	reason := "parent directory is unsafe"
+	diagnostics := daemonDiagnostics{
+		Mode:        "daemon",
+		Unit:        "installed",
+		Active:      "active",
+		State:       health.DaemonState{HaveInfo: true, Version: "1.2.3", Commit: "abc", AlignChecked: true, Aligned: true},
+		Level:       orchestrator.HealthcheckSetupLevelOk,
+		Keyword:     "running",
+		Explanation: "daemon is healthy",
+		DaemonUID:   daemonUIDDiagnostic{Value: 1001, Source: "running daemon /proc"},
+		Scripts: personalScriptsDiagnostics{
+			Pre: personalScriptDiagnostic{
+				Key: "PERSONAL_SCRIPT_PRE_RUN", Path: script, State: personalScriptReady, DaemonUID: 1001,
+				Components: []personalScriptPathComponent{{Path: script, UID: 1001, Mode: 0o700}},
+			},
+			Post: personalScriptDiagnostic{
+				Key: "PERSONAL_SCRIPT_POST_RUN", Path: "/home/operator/post.sh", State: personalScriptRefused, Reason: reason, DaemonUID: 1001,
+			},
+		},
+	}
+
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	logDaemonDiagnostics(logger, diagnostics)
+	out := buf.String()
+
+	start := strings.Index(out, "DEBUG    Start daemon diagnostics")
+	ready := strings.Index(out, "INFO     Personal pre-run script: READY")
+	refused := strings.Index(out, "WARNING  Personal post-run script: REFUSED")
+	end := strings.Index(out, "DEBUG    End daemon diagnostics")
+	if start < 0 || ready < 0 || refused < 0 || end < 0 || start >= ready || ready >= refused || refused >= end {
+		t.Fatalf("diagnostic lines are not enclosed and ordered correctly:\n%s", out)
+	}
+	if strings.Count(out, reason) != 1 {
+		t.Fatalf("refusal reason count = %d, want 1:\n%s", strings.Count(out, reason), out)
+	}
+	timestamped := regexp.MustCompile(`^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] (DEBUG|INFO|WARNING) +`)
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if !timestamped.MatchString(line) {
+			t.Errorf("line does not use standard CLI timestamp/severity: %q", line)
+		}
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("diagnostic rendering executed a personal script; marker stat error = %v", err)
+	}
+}
+
+func TestRunDaemonStatusExitRemainsBasedOnDaemonState(t *testing.T) {
+	origCollector := daemonDiagnosticsCollector
+	t.Cleanup(func() { daemonDiagnosticsCollector = origCollector })
+	daemonDiagnosticsCollector = func(context.Context, *config.Config, string) daemonDiagnostics {
+		return daemonDiagnostics{
+			Level:   orchestrator.HealthcheckSetupLevelOk,
+			Keyword: "running",
+			Scripts: personalScriptsDiagnostics{
+				Post: personalScriptDiagnostic{Key: "PERSONAL_SCRIPT_POST_RUN", Path: "/unsafe", State: personalScriptRefused, Reason: "unsafe"},
+			},
+		}
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+	logger.SetOutput(&bytes.Buffer{})
+	if code := runDaemonStatus(&appRuntime{ctx: context.Background(), logger: logger}); code != types.ExitSuccess.Int() {
+		t.Fatalf("script refusal changed daemon-status exit code to %d", code)
+	}
+}
+
+func TestBuildDaemonStatusPromptRendersSanitizedPersonalScripts(t *testing.T) {
+	diagnostics := daemonDiagnostics{
+		Mode:        "daemon",
+		Unit:        "installed",
+		Active:      "active",
+		Level:       orchestrator.HealthcheckSetupLevelOk,
+		Keyword:     "RUNNING",
+		Explanation: "daemon is healthy",
+		DaemonUID:   daemonUIDDiagnostic{Value: 1001, Source: "running daemon /proc"},
+		Scripts: personalScriptsDiagnostics{
+			Pre:  personalScriptDiagnostic{Key: "PERSONAL_SCRIPT_PRE_RUN", Path: "/safe/pre.sh", State: personalScriptReady},
+			Post: personalScriptDiagnostic{Key: "PERSONAL_SCRIPT_POST_RUN", Path: "/bad\x1b]0;pwned\x07/post.sh", State: personalScriptRefused, Reason: "unsafe\x9b\x1b[2Jreason"},
+		},
+	}
+	prompt := buildDaemonStatusPrompt(diagnostics)
+	assertNoRawInjection(t, prompt)
+	plain := ansi.Strip(prompt)
+	for _, want := range []string{
+		"Personal pre-run script: READY",
+		"/safe/pre.sh",
+		"Personal post-run script: REFUSED",
+		"reason",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("prompt missing %q:\n%s", want, plain)
+		}
+	}
+	if strings.Contains(plain, "pwned") {
+		t.Fatalf("prompt retained OSC payload:\n%s", plain)
+	}
+}

--- a/cmd/proxsave/daemon_status_cli_test.go
+++ b/cmd/proxsave/daemon_status_cli_test.go
@@ -53,6 +53,7 @@ func TestParseProcEffectiveUIDRejectsMissingAndMalformedData(t *testing.T) {
 		"missing":     "Name:\tproxsave\n",
 		"too short":   "Uid:\t1000\n",
 		"not numeric": "Uid:\t1000\toperator\t1002\t1003\n",
+		"negative":    "Uid:\t0\t-1\t0\t0\n",
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := parseProcEffectiveUID([]byte(data)); err == nil {

--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -1014,15 +1014,15 @@ func buildDashboardPersonalScriptLine(label string, diagnostic personalScriptDia
 	case personalScriptReady:
 		line += theme.SuccessText.Render("READY")
 		if path != "" {
-			line += theme.Subtle.Render(" — " + path)
+			line += theme.Subtle.Render(" (" + path + ")")
 		}
 	case personalScriptRefused:
 		line += theme.ErrorText.Render("REFUSED")
 		if path != "" {
-			line += theme.Subtle.Render(" — " + path)
+			line += theme.Subtle.Render(" (" + path + ")")
 		}
 		if reason != "" {
-			line += theme.Subtle.Render(" — " + reason)
+			line += theme.Subtle.Render(": " + reason)
 		}
 	default:
 		line += theme.Subtle.Render("NOT CONFIGURED")

--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -903,43 +903,20 @@ const (
 func runDashboardDaemonStatus(ctx context.Context, session *shell.Session, configPath, baseDir string) {
 	errDaemonStatusEsc := errors.New("daemon status: esc")
 	for {
-		mode := "unknown"
-		var interval time.Duration
-		if cfg, err := daemonStatusLoadConfig(configPath, baseDir); err == nil && cfg != nil {
-			mode = cfg.SchedulerMode
-			interval = cfg.HealthcheckHeartbeatInterval
-			if strings.TrimSpace(cfg.BaseDir) != "" {
-				baseDir = cfg.BaseDir
+		var cfg *config.Config
+		if loaded, err := daemonStatusLoadConfig(configPath, baseDir); err == nil && loaded != nil {
+			cfg = loaded
+			if strings.TrimSpace(loaded.BaseDir) != "" {
+				baseDir = loaded.BaseDir
 			}
 		}
-		unit := "not installed"
-		if daemonUnitInstalled() {
-			unit = "installed"
-		}
-		active := daemonUnitActiveState(ctx)
-		if active == "" {
-			active = "unknown"
-		}
-
-		// Combined verdict via the SHARED daemon-state checker (systemd existence refined onto the
-		// heartbeat, plus on-disk binary alignment). probeProxsaveDaemonAlive is the stricter signal-0
-		// + /proc/cmdline liveness gate. The raw unit/active words stay from the direct probes so the
-		// systemctl vocabulary is shown verbatim. This is IDENTICAL to before -- presentation only.
-		ds := health.CheckDaemonState(health.DaemonStateInput{
-			BaseDir:           baseDir,
-			SchedulerMode:     mode,
-			HeartbeatInterval: interval,
-			Now:               time.Now(),
-			Presence:          daemonPresenceProbe(ctx),
-			ProcAlive:         probeProxsaveDaemonAlive,
-			ProcStale:         procBinaryStaleProbe,
-		})
-		level, keyword, explanation := daemonStatusStyle(ds)
+		diagnostics := daemonDiagnosticsCollector(ctx, cfg, baseDir)
 		// Dashboard "Status:" keywords are ALL-CAPS (the house convention across every
 		// dashboard Status screen). daemonStatusStyle is shared with the plain-text
 		// --daemon-status CLI line, so uppercase HERE (the graphical consumer) rather than at
 		// the source, keeping the CLI/log readout in its natural case.
-		prompt := buildDaemonStatusPrompt(level, strings.ToUpper(keyword), explanation, mode, unit, active, ds)
+		diagnostics.Keyword = strings.ToUpper(diagnostics.Keyword)
+		prompt := buildDaemonStatusPrompt(diagnostics)
 
 		items := []components.SelectorItem[daemonStatusAction]{
 			{Label: "Re-check", Description: "re-run the daemon state check", Value: daemonStatusActionCheck},
@@ -975,7 +952,7 @@ func renderDaemonStatusLevel(level orchestrator.HealthcheckSetupLevel, text stri
 // buildHealthcheckPrompt): a short intro, a two-line Status block (a colored keyword + a Subtle
 // explanation), then a Details block with the scheduler/service facts. The wording/logic of the
 // detail lines is unchanged from the old Notice body; only the presentation moved into the prompt.
-func buildDaemonStatusPrompt(level orchestrator.HealthcheckSetupLevel, keyword, explanation, mode, unit, active string, ds health.DaemonState) string {
+func buildDaemonStatusPrompt(diagnostics daemonDiagnostics) string {
 	// Every dynamic segment below carries text from outside this file (keyword/explanation from
 	// daemonStatusStyle, mode from the config file, active from systemctl, Version/Commit RAW from
 	// .daemon_info.json), so each is SanitizeText-scrubbed before theme rendering to keep raw
@@ -987,8 +964,8 @@ func buildDaemonStatusPrompt(level orchestrator.HealthcheckSetupLevel, keyword, 
 	b.WriteString("\n\n")
 
 	b.WriteString(theme.Text.Render("Status: "))
-	b.WriteString(renderDaemonStatusLevel(level, components.SanitizeText(keyword)))
-	if exp := components.SanitizeText(explanation); exp != "" {
+	b.WriteString(renderDaemonStatusLevel(diagnostics.Level, components.SanitizeText(diagnostics.Keyword)))
+	if exp := components.SanitizeText(diagnostics.Explanation); exp != "" {
 		b.WriteString("\n")
 		b.WriteString(theme.Subtle.Render(exp))
 	}
@@ -996,24 +973,24 @@ func buildDaemonStatusPrompt(level orchestrator.HealthcheckSetupLevel, keyword, 
 	b.WriteString("\n\n")
 	b.WriteString(theme.Text.Render("Details:"))
 	b.WriteString("\n")
-	b.WriteString(theme.Text.Render("Scheduler mode: " + components.SanitizeText(mode)))
+	b.WriteString(theme.Text.Render("Scheduler mode: " + components.SanitizeText(diagnostics.Mode)))
 	b.WriteString("\n")
-	b.WriteString(theme.Text.Render("Daemon service (" + daemonUnitName + "): " + unit))
+	b.WriteString(theme.Text.Render("Daemon service (" + daemonUnitName + "): " + diagnostics.Unit))
 	b.WriteString("\n")
-	b.WriteString(theme.Text.Render("Service state (systemctl is-active): " + components.SanitizeText(active)))
+	b.WriteString(theme.Text.Render("Service state (systemctl is-active): " + components.SanitizeText(diagnostics.Active)))
 	// The running version comes from the identity record (HaveInfo). The alignment verdict comes from
 	// the record-independent /proc probe, so show it whenever AlignChecked -- a live daemon on a
 	// replaced binary reads "Binary alignment: BEHIND". Binary alignment is known only when
 	// AlignChecked; otherwise it is UNKNOWN -- report "unknown" rather than imply "aligned" or a false
 	// "behind".
-	if ds.HaveInfo {
+	if diagnostics.State.HaveInfo {
 		b.WriteString("\n")
-		b.WriteString(theme.Text.Render("Running version: " + components.SanitizeText(ds.Version) + " (" + components.SanitizeText(ds.Commit) + ")"))
+		b.WriteString(theme.Text.Render("Running version: " + components.SanitizeText(diagnostics.State.Version) + " (" + components.SanitizeText(diagnostics.State.Commit) + ")"))
 	}
-	if ds.HaveInfo || ds.AlignChecked {
+	if diagnostics.State.HaveInfo || diagnostics.State.AlignChecked {
 		align := "unknown"
-		if ds.AlignChecked {
-			if ds.Aligned {
+		if diagnostics.State.AlignChecked {
+			if diagnostics.State.Aligned {
 				align = "aligned"
 			} else {
 				align = "BEHIND (restart needed)"

--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -999,7 +999,35 @@ func buildDaemonStatusPrompt(diagnostics daemonDiagnostics) string {
 		b.WriteString("\n")
 		b.WriteString(theme.Text.Render("Binary alignment: " + align))
 	}
+	b.WriteString("\n")
+	b.WriteString(buildDashboardPersonalScriptLine("Personal pre-run script", diagnostics.Scripts.Pre))
+	b.WriteString("\n")
+	b.WriteString(buildDashboardPersonalScriptLine("Personal post-run script", diagnostics.Scripts.Post))
 	return b.String()
+}
+
+func buildDashboardPersonalScriptLine(label string, diagnostic personalScriptDiagnostic) string {
+	line := theme.Text.Render(label + ": ")
+	path := components.SanitizeText(diagnostic.Path)
+	reason := components.SanitizeText(diagnostic.Reason)
+	switch diagnostic.State {
+	case personalScriptReady:
+		line += theme.SuccessText.Render("READY")
+		if path != "" {
+			line += theme.Subtle.Render(" — " + path)
+		}
+	case personalScriptRefused:
+		line += theme.ErrorText.Render("REFUSED")
+		if path != "" {
+			line += theme.Subtle.Render(" — " + path)
+		}
+		if reason != "" {
+			line += theme.Subtle.Render(" — " + reason)
+		}
+	default:
+		line += theme.Subtle.Render("NOT CONFIGURED")
+	}
+	return line
 }
 
 // daemonStatusStyle maps a composed daemon state to a shared HealthcheckSetupLevel (the SAME

--- a/cmd/proxsave/dashboard.go
+++ b/cmd/proxsave/dashboard.go
@@ -202,6 +202,14 @@ func isTerminalInteractive() bool {
 	return true
 }
 
+type dashboardActionDisposition uint8
+
+const (
+	dashboardActionUnhandled dashboardActionDisposition = iota
+	dashboardActionHandled
+	dashboardActionReload
+)
+
 // maybeRunDashboard shows the interactive dashboard when proxsave is invoked
 // completely bare (no flags at all) on an interactive terminal. The chosen
 // action is dispatched by MUTATING args and letting the existing flag-driven
@@ -281,10 +289,15 @@ func maybeRunDashboard(ctx context.Context, args *cli.Args, bootstrap *logging.B
 		// and loop back to the menu. These never leave the dashboard, so the flag
 		// dispatch below is untouched.
 		diagCtx, cancelDiag := withDashboardIdle(ctx)
-		handledDiag := runDashboardDiagnostic(diagCtx, session, action, args, bootstrap)
+		disposition := runDashboardDiagnostic(diagCtx, session, action, args, bootstrap)
 		cancelDiag()
-		if handledDiag {
+		switch disposition {
+		case dashboardActionHandled:
 			continue
+		case dashboardActionReload:
+			keepAlive = true
+			closeDashboardAndRelaunch(ctx, session, getExecInfo().ExecPath, bootstrap)
+			return types.ExitSuccess.Int(), true
 		}
 
 		switch action {
@@ -388,14 +401,15 @@ func runDashboardInstallChoice(ctx context.Context, session *shell.Session) (men
 }
 
 // runDashboardDiagnostic runs the check screen for a diagnostics-group action in
-// the live dashboard session and reports whether it handled the action (so the
-// dashboard loops back to the menu). Non-diagnostic actions return false, leaving
+// the live dashboard session and reports how it handled the action. Ordinary
+// diagnostics loop back to the menu; a successful upgrade requests a process reload.
+// Non-diagnostic actions return dashboardActionUnhandled, leaving
 // them for the normal flag dispatch. Every screen already exists and is reused
 // verbatim; each is non-blocking (errors are swallowed - a failed check must never
 // abort the dashboard). When a setup screen is not eligible (that feature is not
 // configured on this host) it renders nothing, so a short notice is shown instead
 // of a blank flicker.
-func runDashboardDiagnostic(ctx context.Context, session *shell.Session, action menu.Action, args *cli.Args, bootstrap *logging.BootstrapLogger) bool {
+func runDashboardDiagnostic(ctx context.Context, session *shell.Session, action menu.Action, args *cli.Args, bootstrap *logging.BootstrapLogger) dashboardActionDisposition {
 	configPath := ""
 	if args != nil {
 		configPath = args.ConfigPath
@@ -425,7 +439,7 @@ func runDashboardDiagnostic(ctx context.Context, session *shell.Session, action 
 		_, _ = dashboardRunPostInstallAudit(ctx, session, getExecInfo().ExecPath, configPath)
 	case menu.ActionCheckUpgrade:
 		logging.DebugStepBootstrap(bootstrap, "dashboard", "action=check-upgrade")
-		runDashboardUpgradeMenu(ctx, session, configPath)
+		return runDashboardUpgradeMenu(ctx, session, configPath)
 	case menu.ActionDaemonSetup:
 		logging.DebugStepBootstrap(bootstrap, "dashboard", "action=daemon-setup")
 		runDashboardDaemonAdmin(ctx, session, true, configPath, baseDir)
@@ -442,9 +456,9 @@ func runDashboardDiagnostic(ctx context.Context, session *shell.Session, action 
 		logging.DebugStepBootstrap(bootstrap, "dashboard", "action=cleanup-guards")
 		runDashboardCleanupGuards(ctx, session)
 	default:
-		return false
+		return dashboardActionUnhandled
 	}
-	return true
+	return dashboardActionHandled
 }
 
 // Seams so the daemon admin ops can be stubbed in tests (they otherwise run real

--- a/cmd/proxsave/dashboard_relaunch.go
+++ b/cmd/proxsave/dashboard_relaunch.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/safeexec"
+	"github.com/tis24dev/proxsave/internal/ui/shell"
+)
+
+var (
+	dashboardRelaunchCommandContext = safeexec.TrustedCommandContext
+	dashboardRelaunchAfterUpgrade   = relaunchDashboardAfterUpgrade
+)
+
+func relaunchInstalledDashboard(ctx context.Context, execPath string) error {
+	execPath = strings.TrimSpace(execPath)
+	if execPath == "" {
+		return errors.New("installed executable path is empty")
+	}
+	cmd, err := dashboardRelaunchCommandContext(ctx, execPath)
+	if err != nil {
+		return err
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func relaunchDashboardAfterUpgrade(ctx context.Context, execPath string, bootstrap *logging.BootstrapLogger) {
+	done := logging.DebugStartBootstrap(bootstrap, "dashboard relaunch", "exec=%s", execPath)
+	err := relaunchInstalledDashboard(ctx, execPath)
+	if err != nil && bootstrap != nil {
+		bootstrap.Error("Dashboard reload failed after upgrade: %v", err)
+	}
+	done(err)
+}
+
+func closeDashboardAndRelaunch(ctx context.Context, session *shell.Session, execPath string, bootstrap *logging.BootstrapLogger) {
+	_ = session.Close()
+	dashboardRelaunchAfterUpgrade(ctx, execPath, bootstrap)
+}

--- a/cmd/proxsave/dashboard_relaunch_test.go
+++ b/cmd/proxsave/dashboard_relaunch_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+	"github.com/tis24dev/proxsave/internal/ui/shell"
+)
+
+func TestRelaunchInstalledDashboardStartsBareWithInheritedStreams(t *testing.T) {
+	orig := dashboardRelaunchCommandContext
+	t.Cleanup(func() { dashboardRelaunchCommandContext = orig })
+
+	var gotName string
+	var gotArgs []string
+	var gotCmd *exec.Cmd
+	dashboardRelaunchCommandContext = func(ctx context.Context, name string, args ...string) (*exec.Cmd, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		gotCmd = exec.CommandContext(ctx, os.Args[0], "-test.run=^TestDashboardRelaunchHelperProcess$")
+		gotCmd.Env = append(os.Environ(), "PROXSAVE_TEST_DASHBOARD_RELAUNCH=success")
+		return gotCmd, nil
+	}
+
+	if err := relaunchInstalledDashboard(context.Background(), "/opt/proxsave/proxsave"); err != nil {
+		t.Fatalf("relaunchInstalledDashboard: %v", err)
+	}
+	if gotName != "/opt/proxsave/proxsave" || len(gotArgs) != 0 {
+		t.Fatalf("relaunch command = %q %q, want installed binary with no flags", gotName, gotArgs)
+	}
+	if gotCmd.Stdin != os.Stdin || gotCmd.Stdout != os.Stdout || gotCmd.Stderr != os.Stderr {
+		t.Fatal("replacement dashboard must inherit all standard streams")
+	}
+}
+
+func TestRelaunchInstalledDashboardReportsSetupAndChildErrors(t *testing.T) {
+	t.Run("empty executable", func(t *testing.T) {
+		orig := dashboardRelaunchCommandContext
+		t.Cleanup(func() { dashboardRelaunchCommandContext = orig })
+		called := false
+		dashboardRelaunchCommandContext = func(context.Context, string, ...string) (*exec.Cmd, error) {
+			called = true
+			return nil, nil
+		}
+		if err := relaunchInstalledDashboard(context.Background(), "  "); err == nil {
+			t.Fatal("empty executable path must fail")
+		}
+		if called {
+			t.Fatal("empty executable path must fail before command construction")
+		}
+	})
+
+	t.Run("command construction", func(t *testing.T) {
+		orig := dashboardRelaunchCommandContext
+		t.Cleanup(func() { dashboardRelaunchCommandContext = orig })
+		want := errors.New("invalid executable")
+		dashboardRelaunchCommandContext = func(context.Context, string, ...string) (*exec.Cmd, error) {
+			return nil, want
+		}
+		if err := relaunchInstalledDashboard(context.Background(), "/opt/proxsave/proxsave"); !errors.Is(err, want) {
+			t.Fatalf("construction error = %v, want %v", err, want)
+		}
+	})
+
+	t.Run("child exit", func(t *testing.T) {
+		orig := dashboardRelaunchCommandContext
+		t.Cleanup(func() { dashboardRelaunchCommandContext = orig })
+		dashboardRelaunchCommandContext = func(ctx context.Context, _ string, _ ...string) (*exec.Cmd, error) {
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestDashboardRelaunchHelperProcess$")
+			cmd.Env = append(os.Environ(), "PROXSAVE_TEST_DASHBOARD_RELAUNCH=failure")
+			return cmd, nil
+		}
+		if err := relaunchInstalledDashboard(context.Background(), "/opt/proxsave/proxsave"); err == nil {
+			t.Fatal("non-zero child exit must fail")
+		}
+	})
+}
+
+func TestRelaunchDashboardErrorIsInsideDebugWorkflow(t *testing.T) {
+	orig := dashboardRelaunchCommandContext
+	t.Cleanup(func() { dashboardRelaunchCommandContext = orig })
+	dashboardRelaunchCommandContext = func(context.Context, string, ...string) (*exec.Cmd, error) {
+		return nil, errors.New("construction boom")
+	}
+
+	bootstrap := logging.NewBootstrapLogger()
+	bootstrap.SetLevel(types.LogLevelDebug)
+	bootstrap.SetConsoleQuiet(true)
+	var buf bytes.Buffer
+	mirror := logging.New(types.LogLevelDebug, false)
+	mirror.SetOutput(&buf)
+	bootstrap.SetMirrorLogger(mirror)
+
+	relaunchDashboardAfterUpgrade(context.Background(), "/opt/proxsave/proxsave", bootstrap)
+	out := buf.String()
+	start := strings.Index(out, "Start dashboard relaunch")
+	visibleErr := strings.Index(out, "Dashboard reload failed after upgrade: construction boom")
+	end := strings.Index(out, "End dashboard relaunch (error=construction boom")
+	if start < 0 || visibleErr < 0 || end < 0 || !(start < visibleErr && visibleErr < end) {
+		t.Fatalf("relaunch log order must be DEBUG start, timestamped error, DEBUG end; got:\n%s", out)
+	}
+	for _, marker := range []string{"Start dashboard relaunch", "Dashboard reload failed after upgrade", "End dashboard relaunch"} {
+		lineStart := strings.LastIndex(out[:strings.Index(out, marker)], "\n") + 1
+		line := out[lineStart:]
+		if len(line) < 21 || line[0] != '[' || line[20] != ']' {
+			t.Fatalf("log line for %q lacks the standard timestamp prefix: %q", marker, line)
+		}
+	}
+}
+
+func TestCloseDashboardAndRelaunchClosesSessionFirst(t *testing.T) {
+	orig := dashboardRelaunchAfterUpgrade
+	t.Cleanup(func() { dashboardRelaunchAfterUpgrade = orig })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	var output bytes.Buffer
+	session := shell.StartObservedForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"}, &output, nil)
+	called := false
+	dashboardRelaunchAfterUpgrade = func(context.Context, string, *logging.BootstrapLogger) {
+		called = true
+		select {
+		case <-session.Done():
+		default:
+			t.Fatal("dashboard session was still active when replacement process started")
+		}
+	}
+
+	closeDashboardAndRelaunch(context.Background(), session, "/opt/proxsave/proxsave", nil)
+	if !called {
+		t.Fatal("replacement process was not started")
+	}
+}
+
+func TestDashboardRelaunchHelperProcess(t *testing.T) {
+	switch os.Getenv("PROXSAVE_TEST_DASHBOARD_RELAUNCH") {
+	case "success":
+		os.Exit(0)
+	case "failure":
+		os.Exit(23)
+	}
+}

--- a/cmd/proxsave/dashboard_relaunch_test.go
+++ b/cmd/proxsave/dashboard_relaunch_test.go
@@ -103,7 +103,7 @@ func TestRelaunchDashboardErrorIsInsideDebugWorkflow(t *testing.T) {
 	start := strings.Index(out, "Start dashboard relaunch")
 	visibleErr := strings.Index(out, "Dashboard reload failed after upgrade: construction boom")
 	end := strings.Index(out, "End dashboard relaunch (error=construction boom")
-	if start < 0 || visibleErr < 0 || end < 0 || !(start < visibleErr && visibleErr < end) {
+	if start < 0 || visibleErr < 0 || end < 0 || start >= visibleErr || visibleErr >= end {
 		t.Fatalf("relaunch log order must be DEBUG start, timestamped error, DEBUG end; got:\n%s", out)
 	}
 	for _, marker := range []string{"Start dashboard relaunch", "Dashboard reload failed after upgrade", "End dashboard relaunch"} {

--- a/cmd/proxsave/dashboard_test.go
+++ b/cmd/proxsave/dashboard_test.go
@@ -333,7 +333,15 @@ func TestBuildDaemonStatusPrompt(t *testing.T) {
 		Diagnosis:    health.Diagnosis{State: health.TxRunningNoReport},
 	}
 	level, keyword, expl := daemonStatusStyle(behind)
-	prompt := ansi.Strip(buildDaemonStatusPrompt(level, keyword, expl, "daemon", "installed", "active", behind))
+	prompt := ansi.Strip(buildDaemonStatusPrompt(daemonDiagnostics{
+		Mode:        "daemon",
+		Unit:        "installed",
+		Active:      "active",
+		State:       behind,
+		Level:       level,
+		Keyword:     keyword,
+		Explanation: expl,
+	}))
 	for _, want := range []string{
 		"Status: ",
 		keyword,
@@ -379,13 +387,15 @@ func TestBuildDaemonStatusPromptSanitizesInjection(t *testing.T) {
 		Diagnosis:    health.Diagnosis{State: health.TxRunningNoReport},
 	}
 	level, keyword, expl := daemonStatusStyle(behind)
-	prompt := buildDaemonStatusPrompt(
-		level, keyword, expl,
-		"cron\x1b]0;evilmode\x07", // mode: from the config file
-		"installed",
-		"active\x9b\x1b]0;x\x07running", // active: from systemctl (0x9b is the bare C1 CSI byte)
-		behind,
-	)
+	prompt := buildDaemonStatusPrompt(daemonDiagnostics{
+		Mode:        "cron\x1b]0;evilmode\x07", // mode: from the config file
+		Unit:        "installed",
+		Active:      "active\x9b\x1b]0;x\x07running", // active: from systemctl (0x9b is the bare C1 CSI byte)
+		State:       behind,
+		Level:       level,
+		Keyword:     keyword,
+		Explanation: expl,
+	})
 	assertNoRawInjection(t, prompt)
 	// OSC payloads ("pwned", "evilmode") are stripped WHOLE with their escape, so
 	// they must NOT survive. Commit's CSI erase carries no payload, so "abcdef"

--- a/cmd/proxsave/dashboard_upgrade.go
+++ b/cmd/proxsave/dashboard_upgrade.go
@@ -155,7 +155,6 @@ func runDashboardUpgrade(ctx context.Context, session *shell.Session, configPath
 		}
 		avail = false
 		if upgRun(ctx, session, configPath) == types.ExitSuccess.Int() {
-			kw, sty, sym = "UPGRADED", theme.SuccessText, symOk
 			dashboardUpgradeRestartDaemon(ctx, session, configPath)
 			return dashboardActionReload
 		} else {

--- a/cmd/proxsave/dashboard_upgrade.go
+++ b/cmd/proxsave/dashboard_upgrade.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	dashboardUpgradeCheck   = checkForUpdates
-	dashboardUpgradeRun     = runUpgrade
+	dashboardUpgradeRun     = runUpgradeWithOptions
 	dashboardUpgradeVersion = buildinfo.String
 )
 
@@ -249,7 +249,7 @@ func upgRun(ctx context.Context, session *shell.Session, configPath string) int 
 			// pipe into the panel (restored on return/panic), so the panel shows the same
 			// colored [ts] LEVEL lines as the CLI instead of losing them to the altscreen.
 			defer captureRunOutput(bl, emit)()
-			code = dashboardUpgradeRun(taskCtx, ar, bl)
+			code = dashboardUpgradeRun(taskCtx, ar, bl, upgradeRunOptions{deferWhatsnew: true})
 			return buildUpgradeOutcomePrompt(code), nil
 		})
 	if streamErr != nil {

--- a/cmd/proxsave/dashboard_upgrade.go
+++ b/cmd/proxsave/dashboard_upgrade.go
@@ -67,7 +67,7 @@ func releaseTagURL(tag string) string {
 // screen carries the other's button: "Check upgrade" opens the binary upgrade screen
 // (runDashboardUpgrade), "Check config" opens the config upgrade flow (--upgrade-config),
 // and Back/esc returns to the dashboard menu. It loops so each sub-flow returns here.
-func runDashboardUpgradeMenu(ctx context.Context, session *shell.Session, configPath string) {
+func runDashboardUpgradeMenu(ctx context.Context, session *shell.Session, configPath string) dashboardActionDisposition {
 	back := errors.New("back")
 	for {
 		prompt := theme.Emphasis.Render("Current version: ") + theme.Text.Render(upgradeSafeToken(dashboardUpgradeVersion()))
@@ -80,11 +80,13 @@ func runDashboardUpgradeMenu(ctx context.Context, session *shell.Session, config
 			components.WithSelectorPromptStyled[upgAct](prompt),
 			components.WithSelectorBack[upgAct](back)))
 		if err != nil || a == upgBack {
-			return
+			return dashboardActionHandled
 		}
 		switch a {
 		case upgGo:
-			runDashboardUpgrade(ctx, session, configPath)
+			if disposition := runDashboardUpgrade(ctx, session, configPath); disposition == dashboardActionReload {
+				return disposition
+			}
 		case upgConfig:
 			runDashboardUpdateConfig(ctx, session, configPath)
 		}
@@ -96,7 +98,7 @@ func runDashboardUpgradeMenu(ctx context.Context, session *shell.Session, config
 // "Run upgrade" streams the upgrade INSIDE the altscreen session via components.RunStreamTask
 // (upgRun), the same contained viewport panel backup and install-finalize use, then drives
 // the single daemon restart. It loops back to the menu on Back.
-func runDashboardUpgrade(ctx context.Context, session *shell.Session, configPath string) {
+func runDashboardUpgrade(ctx context.Context, session *shell.Session, configPath string) dashboardActionDisposition {
 	cur := upgradeSafeToken(dashboardUpgradeVersion())
 	// Symbols on the RESULT keyword (consistent with the Telegram/healthcheck check
 	// screens): green ✓ ok, yellow ⚠ attention, red ✗ error. The pre-check "NOT CHECKED"
@@ -145,7 +147,7 @@ func runDashboardUpgrade(ctx context.Context, session *shell.Session, configPath
 			},
 			components.WithSelectorPromptStyled[upgAct](p), components.WithSelectorBack[upgAct](back)))
 		if err != nil || a == upgBack {
-			return
+			return dashboardActionHandled
 		}
 		if !avail {
 			pendingCheck = true // "Re-check" pressed: re-run the check on the next loop
@@ -155,6 +157,7 @@ func runDashboardUpgrade(ctx context.Context, session *shell.Session, configPath
 		if upgRun(ctx, session, configPath) == types.ExitSuccess.Int() {
 			kw, sty, sym = "UPGRADED", theme.SuccessText, symOk
 			dashboardUpgradeRestartDaemon(ctx, session, configPath)
+			return dashboardActionReload
 		} else {
 			kw, sty, sym = "FAILED", theme.ErrorText, symErr
 			showDaemonResultScreen(ctx, session, "Upgrade failed", orchestrator.HealthcheckSetupLevelError,

--- a/cmd/proxsave/dashboard_upgrade_test.go
+++ b/cmd/proxsave/dashboard_upgrade_test.go
@@ -104,10 +104,12 @@ func TestDashboardUpgradeScreen(t *testing.T) {
 		}
 	}
 	var gotArgs *cli.Args
+	var gotOpts upgradeRunOptions
 	runCalls := 0
-	dashboardUpgradeRun = func(ctx context.Context, args *cli.Args, bl *logging.BootstrapLogger) int {
+	dashboardUpgradeRun = func(ctx context.Context, args *cli.Args, bl *logging.BootstrapLogger, opts upgradeRunOptions) int {
 		runCalls++
 		gotArgs = args
+		gotOpts = opts
 		if runCalls == 1 {
 			return 0 // first run succeeds
 		}
@@ -171,6 +173,9 @@ func TestDashboardUpgradeScreen(t *testing.T) {
 	_ = waitFor("NEW BINARY ON DISK") // inactive-daemon success uses the dashboard ALL-CAPS status convention
 	if gotArgs == nil || !gotArgs.Upgrade || !gotArgs.UpgradeAutoYes || gotArgs.ConfigPath != "/tmp/backup.env" {
 		t.Fatalf("run upgrade must pass Upgrade+AutoYes+ConfigPath, got %+v", gotArgs)
+	}
+	if !gotOpts.deferWhatsnew {
+		t.Fatal("dashboard upgrade must defer Screen 0 to the replacement dashboard")
 	}
 
 	driver.keys("enter")         // dismiss the notice
@@ -311,7 +316,7 @@ func TestDashboardUpgradeRestartDaemonRelaunchNote(t *testing.T) {
 	dashboardUpgradeCheck = func(context.Context, *logging.Logger, string) *UpdateInfo {
 		return &UpdateInfo{NewVersion: true, Current: "1.0.0", Latest: "2.0.0", Tag: "v2.0.0"}
 	}
-	dashboardUpgradeRun = func(context.Context, *cli.Args, *logging.BootstrapLogger) int { return 0 }
+	dashboardUpgradeRun = func(context.Context, *cli.Args, *logging.BootstrapLogger, upgradeRunOptions) int { return 0 }
 
 	// Daemon-ACTIVE path: an installed unit + active presence route the post-upgrade restart
 	// through restartAndVerifyDaemon. A readable (empty) config keeps the backup lock path

--- a/cmd/proxsave/dashboard_upgrade_test.go
+++ b/cmd/proxsave/dashboard_upgrade_test.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -80,10 +81,9 @@ func TestRenderReleaseNotes(t *testing.T) {
 	}
 }
 
-// TestDashboardUpgradeScreen drives the in-session upgrade screen directly: Check (shows
-// the available version, sanitized) -> Run upgrade (calls the real upgrade with
-// Upgrade+AutoYes+ConfigPath, keeps the binary-upgrade detail screen after each
-// result) -> Back. Both terminal result keywords stay ALL-CAPS.
+// TestDashboardUpgradeScreen drives a successful in-session upgrade. After the daemon
+// result is dismissed, control must propagate a reload disposition instead of returning to
+// the old binary's upgrade screen.
 func TestDashboardUpgradeScreen(t *testing.T) {
 	origVer, origChk := dashboardUpgradeVersion, dashboardUpgradeCheck
 	origRun := dashboardUpgradeRun
@@ -110,10 +110,7 @@ func TestDashboardUpgradeScreen(t *testing.T) {
 		runCalls++
 		gotArgs = args
 		gotOpts = opts
-		if runCalls == 1 {
-			return 0 // first run succeeds
-		}
-		return 1 // second run exercises the failure result
+		return 0
 	}
 
 	// Build an observed session eagerly (the shared seam creates it lazily via a flow).
@@ -123,10 +120,9 @@ func TestDashboardUpgradeScreen(t *testing.T) {
 	driver.session = shell.StartObservedForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"},
 		driver.buf, func(title string) { driver.pushes <- screenPush{title: title, at: driver.buf.Len()} })
 
-	done := make(chan struct{})
+	done := make(chan dashboardActionDisposition, 1)
 	go func() {
-		runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env")
-		close(done)
+		done <- runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env")
 	}()
 
 	// waitFor polls the accumulated output until it contains substr (the screen-title
@@ -178,27 +174,60 @@ func TestDashboardUpgradeScreen(t *testing.T) {
 		t.Fatal("dashboard upgrade must defer Screen 0 to the replacement dashboard")
 	}
 
-	driver.keys("enter")         // dismiss the notice
-	driver.waitScreen("Upgrade") // back on the screen, now showing UPGRADED with a Re-check button
-	_ = waitFor("UPGRADED")
-	driver.keys("enter") // Re-check -> update remains available
+	driver.keys("enter") // dismiss the notice
+	if runCalls != 1 {
+		t.Fatalf("run upgrade calls = %d, want 1", runCalls)
+	}
+	select {
+	case got := <-done:
+		if got != dashboardActionReload {
+			t.Fatalf("successful dashboard upgrade disposition = %v, want reload", got)
+		}
+	case <-time.After(uitest.Deadline(60 * time.Second)):
+		t.Fatal("successful upgrade did not request dashboard reload")
+	}
+}
+
+// TestDashboardUpgradeFailureStaysInScreen catches the opposite branch: a failed upgrade
+// remains retryable in the current dashboard and returns handled only when the user backs out.
+func TestDashboardUpgradeFailureStaysInScreen(t *testing.T) {
+	origVer, origChk, origRun := dashboardUpgradeVersion, dashboardUpgradeCheck, dashboardUpgradeRun
+	t.Cleanup(func() {
+		dashboardUpgradeVersion, dashboardUpgradeCheck, dashboardUpgradeRun = origVer, origChk, origRun
+	})
+	dashboardUpgradeVersion = func() string { return "1.0.0" }
+	dashboardUpgradeCheck = func(context.Context, *logging.Logger, string) *UpdateInfo {
+		return &UpdateInfo{NewVersion: true, Current: "1.0.0", Latest: "2.0.0", Tag: "v2.0.0"}
+	}
+	dashboardUpgradeRun = func(context.Context, *cli.Args, *logging.BootstrapLogger, upgradeRunOptions) int { return 1 }
+
+	driver := &newkeyUIDriver{t: t, buf: &shell.SyncBuffer{}, pushes: make(chan screenPush, 64)}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	driver.session = shell.StartObservedForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"},
+		driver.buf, func(title string) { driver.pushes <- screenPush{title: title, at: driver.buf.Len()} })
+
+	done := make(chan dashboardActionDisposition, 1)
+	go func() { done <- runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env") }()
+
 	driver.waitScreen("Upgrade")
-	driver.keys("enter") // Run upgrade again, this time failing
+	driver.keys("enter")
 	driver.waitScreen("Running upgrade")
 	driver.waitOutput("enter continue")
 	driver.keys("enter")
 	driver.waitScreen("Upgrade failed")
-	_ = waitFor("FAILED") // failure result uses the same ALL-CAPS convention
+	driver.waitOutput("FAILED")
 	driver.keys("enter")
-	driver.waitScreen("Upgrade") // failure also returns to the binary-upgrade detail screen
-	if runCalls != 2 {
-		t.Fatalf("run upgrade calls = %d, want 2", runCalls)
-	}
-	driver.keys("down enter") // Back (2nd item) -> return
+	driver.waitScreen("Upgrade")
+	driver.keys("down enter")
+
 	select {
-	case <-done:
+	case got := <-done:
+		if got != dashboardActionHandled {
+			t.Fatalf("failed dashboard upgrade disposition = %v, want handled", got)
+		}
 	case <-time.After(uitest.Deadline(60 * time.Second)):
-		t.Fatal("upgrade screen did not return")
+		t.Fatal("failed upgrade screen did not return after Back")
 	}
 }
 
@@ -217,10 +246,9 @@ func TestDashboardUpgradeExternalCheckFailureIsWarning(t *testing.T) {
 	driver.session = shell.StartObservedForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"},
 		driver.buf, func(title string) { driver.pushes <- screenPush{title: title, at: driver.buf.Len()} })
 
-	done := make(chan struct{})
+	done := make(chan dashboardActionDisposition, 1)
 	go func() {
-		runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env")
-		close(done)
+		done <- runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env")
 	}()
 
 	driver.waitScreen("Upgrade")
@@ -242,7 +270,10 @@ func TestDashboardUpgradeExternalCheckFailureIsWarning(t *testing.T) {
 
 	driver.keys("down enter") // Back, not Re-check
 	select {
-	case <-done:
+	case got := <-done:
+		if got != dashboardActionHandled {
+			t.Fatalf("external-check Back disposition = %v, want handled", got)
+		}
 	case <-time.After(uitest.Deadline(60 * time.Second)):
 		t.Fatal("upgrade screen did not return after external check failure")
 	}
@@ -267,10 +298,9 @@ func TestDashboardUpgradeMenu(t *testing.T) {
 	driver.session = shell.StartObservedForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"},
 		driver.buf, func(title string) { driver.pushes <- screenPush{title: title, at: driver.buf.Len()} })
 
-	done := make(chan struct{})
+	done := make(chan dashboardActionDisposition, 1)
 	go func() {
-		runDashboardUpgradeMenu(ctx, driver.session, "/tmp/backup.env")
-		close(done)
+		done <- runDashboardUpgradeMenu(ctx, driver.session, "/tmp/backup.env")
 	}()
 
 	waitFor := func(substr string) {
@@ -293,7 +323,10 @@ func TestDashboardUpgradeMenu(t *testing.T) {
 	waitFor("NO UPGRADE")        // ...which opened AND auto-checked (deterministic stub): the two are split
 	cancel()
 	select {
-	case <-done:
+	case got := <-done:
+		if got != dashboardActionHandled {
+			t.Fatalf("upgrade chooser disposition = %v, want handled", got)
+		}
 	case <-time.After(uitest.Deadline(60 * time.Second)):
 		t.Fatal("upgrade chooser did not return")
 	}
@@ -341,10 +374,9 @@ func TestDashboardUpgradeRestartDaemonRelaunchNote(t *testing.T) {
 	driver.session = shell.StartObservedForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"},
 		driver.buf, func(title string) { driver.pushes <- screenPush{title: title, at: driver.buf.Len()} })
 
-	done := make(chan struct{})
+	done := make(chan dashboardActionDisposition, 1)
 	go func() {
-		runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env")
-		close(done)
+		done <- runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env")
 	}()
 
 	waitFor := func(substr string) {
@@ -370,11 +402,64 @@ func TestDashboardUpgradeRestartDaemonRelaunchNote(t *testing.T) {
 	driver.waitScreen("Daemon restart")
 	waitFor("RESTARTED, ALIGNED") // the aligned success keyword
 	waitFor("relaunch proxsave")  // ...plus the relaunch note (absent in the active branch before the fix)
+	driver.keys("enter")
 
-	cancel()
 	select {
-	case <-done:
+	case got := <-done:
+		if got != dashboardActionReload {
+			t.Fatalf("aligned restart disposition = %v, want reload", got)
+		}
 	case <-time.After(uitest.Deadline(60 * time.Second)):
-		t.Fatal("upgrade screen did not return")
+		t.Fatal("aligned restart did not request dashboard reload")
+	}
+}
+
+// TestDashboardUpgradeRestartFailureStillReloads pins the installed-binary boundary: once
+// binary and config upgrade succeeded, a daemon restart error is shown but cannot send the
+// operator back into the old process.
+func TestDashboardUpgradeRestartFailureStillReloads(t *testing.T) {
+	origVer, origChk := dashboardUpgradeVersion, dashboardUpgradeCheck
+	origRun, origInstalled, origLoad := dashboardUpgradeRun, daemonInstalledProbe, upgradeLoadConfig
+	t.Cleanup(func() {
+		dashboardUpgradeVersion, dashboardUpgradeCheck = origVer, origChk
+		dashboardUpgradeRun, daemonInstalledProbe, upgradeLoadConfig = origRun, origInstalled, origLoad
+	})
+	dashboardUpgradeVersion = func() string { return "1.0.0" }
+	dashboardUpgradeCheck = func(context.Context, *logging.Logger, string) *UpdateInfo {
+		return &UpdateInfo{NewVersion: true, Current: "1.0.0", Latest: "2.0.0", Tag: "v2.0.0"}
+	}
+	dashboardUpgradeRun = func(context.Context, *cli.Args, *logging.BootstrapLogger, upgradeRunOptions) int { return 0 }
+	daemonInstalledProbe = func() bool { return true }
+	upgradeLoadConfig = func(string, string) (*config.Config, error) { return &config.Config{}, nil }
+	shrinkRestartBudgets(t)
+	stubRestartSeams(t,
+		func(context.Context) error { return errors.New("systemctl boom") },
+		func(string) bool { return false },
+		func(health.DaemonStateInput) health.DaemonState { return health.DaemonState{} })
+
+	driver := &newkeyUIDriver{t: t, buf: &shell.SyncBuffer{}, pushes: make(chan screenPush, 64)}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	driver.session = shell.StartObservedForTest(ctx, shell.Config{AppName: "ProxSave", Subtitle: "Dashboard"},
+		driver.buf, func(title string) { driver.pushes <- screenPush{title: title, at: driver.buf.Len()} })
+	done := make(chan dashboardActionDisposition, 1)
+	go func() { done <- runDashboardUpgrade(ctx, driver.session, "/tmp/backup.env") }()
+
+	driver.waitScreen("Upgrade")
+	driver.keys("enter")
+	driver.waitScreen("Running upgrade")
+	driver.waitOutput("enter continue")
+	driver.keys("enter")
+	driver.waitScreen("Daemon restart")
+	driver.waitOutput("RESTART FAILED")
+	driver.keys("enter")
+
+	select {
+	case got := <-done:
+		if got != dashboardActionReload {
+			t.Fatalf("failed restart disposition = %v, want reload", got)
+		}
+	case <-time.After(uitest.Deadline(60 * time.Second)):
+		t.Fatal("failed restart did not request dashboard reload")
 	}
 }

--- a/cmd/proxsave/personal_scripts_audited_test.go
+++ b/cmd/proxsave/personal_scripts_audited_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"go/parser"
 	"go/token"
 	"io/fs"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -444,6 +446,51 @@ func capturePersonalScriptValidation(t *testing.T, pre, post string) (preOut, po
 	cfg := &config.Config{PersonalScriptPreRun: pre, PersonalScriptPostRun: post}
 	validatePersonalScripts(cfg)
 	return cfg.PersonalScriptPreRun, cfg.PersonalScriptPostRun, buf.String()
+}
+
+type personalScriptOwnerFixture struct {
+	uid uint32
+}
+
+func (personalScriptOwnerFixture) Name() string       { return "owner-fixture" }
+func (personalScriptOwnerFixture) Size() int64        { return 0 }
+func (personalScriptOwnerFixture) Mode() os.FileMode  { return 0o700 }
+func (personalScriptOwnerFixture) ModTime() time.Time { return time.Time{} }
+func (personalScriptOwnerFixture) IsDir() bool        { return false }
+func (f personalScriptOwnerFixture) Sys() any         { return &syscall.Stat_t{Uid: f.uid} }
+
+func TestPersonalScriptOwnerErrorAllowsOnlyRootOrDaemonUIDAndGuidesRecovery(t *testing.T) {
+	daemonUID := os.Geteuid()
+	for name, uid := range map[string]uint32{
+		"root":       0,
+		"daemon uid": uint32(daemonUID),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := personalScriptOwnerError("/trusted/script", personalScriptOwnerFixture{uid: uid}); err != nil {
+				t.Fatalf("trusted uid %d was refused: %v", uid, err)
+			}
+		})
+	}
+
+	foreignUID := uint32(4242)
+	if int(foreignUID) == daemonUID {
+		foreignUID++
+	}
+	err := personalScriptOwnerError("/home/operator", personalScriptOwnerFixture{uid: foreignUID})
+	if err == nil {
+		t.Fatal("a path component owned by a foreign uid was accepted")
+	}
+	for _, want := range []string{
+		"/home/operator",
+		fmt.Sprintf("uid %d", foreignUID),
+		fmt.Sprintf("daemon uid %d", daemonUID),
+		"Keep the user home ownership unchanged",
+		"/usr/local/bin",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("ownership refusal is missing %q: %v", want, err)
+		}
+	}
 }
 
 func TestPersonalScriptValidationRefusesAWorldWritableScript(t *testing.T) {

--- a/cmd/proxsave/personal_scripts_audited_test.go
+++ b/cmd/proxsave/personal_scripts_audited_test.go
@@ -466,7 +466,7 @@ func TestPersonalScriptOwnerErrorAllowsOnlyRootOrDaemonUIDAndGuidesRecovery(t *t
 		"daemon uid": uint32(daemonUID),
 	} {
 		t.Run(name, func(t *testing.T) {
-			if err := personalScriptOwnerError("/trusted/script", personalScriptOwnerFixture{uid: uid}); err != nil {
+			if err := personalScriptOwnerError("/trusted/script", personalScriptOwnerFixture{uid: uid}, daemonUID); err != nil {
 				t.Fatalf("trusted uid %d was refused: %v", uid, err)
 			}
 		})
@@ -476,7 +476,7 @@ func TestPersonalScriptOwnerErrorAllowsOnlyRootOrDaemonUIDAndGuidesRecovery(t *t
 	if int(foreignUID) == daemonUID {
 		foreignUID++
 	}
-	err := personalScriptOwnerError("/home/operator", personalScriptOwnerFixture{uid: foreignUID})
+	err := personalScriptOwnerError("/home/operator", personalScriptOwnerFixture{uid: foreignUID}, daemonUID)
 	if err == nil {
 		t.Fatal("a path component owned by a foreign uid was accepted")
 	}

--- a/cmd/proxsave/personal_scripts_audited_test.go
+++ b/cmd/proxsave/personal_scripts_audited_test.go
@@ -548,10 +548,11 @@ func TestPersonalScriptValidationRefusesASymlink(t *testing.T) {
 func TestPersonalScriptValidationKeepsATrustedPathAndStaysSilent(t *testing.T) {
 	dir := t.TempDir()
 	script := writePersonalScript(t, dir, "good.sh", "exit 0")
+	configured := filepath.Dir(script) + string(os.PathSeparator) + "." + string(os.PathSeparator) + filepath.Base(script)
 
-	pre, post, logged := capturePersonalScriptValidation(t, script, script)
+	pre, post, logged := capturePersonalScriptValidation(t, configured, configured)
 	if pre != script || post != script {
-		t.Fatalf("a trusted path did not survive: pre=%q post=%q\n%s", pre, post, logged)
+		t.Fatalf("trusted paths were not normalized: pre=%q post=%q want=%q\n%s", pre, post, script, logged)
 	}
 	if strings.Contains(logged, "WARNING") {
 		t.Fatalf("a trusted path produced a warning:\n%s", logged)

--- a/cmd/proxsave/personal_scripts_gate.go
+++ b/cmd/proxsave/personal_scripts_gate.go
@@ -94,7 +94,7 @@ func personalScriptOwnerError(path string, info os.FileInfo) error {
 		return fmt.Errorf("owner of %s cannot be determined", path)
 	}
 	if st.Uid != 0 && int(st.Uid) != os.Geteuid() {
-		return fmt.Errorf("%s is owned by uid %d, not root and not the daemon's own user", path, st.Uid)
+		return fmt.Errorf("%s is owned by uid %d; accepted owners are root or daemon uid %d. Keep the user home ownership unchanged and move the script to a root-owned path such as /usr/local/bin", path, st.Uid, os.Geteuid())
 	}
 	return nil
 }

--- a/cmd/proxsave/personal_scripts_gate.go
+++ b/cmd/proxsave/personal_scripts_gate.go
@@ -1,15 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
-	"syscall"
 
 	"github.com/tis24dev/proxsave/internal/config"
 	"github.com/tis24dev/proxsave/internal/logging"
-	"github.com/tis24dev/proxsave/internal/safeexec"
 )
 
 // This file is the LOUD half of the personal-script feature and lives apart from
@@ -33,68 +28,22 @@ import (
 // later execution, which is why the starters do not re-validate: the window belongs to root
 // alone.
 func validatePersonalScripts(cfg *config.Config) {
-	cfg.PersonalScriptPreRun = validatedPersonalScriptPath("PERSONAL_SCRIPT_PRE_RUN", cfg.PersonalScriptPreRun)
-	cfg.PersonalScriptPostRun = validatedPersonalScriptPath("PERSONAL_SCRIPT_POST_RUN", cfg.PersonalScriptPostRun)
+	if cfg == nil {
+		return
+	}
+	diagnostics := inspectPersonalScripts(cfg, os.Geteuid())
+	cfg.PersonalScriptPreRun = applyPersonalScriptDiagnostic(diagnostics.Pre)
+	cfg.PersonalScriptPostRun = applyPersonalScriptDiagnostic(diagnostics.Post)
 }
 
-func validatedPersonalScriptPath(key, path string) string {
-	path = strings.TrimSpace(path)
-	if path == "" {
+func applyPersonalScriptDiagnostic(diagnostic personalScriptDiagnostic) string {
+	switch diagnostic.State {
+	case personalScriptReady:
+		return diagnostic.Path
+	case personalScriptRefused:
+		logging.Warning("%s disabled for this daemon: %s", diagnostic.Key, diagnostic.Reason)
+		return ""
+	default:
 		return ""
 	}
-	if err := personalScriptPathError(path); err != nil {
-		logging.Warning("%s disabled for this daemon: %v", key, err)
-		return ""
-	}
-	return path
-}
-
-func personalScriptPathError(path string) error {
-	clean := filepath.Clean(path)
-	resolved, err := filepath.EvalSymlinks(clean)
-	if err != nil {
-		return fmt.Errorf("resolve %s: %w", path, err)
-	}
-	if resolved != clean {
-		return fmt.Errorf("%s traverses a symlink (resolves to %s)", path, resolved)
-	}
-	if err := safeexec.ValidateTrustedExecutablePath(clean); err != nil {
-		return err
-	}
-	info, err := os.Stat(clean)
-	if err != nil {
-		return fmt.Errorf("stat %s: %w", path, err)
-	}
-	if err := personalScriptOwnerError(clean, info); err != nil {
-		return err
-	}
-	if info.Mode().Perm()&0o022 != 0 {
-		return fmt.Errorf("%s is writable by group or others (mode %04o)", clean, info.Mode().Perm())
-	}
-	for dir := filepath.Dir(clean); ; dir = filepath.Dir(dir) {
-		dirInfo, err := os.Stat(dir)
-		if err != nil {
-			return fmt.Errorf("stat %s: %w", dir, err)
-		}
-		if err := personalScriptOwnerError(dir, dirInfo); err != nil {
-			return err
-		}
-		if dirInfo.Mode().Perm()&0o022 != 0 && dirInfo.Mode()&os.ModeSticky == 0 {
-			return fmt.Errorf("directory %s is writable by group or others without the sticky bit (mode %04o)", dir, dirInfo.Mode().Perm())
-		}
-		if dir == "/" {
-			return nil
-		}
-	}
-}
-
-func personalScriptOwnerError(path string, info os.FileInfo) error {
-	st, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return fmt.Errorf("owner of %s cannot be determined", path)
-	}
-	if st.Uid != 0 && int(st.Uid) != os.Geteuid() {
-		return fmt.Errorf("%s is owned by uid %d; accepted owners are root or daemon uid %d. Keep the user home ownership unchanged and move the script to a root-owned path such as /usr/local/bin", path, st.Uid, os.Geteuid())
-	}
-	return nil
 }

--- a/cmd/proxsave/personal_scripts_inspection.go
+++ b/cmd/proxsave/personal_scripts_inspection.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/safeexec"
+)
+
+type personalScriptState string
+
+const (
+	personalScriptNotConfigured personalScriptState = "not-configured"
+	personalScriptReady         personalScriptState = "ready"
+	personalScriptRefused       personalScriptState = "refused"
+)
+
+type personalScriptPathComponent struct {
+	Path string
+	UID  uint32
+	Mode os.FileMode
+}
+
+type personalScriptDiagnostic struct {
+	Key        string
+	Path       string
+	State      personalScriptState
+	Reason     string
+	DaemonUID  int
+	Components []personalScriptPathComponent
+}
+
+type personalScriptsDiagnostics struct {
+	Pre  personalScriptDiagnostic
+	Post personalScriptDiagnostic
+}
+
+var (
+	personalScriptEvalSymlinks       = filepath.EvalSymlinks
+	personalScriptStat               = os.Stat
+	personalScriptValidateExecutable = safeexec.ValidateTrustedExecutablePath
+)
+
+// inspectPersonalScripts returns both configured-script verdicts without
+// logging, mutating the configuration, or executing either script.
+func inspectPersonalScripts(cfg *config.Config, daemonUID int) personalScriptsDiagnostics {
+	pre, post := "", ""
+	if cfg != nil {
+		pre = cfg.PersonalScriptPreRun
+		post = cfg.PersonalScriptPostRun
+	}
+	return personalScriptsDiagnostics{
+		Pre:  inspectPersonalScript("PERSONAL_SCRIPT_PRE_RUN", pre, daemonUID),
+		Post: inspectPersonalScript("PERSONAL_SCRIPT_POST_RUN", post, daemonUID),
+	}
+}
+
+// inspectPersonalScript applies the daemon's trusted-path policy and records
+// the ownership/mode evidence used to reach its presentation-neutral verdict.
+func inspectPersonalScript(key, path string, daemonUID int) personalScriptDiagnostic {
+	path = strings.TrimSpace(path)
+	diagnostic := personalScriptDiagnostic{
+		Key:       key,
+		Path:      path,
+		State:     personalScriptNotConfigured,
+		DaemonUID: daemonUID,
+	}
+	if path == "" {
+		return diagnostic
+	}
+
+	refuse := func(err error) personalScriptDiagnostic {
+		diagnostic.State = personalScriptRefused
+		diagnostic.Reason = err.Error()
+		return diagnostic
+	}
+
+	clean := filepath.Clean(path)
+	resolved, err := personalScriptEvalSymlinks(clean)
+	if err != nil {
+		return refuse(fmt.Errorf("resolve %s: %w", path, err))
+	}
+	if resolved != clean {
+		return refuse(fmt.Errorf("%s traverses a symlink (resolves to %s)", path, resolved))
+	}
+	if err := personalScriptValidateExecutable(clean); err != nil {
+		return refuse(err)
+	}
+
+	info, err := personalScriptStat(clean)
+	if err != nil {
+		return refuse(fmt.Errorf("stat %s: %w", path, err))
+	}
+	if err := appendPersonalScriptComponent(&diagnostic, clean, info); err != nil {
+		return refuse(err)
+	}
+	if err := personalScriptOwnerError(clean, info, daemonUID); err != nil {
+		return refuse(err)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return refuse(fmt.Errorf("%s is writable by group or others (mode %04o)", clean, info.Mode().Perm()))
+	}
+
+	for dir := filepath.Dir(clean); ; dir = filepath.Dir(dir) {
+		dirInfo, err := personalScriptStat(dir)
+		if err != nil {
+			return refuse(fmt.Errorf("stat %s: %w", dir, err))
+		}
+		if err := appendPersonalScriptComponent(&diagnostic, dir, dirInfo); err != nil {
+			return refuse(err)
+		}
+		if err := personalScriptOwnerError(dir, dirInfo, daemonUID); err != nil {
+			return refuse(err)
+		}
+		if dirInfo.Mode().Perm()&0o022 != 0 && dirInfo.Mode()&os.ModeSticky == 0 {
+			return refuse(fmt.Errorf("directory %s is writable by group or others without the sticky bit (mode %04o)", dir, dirInfo.Mode().Perm()))
+		}
+		if dir == "/" {
+			diagnostic.State = personalScriptReady
+			return diagnostic
+		}
+	}
+}
+
+func appendPersonalScriptComponent(diagnostic *personalScriptDiagnostic, path string, info os.FileInfo) error {
+	uid, err := personalScriptOwnerUID(path, info)
+	if err != nil {
+		return err
+	}
+	diagnostic.Components = append(diagnostic.Components, personalScriptPathComponent{
+		Path: path,
+		UID:  uid,
+		Mode: info.Mode(),
+	})
+	return nil
+}
+
+func personalScriptOwnerUID(path string, info os.FileInfo) (uint32, error) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("owner of %s cannot be determined", path)
+	}
+	return st.Uid, nil
+}
+
+func personalScriptOwnerError(path string, info os.FileInfo, daemonUID int) error {
+	uid, err := personalScriptOwnerUID(path, info)
+	if err != nil {
+		return err
+	}
+	if uid != 0 && int(uid) != daemonUID {
+		return fmt.Errorf("%s is owned by uid %d; accepted owners are root or daemon uid %d. Keep the user home ownership unchanged and move the script to a root-owned path such as /usr/local/bin", path, uid, daemonUID)
+	}
+	return nil
+}

--- a/cmd/proxsave/personal_scripts_inspection.go
+++ b/cmd/proxsave/personal_scripts_inspection.go
@@ -120,6 +120,7 @@ func inspectPersonalScript(key, path string, daemonUID int) personalScriptDiagno
 			return refuse(fmt.Errorf("directory %s is writable by group or others without the sticky bit (mode %04o)", dir, dirInfo.Mode().Perm()))
 		}
 		if dir == "/" {
+			diagnostic.Path = clean
 			diagnostic.State = personalScriptReady
 			return diagnostic
 		}

--- a/cmd/proxsave/personal_scripts_inspection_test.go
+++ b/cmd/proxsave/personal_scripts_inspection_test.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+type personalScriptInspectionFileInfo struct {
+	name string
+	mode os.FileMode
+	uid  uint32
+	dir  bool
+}
+
+func (f personalScriptInspectionFileInfo) Name() string      { return f.name }
+func (personalScriptInspectionFileInfo) Size() int64         { return 0 }
+func (f personalScriptInspectionFileInfo) Mode() os.FileMode { return f.mode }
+func (personalScriptInspectionFileInfo) ModTime() time.Time  { return time.Time{} }
+func (f personalScriptInspectionFileInfo) IsDir() bool       { return f.dir }
+func (f personalScriptInspectionFileInfo) Sys() any          { return &syscall.Stat_t{Uid: f.uid} }
+
+func installPersonalScriptInspectionOps(
+	t *testing.T,
+	eval func(string) (string, error),
+	stat func(string) (os.FileInfo, error),
+	validate func(string) error,
+) {
+	t.Helper()
+	origEval := personalScriptEvalSymlinks
+	origStat := personalScriptStat
+	origValidate := personalScriptValidateExecutable
+	t.Cleanup(func() {
+		personalScriptEvalSymlinks = origEval
+		personalScriptStat = origStat
+		personalScriptValidateExecutable = origValidate
+	})
+	personalScriptEvalSymlinks = eval
+	personalScriptStat = stat
+	personalScriptValidateExecutable = validate
+}
+
+func TestInspectPersonalScriptStatesAndReasons(t *testing.T) {
+	const daemonUID = 1001
+	trustedFile := personalScriptInspectionFileInfo{name: "script.sh", mode: 0o700, uid: daemonUID}
+	trustedDir := personalScriptInspectionFileInfo{name: "scripts", mode: os.ModeDir | 0o700, uid: daemonUID, dir: true}
+	rootDir := personalScriptInspectionFileInfo{name: "/", mode: os.ModeDir | 0o755, uid: 0, dir: true}
+
+	tests := []struct {
+		name       string
+		path       string
+		eval       func(string) (string, error)
+		stat       func(string) (os.FileInfo, error)
+		validate   func(string) error
+		wantState  personalScriptState
+		wantReason string
+		wantParts  int
+	}{
+		{
+			name:      "not configured",
+			path:      "   ",
+			wantState: personalScriptNotConfigured,
+		},
+		{
+			name: "ready",
+			path: "/srv/scripts/script.sh",
+			eval: func(path string) (string, error) { return path, nil },
+			stat: func(path string) (os.FileInfo, error) {
+				switch path {
+				case "/srv/scripts/script.sh":
+					return trustedFile, nil
+				case "/srv/scripts", "/srv":
+					return trustedDir, nil
+				case "/":
+					return rootDir, nil
+				default:
+					return nil, fmt.Errorf("unexpected stat %s", path)
+				}
+			},
+			validate:  func(string) error { return nil },
+			wantState: personalScriptReady,
+			wantParts: 4,
+		},
+		{
+			name:       "missing",
+			path:       "/missing/script.sh",
+			eval:       func(string) (string, error) { return "", os.ErrNotExist },
+			wantState:  personalScriptRefused,
+			wantReason: "resolve /missing/script.sh",
+		},
+		{
+			name:       "relative",
+			path:       "script.sh",
+			eval:       func(path string) (string, error) { return path, nil },
+			validate:   func(string) error { return errors.New("executable path must be absolute: script.sh") },
+			wantState:  personalScriptRefused,
+			wantReason: "must be absolute",
+		},
+		{
+			name:       "symlinked",
+			path:       "/srv/scripts/link.sh",
+			eval:       func(string) (string, error) { return "/srv/scripts/script.sh", nil },
+			wantState:  personalScriptRefused,
+			wantReason: "traverses a symlink",
+		},
+		{
+			name:       "directory",
+			path:       "/srv/scripts",
+			eval:       func(path string) (string, error) { return path, nil },
+			validate:   func(string) error { return errors.New("executable path is not a regular file: /srv/scripts") },
+			wantState:  personalScriptRefused,
+			wantReason: "not a regular file",
+		},
+		{
+			name:       "not executable",
+			path:       "/srv/scripts/script.sh",
+			eval:       func(path string) (string, error) { return path, nil },
+			validate:   func(string) error { return errors.New("executable path is not executable: /srv/scripts/script.sh") },
+			wantState:  personalScriptRefused,
+			wantReason: "not executable",
+		},
+		{
+			name:       "world writable",
+			path:       "/srv/scripts/script.sh",
+			eval:       func(path string) (string, error) { return path, nil },
+			validate:   func(string) error { return errors.New("executable path is world-writable: /srv/scripts/script.sh") },
+			wantState:  personalScriptRefused,
+			wantReason: "world-writable",
+		},
+		{
+			name: "group writable",
+			path: "/srv/scripts/script.sh",
+			eval: func(path string) (string, error) { return path, nil },
+			stat: func(string) (os.FileInfo, error) {
+				return personalScriptInspectionFileInfo{name: "script.sh", mode: 0o720, uid: daemonUID}, nil
+			},
+			validate:   func(string) error { return nil },
+			wantState:  personalScriptRefused,
+			wantReason: "writable by group or others",
+			wantParts:  1,
+		},
+		{
+			name: "foreign owned target",
+			path: "/srv/scripts/script.sh",
+			eval: func(path string) (string, error) { return path, nil },
+			stat: func(string) (os.FileInfo, error) {
+				return personalScriptInspectionFileInfo{name: "script.sh", mode: 0o700, uid: 4242}, nil
+			},
+			validate:   func(string) error { return nil },
+			wantState:  personalScriptRefused,
+			wantReason: "owned by uid 4242",
+			wantParts:  1,
+		},
+		{
+			name: "foreign owned parent",
+			path: "/home/operator/script.sh",
+			eval: func(path string) (string, error) { return path, nil },
+			stat: func(path string) (os.FileInfo, error) {
+				if path == "/home/operator" {
+					return personalScriptInspectionFileInfo{name: "operator", mode: os.ModeDir | 0o700, uid: 4242, dir: true}, nil
+				}
+				return trustedFile, nil
+			},
+			validate:   func(string) error { return nil },
+			wantState:  personalScriptRefused,
+			wantReason: "/home/operator is owned by uid 4242",
+			wantParts:  2,
+		},
+		{
+			name: "writable non sticky parent",
+			path: "/srv/scripts/script.sh",
+			eval: func(path string) (string, error) { return path, nil },
+			stat: func(path string) (os.FileInfo, error) {
+				if path == "/srv/scripts" {
+					return personalScriptInspectionFileInfo{name: "scripts", mode: os.ModeDir | 0o777, uid: daemonUID, dir: true}, nil
+				}
+				return trustedFile, nil
+			},
+			validate:   func(string) error { return nil },
+			wantState:  personalScriptRefused,
+			wantReason: "without the sticky bit",
+			wantParts:  2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			eval := tc.eval
+			if eval == nil {
+				eval = func(path string) (string, error) { return path, nil }
+			}
+			stat := tc.stat
+			if stat == nil {
+				stat = func(string) (os.FileInfo, error) { return trustedFile, nil }
+			}
+			validate := tc.validate
+			if validate == nil {
+				validate = func(string) error { return nil }
+			}
+			installPersonalScriptInspectionOps(t, eval, stat, validate)
+
+			got := inspectPersonalScript("PERSONAL_SCRIPT_PRE_RUN", tc.path, daemonUID)
+			if got.State != tc.wantState {
+				t.Fatalf("state = %q, want %q; diagnostic=%+v", got.State, tc.wantState, got)
+			}
+			if tc.wantReason != "" && !strings.Contains(got.Reason, tc.wantReason) {
+				t.Errorf("reason %q does not contain %q", got.Reason, tc.wantReason)
+			}
+			if len(got.Components) != tc.wantParts {
+				t.Errorf("components = %d, want %d: %+v", len(got.Components), tc.wantParts, got.Components)
+			}
+			if got.Key != "PERSONAL_SCRIPT_PRE_RUN" || got.DaemonUID != daemonUID {
+				t.Errorf("identity fields missing: %+v", got)
+			}
+		})
+	}
+}
+
+func TestInspectPersonalScriptsIsPureAndDoesNotExecute(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "executed")
+	script := writePersonalScript(t, dir, "pure.sh", "touch "+marker)
+	cfg := &config.Config{PersonalScriptPreRun: script, PersonalScriptPostRun: ""}
+
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	previous := logging.GetDefaultLogger()
+	logging.SetDefaultLogger(logger)
+	t.Cleanup(func() { logging.SetDefaultLogger(previous) })
+
+	beforePre, beforePost := cfg.PersonalScriptPreRun, cfg.PersonalScriptPostRun
+	got := inspectPersonalScripts(cfg, os.Geteuid())
+	if got.Pre.State != personalScriptReady || got.Post.State != personalScriptNotConfigured {
+		t.Fatalf("unexpected diagnostics: %+v", got)
+	}
+	if cfg.PersonalScriptPreRun != beforePre || cfg.PersonalScriptPostRun != beforePost {
+		t.Fatalf("inspection mutated config: before=(%q,%q) after=(%q,%q)", beforePre, beforePost, cfg.PersonalScriptPreRun, cfg.PersonalScriptPostRun)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("inspection logged output: %s", buf.String())
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("inspection executed the script; marker stat error = %v", err)
+	}
+}
+
+func TestPersonalScriptValidationEmitsOneWarningPerRefusedSetting(t *testing.T) {
+	dir := t.TempDir()
+	script := writePersonalScript(t, dir, "loose.sh", "exit 0")
+	if err := os.Chmod(script, 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	pre, post, logged := capturePersonalScriptValidation(t, script, script)
+	if pre != "" || post != "" {
+		t.Fatalf("refused settings survived: pre=%q post=%q", pre, post)
+	}
+	for _, key := range []string{"PERSONAL_SCRIPT_PRE_RUN", "PERSONAL_SCRIPT_POST_RUN"} {
+		if got := strings.Count(logged, key+" disabled for this daemon:"); got != 1 {
+			t.Errorf("%s warning count = %d, want 1\n%s", key, got, logged)
+		}
+	}
+}

--- a/cmd/proxsave/upgrade.go
+++ b/cmd/proxsave/upgrade.go
@@ -127,7 +127,15 @@ func logUpgradeDaemonRestart(bootstrap *logging.BootstrapLogger, rv *RestartVeri
 //
 // The shared setup (logger, banner, config load) runs before either phase so the
 // --localfile path prints the same header and honours the same guards.
+type upgradeRunOptions struct {
+	deferWhatsnew bool
+}
+
 func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.BootstrapLogger) int {
+	return runUpgradeWithOptions(ctx, args, bootstrap, upgradeRunOptions{})
+}
+
+func runUpgradeWithOptions(ctx context.Context, args *cli.Args, bootstrap *logging.BootstrapLogger, opts upgradeRunOptions) int {
 	baseDir, _ := detectedBaseDirOrFallback()
 	_ = os.Setenv("BASE_DIR", baseDir)
 
@@ -189,7 +197,7 @@ func runUpgrade(ctx context.Context, args *cli.Args, bootstrap *logging.Bootstra
 	}
 
 	// Phase 2: local finalize, shared by the download and --localfile paths.
-	code, finalizeErr := upgradeFinalizePhase(ctx, args, bootstrap, sessionLogger, baseDir, execPath, versionInstalled, upgradeErr)
+	code, finalizeErr := upgradeFinalizePhase(ctx, args, bootstrap, sessionLogger, baseDir, execPath, versionInstalled, upgradeErr, opts)
 	workflowErr = finalizeErr
 	return code
 }
@@ -276,7 +284,7 @@ func upgradeAcquireBinary(ctx context.Context, args *cli.Args, bootstrap *loggin
 // which both reach it with the target binary already in place. Returns the
 // process exit code and the error to attribute to the workflow span (nil on full
 // success, the config-upgrade error, or the binary-install error).
-func upgradeFinalizePhase(ctx context.Context, args *cli.Args, bootstrap *logging.BootstrapLogger, sessionLogger *logging.Logger, baseDir, execPath, versionInstalled string, upgradeErr error) (int, error) {
+func upgradeFinalizePhase(ctx context.Context, args *cli.Args, bootstrap *logging.BootstrapLogger, sessionLogger *logging.Logger, baseDir, execPath, versionInstalled string, upgradeErr error, opts upgradeRunOptions) (int, error) {
 	var cfgUpgradeResult *config.UpgradeResult
 	var cfgUpgradeErr error
 	if upgradeErr == nil {
@@ -352,12 +360,12 @@ func upgradeFinalizePhase(ctx context.Context, args *cli.Args, bootstrap *loggin
 	// new) for the freshly installed release by re-invoking the installed binary with
 	// --show-whatsnew. The notes registry is compiled into each binary, so the INSTALLED
 	// binary -- not necessarily this process (the download path finalizes from the OLD
-	// binary) -- is the one that must render them. Best-effort and gated (interactive AND
-	// not auto-yes) inside the helper; never changes the exit code. A config-upgrade
+	// binary) -- is the one that must render them. Best-effort and gated by the terminal/
+	// deferred-presentation policy inside the helper; never changes the exit code. A config-upgrade
 	// failure (cfgUpgradeErr) leaves the footer showing "Configuration: ERROR" and a
 	// nonzero exit, so opening a celebratory notes screen there would contradict it.
 	if upgradeErr == nil && cfgUpgradeErr == nil {
-		runWhatsnewAfterUpgrade(ctx, execPath, args, bootstrap)
+		runWhatsnewAfterUpgrade(ctx, execPath, args, bootstrap, opts)
 	}
 
 	// The workflow span error mirrors the exit code's reasoning: a binary-install
@@ -1004,13 +1012,11 @@ func upgradeConfigWithBinary(ctx context.Context, execPath, configPath string) (
 var whatsnewAfterUpgradeInteractive = isTerminalInteractive
 
 // shouldRunWhatsnewAfterUpgrade decides whether to open Screen 0 at the end of an upgrade.
-// It requires an interactive terminal AND that the operator did NOT request auto-yes
-// (`--upgrade y`). Auto-yes signals non-interactive intent even when a pty IS allocated
-// (ssh -tt, Ansible with a pty, `script -c`), where isTerminalInteractive() alone is true;
-// opening a screen that waits for a human keypress there would stall the process until the
-// Screen 0 timeout on an otherwise successful automated upgrade, so auto-yes must skip it.
-func shouldRunWhatsnewAfterUpgrade(args *cli.Args) bool {
-	if args == nil || args.UpgradeAutoYes {
+// It follows the actual terminal: auto-yes controls only the initial confirmation and does
+// not make a TTY-driven upgrade non-interactive. The dashboard explicitly defers the screen
+// because its replacement process owns post-upgrade presentation.
+func shouldRunWhatsnewAfterUpgrade(args *cli.Args, opts upgradeRunOptions) bool {
+	if args == nil || opts.deferWhatsnew {
 		return false
 	}
 	return whatsnewAfterUpgradeInteractive()
@@ -1021,11 +1027,11 @@ func shouldRunWhatsnewAfterUpgrade(args *cli.Args) bool {
 // upgrade. It MUST be the installed binary that renders it: the notes registry is compiled
 // into each binary, so on the download path -- where THIS process is still the OLD binary --
 // only execPath knows the new release's notes. Stdio is inherited so the child paints the
-// TUI on the real terminal. Gated by shouldRunWhatsnewAfterUpgrade (interactive AND not
-// auto-yes) so an automated upgrade never blocks, and best-effort so a render failure never
-// changes the upgrade's exit code.
-func runWhatsnewAfterUpgrade(ctx context.Context, execPath string, args *cli.Args, bootstrap *logging.BootstrapLogger) {
-	if !shouldRunWhatsnewAfterUpgrade(args) {
+// TUI on the real terminal. Gated by shouldRunWhatsnewAfterUpgrade so a no-TTY automated
+// upgrade never blocks and the dashboard can defer presentation; best-effort so a render
+// failure never changes the upgrade's exit code.
+func runWhatsnewAfterUpgrade(ctx context.Context, execPath string, args *cli.Args, bootstrap *logging.BootstrapLogger, opts upgradeRunOptions) {
+	if !shouldRunWhatsnewAfterUpgrade(args, opts) {
 		return
 	}
 	execPath = strings.TrimSpace(execPath)

--- a/cmd/proxsave/whatsnew_upgrade_test.go
+++ b/cmd/proxsave/whatsnew_upgrade_test.go
@@ -123,11 +123,10 @@ func TestUpgradeShowsWhatsnewAfterFooter(t *testing.T) {
 	}
 }
 
-// TestShouldRunWhatsnewAfterUpgrade pins the post-upgrade gate: Screen 0 opens only on an
-// interactive terminal AND when the operator did not request auto-yes. Auto-yes (`--upgrade
-// y`) means non-interactive intent even under a pty (ssh -tt, Ansible, script -c), so it must
-// skip the screen; otherwise a successful automated upgrade would stall until the Screen 0
-// timeout waiting for a keypress nobody sends.
+// TestShouldRunWhatsnewAfterUpgrade pins the post-upgrade gate: Screen 0 follows the actual
+// terminal. Auto-yes only suppresses the initial confirmation; a manual `--upgrade y` in a
+// TTY still shows Screen 0, while the dashboard explicitly defers presentation to its
+// replacement process.
 func TestShouldRunWhatsnewAfterUpgrade(t *testing.T) {
 	orig := whatsnewAfterUpgradeInteractive
 	t.Cleanup(func() { whatsnewAfterUpgradeInteractive = orig })
@@ -135,19 +134,21 @@ func TestShouldRunWhatsnewAfterUpgrade(t *testing.T) {
 	cases := []struct {
 		name        string
 		args        *cli.Args
+		opts        upgradeRunOptions
 		interactive bool
 		want        bool
 	}{
-		{"interactive human upgrade shows", &cli.Args{}, true, true},
-		{"auto-yes under a pty skips (no stall)", &cli.Args{UpgradeAutoYes: true}, true, false},
-		{"non-interactive skips", &cli.Args{}, false, false},
-		{"auto-yes and non-interactive skips", &cli.Args{UpgradeAutoYes: true}, false, false},
-		{"nil args skips", nil, true, false},
+		{"interactive prompted upgrade shows", &cli.Args{}, upgradeRunOptions{}, true, true},
+		{"interactive auto-yes upgrade shows", &cli.Args{UpgradeAutoYes: true}, upgradeRunOptions{}, true, true},
+		{"non-interactive prompted upgrade skips", &cli.Args{}, upgradeRunOptions{}, false, false},
+		{"non-interactive auto-yes upgrade skips", &cli.Args{UpgradeAutoYes: true}, upgradeRunOptions{}, false, false},
+		{"dashboard defers presentation", &cli.Args{UpgradeAutoYes: true}, upgradeRunOptions{deferWhatsnew: true}, true, false},
+		{"nil args skips", nil, upgradeRunOptions{}, true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			whatsnewAfterUpgradeInteractive = func() bool { return tc.interactive }
-			if got := shouldRunWhatsnewAfterUpgrade(tc.args); got != tc.want {
+			if got := shouldRunWhatsnewAfterUpgrade(tc.args, tc.opts); got != tc.want {
 				t.Fatalf("shouldRunWhatsnewAfterUpgrade = %v, want %v", got, tc.want)
 			}
 		})

--- a/cmd/proxsave/whatsnew_verf01_test.go
+++ b/cmd/proxsave/whatsnew_verf01_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/tis24dev/proxsave/internal/cli"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/orchestrator"
 	"github.com/tis24dev/proxsave/internal/types"
@@ -15,13 +16,15 @@ import (
 )
 
 // TestVERF01 is the consolidated end-to-end verification of the "what's new" feature over
-// the REAL gate (Decide/ShouldWarn/MarkSeen/LoadState/StatePath) and the two wirings. Four
+// the REAL gate (Decide/ShouldWarn/MarkSeen/LoadState/StatePath) and the two wirings. Five
 // scenarios must hold together in one session:
 //  1. a fresh install (seeded to current) shows nothing on either channel;
 //  2. a real upgrader (absent flag) shows Screen 0 exactly once, then goes silent;
 //  3. a non-interactive run emits exactly one captured WARNING WITHOUT writing the flag,
 //     so the backup state is untouched and the warning re-fires on every run;
-//  4. a timeout/Esc leaves the flag unwritten, so ShouldWarn still reports unseen.
+//  4. an auto-confirmed upgrade without a TTY skips Screen 0 and leaves the previous seen
+//     version intact, so exactly one warning reaches notification accounting;
+//  5. a timeout/Esc leaves the flag unwritten, so ShouldWarn still reports unseen.
 //
 // The live on-TTY paint of Screen 0 and the real --backup channel delivery stay manual UAT
 // (03-VALIDATION.md); everything gate/wiring is verified here.
@@ -97,6 +100,40 @@ func TestVERF01(t *testing.T) {
 		}
 		if got := warnOnce(t, base); got != 1 {
 			t.Fatalf("second non-interactive run warningCount = %d, want 1 (warns every run)", got)
+		}
+	})
+
+	t.Run("auto_yes_without_tty_leaves_healthchecks_warning_armed", func(t *testing.T) {
+		origInteractive := whatsnewAfterUpgradeInteractive
+		whatsnewAfterUpgradeInteractive = func() bool { return false }
+		t.Cleanup(func() { whatsnewAfterUpgradeInteractive = origInteractive })
+
+		base := t.TempDir()
+		if err := whatsnew.MarkSeen(base, "0.32.0"); err != nil {
+			t.Fatalf("seed previous version: %v", err)
+		}
+		if shouldRunWhatsnewAfterUpgrade(&cli.Args{UpgradeAutoYes: true}, upgradeRunOptions{}) {
+			t.Fatal("auto-confirmed no-TTY upgrade must not start Screen 0")
+		}
+
+		logPath := filepath.Join(t.TempDir(), "run.log")
+		logger := logging.New(types.LogLevelDebug, false)
+		logger.SetOutput(&bytes.Buffer{})
+		if err := logger.OpenLogFile(logPath); err != nil {
+			t.Fatalf("OpenLogFile: %v", err)
+		}
+		maybeWarnWhatsnew(logger, base, "0.33.0", false)
+		if err := logger.CloseLogFile(); err != nil {
+			t.Fatalf("CloseLogFile: %v", err)
+		}
+
+		_, _, warningCount, _ := orchestrator.ParseLogCounts(logPath, 10)
+		if warningCount != 1 {
+			t.Fatalf("warningCount = %d, want 1", warningCount)
+		}
+		state, present, err := whatsnew.LoadState(base)
+		if err != nil || !present || state.LastSeenNotesVersion != "0.32.0" {
+			t.Fatalf("seen state changed after unattended path: state=%+v present=%v err=%v", state, present, err)
 		}
 	})
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -442,6 +442,11 @@ proxsave -l info    # debug|info|warning|error|critical
 - **Console**: Colored output (if `USE_COLOR=true`)
 - **File**: `LOG_PATH/backup-$(hostname)-YYYYMMDD-HHMMSS.log`
 
+The level threshold mutes the **console only** for warnings and above: a warning or
+error raised below the chosen level is still counted (footer, exit code) and still
+written to the log file, so the artifact shipped with notifications keeps the
+evidence. Levels below warning are filtered everywhere, as before.
+
 **`--log-level` vs `DEBUG_LEVEL`**:
 - `DEBUG_LEVEL` (config) sets the base log level: `standard` resolves to `info`, `advanced` and `extreme` both resolve to `debug`. Default is `info`.
 - `--log-level` (CLI flag) overrides `DEBUG_LEVEL` for that run.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -106,7 +106,7 @@ proxsave -h
 | `--daemon` | | Run as the resident backup daemon (schedules + supervises runs, reports to healthchecks). Invoked by `proxsave-daemon.service`; not run by hand. See [docs/DAEMON.md](DAEMON.md) and [docs/HEALTHCHECKS.md](HEALTHCHECKS.md). |
 | `--daemon-setup` | | Switch this install to daemon mode: install+enable the service and remove the cron entry. |
 | `--daemon-remove` | | Revert to the cron scheduler, disable the service, and block future upgrades from reinstalling the daemon. |
-| `--daemon-status` | | Print the daemon status (scheduler mode, service state, running version, binary alignment) and exit. Exit code is `0` only when the daemon is running and aligned, non-zero otherwise, so scripts can gate on it. |
+| `--daemon-status` | | Read-only daemon status (scheduler/service state, version/alignment, and personal pre/post script readiness) and exit. `--log-level debug` adds daemon-UID and path-component evidence without executing scripts. Exit code remains based only on daemon health: `0` when running and aligned, non-zero otherwise. |
 | `--show-whatsnew` | | Show the release-notes screen once and exit, then mark it seen. `--upgrade` calls it for you on an interactive terminal; run it by hand after an unattended upgrade to stop the "unseen release notes" warning. |
 
 ---
@@ -704,7 +704,7 @@ crontab -e
 | `--daemon` | - | Run as the resident backup daemon (installed as `proxsave-daemon.service`; not run by hand) |
 | `--daemon-setup` | - | Switch this install to daemon mode (install+enable the service, remove the cron entry) |
 | `--daemon-remove` | - | Revert to the cron scheduler, disable the service, and block future upgrades from reinstalling the daemon |
-| `--daemon-status` | - | Print daemon status and exit (`0` only when running and aligned) |
+| `--daemon-status` | - | Read-only daemon and personal-script status; add `--log-level debug` for UID/path evidence. Scripts are not executed; exit is `0` only when the daemon is running and aligned |
 | `--cleanup-guards` | - | Remove leftover ProxSave mount guards under `/var/lib/proxsave/guards` (use with `--dry-run` to preview) |
 | `--support` | - | Run in support mode (force DEBUG logging and email log). Available for the standard backup run and `--restore` |
 

--- a/docs/CLUSTER_RECOVERY.md
+++ b/docs/CLUSTER_RECOVERY.md
@@ -148,11 +148,11 @@ In the TUI it is a selector titled `Cluster restore mode` with `SAFE`, `RECOVERY
 
 SAFE never writes config.db, never stops `pve-cluster`/`pvedaemon`/`pveproxy`/`pvestatd`, and never unmounts `/etc/pve`. It extracts the cluster files to an export directory and re-applies them to the RUNNING cluster through `pvesh`/`pveum`:
 
-- storage definitions (`pvesh create /storage` from storage.cfg), unless the `storage_pve` category already restores them;
-- datacenter options (`pvesh set /cluster/config`);
+- storage definitions from storage.cfg (`pvesh create /storage`, falling back to `pvesh set /storage/<id>` for definitions that already exist);
+- datacenter options (datacenter.cfg written into pmxcfs, which replicates cluster-wide; the API has no whole-file endpoint);
 - resource pools (`pveum pool add/modify` for definitions, then membership, with an optional allow-move guard when a pool lists guests);
 - PCI, USB, and directory resource mappings;
-- VM and CT configs, re-created on the CURRENT node via `pvesh create` then `pvesh set` under `/nodes/<node>/qemu|lxc/<vmid>/config`.
+- VM and CT configs on the CURRENT node: existing guests via `pvesh set` under `/nodes/<node>/qemu|lxc/<vmid>/config` (minus the create-only keys the update schema refuses, with the staged conf written into pmxcfs as the fallback when the guest is not running); missing guests registered by writing the conf into pmxcfs (config only - disks are not part of a config restore).
 
 Use SAFE when the node or cluster is up and you want to merge the backed-up configuration back in without touching the live database. SAFE needs `pvesh` on PATH; without it, it logs a skip and applies nothing.
 

--- a/docs/CLUSTER_RECOVERY.md
+++ b/docs/CLUSTER_RECOVERY.md
@@ -152,11 +152,13 @@ SAFE never writes config.db, never stops `pve-cluster`/`pvedaemon`/`pveproxy`/`p
 - datacenter options (datacenter.cfg written into pmxcfs, which replicates cluster-wide; the API has no whole-file endpoint);
 - resource pools (`pveum pool add/modify` for definitions, then membership, with an optional allow-move guard when a pool lists guests);
 - PCI, USB, and directory resource mappings;
-- VM and CT configs on the CURRENT node: existing guests via `pvesh set` under `/nodes/<node>/qemu|lxc/<vmid>/config` (minus the create-only keys the update schema refuses, with the staged conf written into pmxcfs as the fallback when the guest is not running); missing guests registered by writing the conf into pmxcfs (config only - disks are not part of a config restore).
+- VM and CT configs: before any guest mutation, SAFE loads the cluster-wide inventory with `pvesh get /cluster/resources --type vm --output-format=json`. An unavailable, malformed, incomplete, or ambiguous inventory fails the whole selected guest batch closed. A VMID owned by another node, or present with a different guest type, is reported and skipped; SAFE never moves it. Existing guests on the current node are updated with `pvesh set` under `/nodes/<node>/qemu|lxc/<vmid>/config` (minus create-only keys); if that fails, the staged conf is written into pmxcfs only after `status/current` explicitly reports `stopped`. A VMID absent cluster-wide is registered on the current node by writing the conf into pmxcfs (config only - disks are not part of a config restore).
 
 Use SAFE when the node or cluster is up and you want to merge the backed-up configuration back in without touching the live database. SAFE needs `pvesh` on PATH; without it, it logs a skip and applies nothing.
 
 If the backup's VM/CT configs are stored under a node name that does not match the current host (a hostname change), SAFE handles it for you: it warns, and either auto-selects the single exported node or asks which exported node to import the guest configs from. The chosen configs are applied to the current node. You do not need to copy `/etc/pve/nodes/...` by hand.
+
+Selecting an exported node controls only which backed-up files are considered. It does not override live cluster ownership: if one of those VMIDs already belongs to another node, SAFE skips it rather than applying or moving it to the current node.
 
 This applies only when the guest configs are actually in the export, which means the restore included `pve_config_export`. FULL includes it; CUSTOM includes it if you select it; STORAGE and SYSTEM BASE strip export-only categories, so in those modes SAFE applies no guest config and the node-name handling never runs.
 

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -234,7 +234,9 @@ They are **yours, not ProxSave's**, and the whole contract follows from that:
   shape). A path that fails any of it is disabled for that daemon and the gate says so, once:
   a `WARNING` in the daemon's log naming the variable, the path and the reason. That warning
   is deliberate and is the single exception to the silence above - without it, a refused path
-  would be indistinguishable from a script that ran and did nothing.
+  would be indistinguishable from a script that ran and did nothing. Do not change a user's
+  home directory to `root:root` to satisfy this check. Move the script to a fully root-owned
+  path such as `/usr/local/bin`, then update `backup.env` and restart the daemon.
 - **Started as they are.** The path is executed directly: no shell, so no pipes, redirections
   or arguments in the value, and no arguments passed. The script inherits the daemon's own
   environment with two variables removed, `LOG_FILE` and `BASE_DIR`: the first names the run

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -36,6 +36,7 @@ An in-place `--upgrade` replaces the on-disk binary without restarting the resid
 
 ```bash
 proxsave --daemon-status                       # read-only status + exit code (see below)
+proxsave --daemon-status --log-level debug     # include script-path ownership/mode evidence
 systemctl status proxsave-daemon.service       # is it running?
 journalctl -u proxsave-daemon.service -f       # follow its log
 proxsave --daemon-setup                        # switch to the daemon
@@ -51,9 +52,13 @@ Daemon service (proxsave-daemon.service): installed | not installed
 Service state (systemctl is-active): <active|inactive|...>
 Running version: <version> (<commit>)
 Binary alignment: aligned | BEHIND (restart needed) | unknown
+Personal pre-run script: NOT CONFIGURED | READY — <path> | REFUSED — <path> — <reason>
+Personal post-run script: NOT CONFIGURED | READY — <path> | REFUSED — <path> — <reason>
 ```
 
-The last two lines (`Running version:` and `Binary alignment:`) appear only when a running daemon and its identity record are available; they are omitted when the daemon is not installed or not running. It exits `0` **only** when the daemon is running, beating, and aligned; every gap (not installed, not running, stale, running but not reporting, or behind) exits non-zero, so `proxsave --daemon-status` can gate a script. It cannot be combined with `--daemon`, `--daemon-setup`, or `--daemon-remove`.
+`Running version:` and `Binary alignment:` appear only when their daemon evidence is available. The two personal-script lines always appear. `READY` means the configured path passes the same trusted-path gate used at daemon startup; `REFUSED` includes the exact refusal reason. With debug logging, the block also shows the UID used for that decision and every inspected path component's owner and mode. It reads the effective UID from the live daemon's `/proc/<pid>/status` when possible and explicitly reports a fallback to the status command's UID when it cannot.
+
+This check is read-only: it never executes a personal script, starts a backup, acquires daemon ownership, or sends a healthcheck ping. Script status does not alter its exit code. It exits `0` **only** when the daemon is running, beating, and aligned; every daemon gap (not installed, not running, stale, running but not reporting, or behind) exits non-zero, so `proxsave --daemon-status` can gate a script. It cannot be combined with `--daemon`, `--daemon-setup`, or `--daemon-remove`.
 
 ## Install
 
@@ -202,7 +207,7 @@ They are **yours, not ProxSave's**, and the whole contract follows from that:
 
 - **Daemon runs only.** A manual `proxsave --backup`, a cron-mode run, and a dashboard run
   start neither script. Only the run the daemon schedules and supervises is bracketed.
-- **Nothing is reported about them.** Their standard output and standard error go to
+- **Nothing is reported about their execution.** Their standard output and standard error go to
   `/dev/null`. Nothing they print or fail at appears in the run log, in the log file, in the
   run recap, in an email, Telegram, Gotify or webhook notification, in a healthchecks ping, or
   in the Prometheus metrics. If you want a record of what your script did, your script writes
@@ -266,9 +271,11 @@ Both values are read once, when the daemon starts. Changing a path in `backup.en
 effect at the next daemon restart; changing the contents of the script file takes effect at
 the next run.
 
-Because ProxSave says nothing about these scripts, a script that never runs looks exactly like
-a script that ran and did nothing. Test it by hand first, as root:
-`/usr/local/bin/my-pre-run.sh; echo $?`.
+To diagnose the configured paths without executing either script, run
+`proxsave --daemon-status --log-level debug`. It applies the daemon startup gate, reports
+`READY`, `REFUSED` with the exact reason, or `NOT CONFIGURED`, and includes the UID plus
+ownership/mode evidence. This does not prove the script's own logic succeeds; test that separately,
+as root, with `/usr/local/bin/my-pre-run.sh; echo $?`.
 
 ## Caveat: uninterruptible sleep (D state)
 

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -23,14 +23,15 @@ A notification is always best-effort. No channel can fail, delay, or block a bac
   an `error` outcome for that channel, and returns `nil` to the caller
   (`internal/orchestrator/notification_adapter.go`). The dispatcher ignores the return
   value too.
-- The run's exit code is **frozen before any channel sends**. `applyIssueExitCode`
-  promotes the exit code from the collected errors and warnings first, then the
-  notification phase runs. A warning raised while sending a notification is still a
-  warning, never an error, and never changes the exit code
-  (`internal/orchestrator/extensions.go`).
+- A notification failure is **warning-weight for the exit code**. The exit code is
+  first computed before the channels send; after dispatch the run log is re-parsed
+  once more, so a `NOTIFY-ERR` raised while sending promotes an otherwise clean run
+  from `0` to `1` - never to an error code
+  (`internal/orchestrator/backup_run_phases.go`, `finalizeSuccessIssueStats`).
 
 So a red channel in the logs tells you a message did not go out. It never means the
-backup failed.
+backup failed - but the run does exit `1`, so monitoring learns notifications are
+broken exactly when email cannot say so.
 
 ## Two tiers
 

--- a/docs/RESTORE_GUIDE.md
+++ b/docs/RESTORE_GUIDE.md
@@ -914,7 +914,7 @@ Cluster backup detected. Choose how to restore the cluster database:
 
 **Post-restore actions (SAFE mode)**:
 After export, the workflow offers interactive options to apply configurations via `pvesh`:
-1. **VM/CT configs**: Scans exported configs (under `/etc/pve/nodes/<node>/...`) and applies them via `pvesh set /nodes/<node>/qemu/<vmid>/config` (create-only keys such as `meta`/`ostemplate` are stripped; if the set fails and the guest is not running, the exported conf is written into pmxcfs; a missing guest is registered by writing its conf)
+1. **VM/CT configs**: Scans exported configs (under `/etc/pve/nodes/<node>/...`) and first loads the cluster-wide guest inventory. Existing guests on the current node are applied via `pvesh set /nodes/<node>/qemu|lxc/<vmid>/config` (create-only keys such as `meta`/`ostemplate` are stripped; if the set fails, the exported conf is written into pmxcfs only when `status/current` explicitly reports `stopped`). A VMID absent cluster-wide is registered by writing its conf; a VMID owned by another node or present as the other guest type is skipped without mutation. An unavailable or invalid inventory stops the entire guest batch before mutation.
    - If the target node hostname differs from the hostname stored in the backup (common after hardware migration / reinstall), ProxSave detects the mismatch and prompts you to select the exported node directory to import from (instead of silently reporting "No VM/CT configs found").
 2. **Storage configuration**: applies each `storage.cfg` block via `pvesh create /storage --storage=<id> --type=<type> ...`, falling back to `pvesh set /storage/<id>` when the definition already exists (as `local` always does)
 3. **Datacenter configuration**: writes `datacenter.cfg` into pmxcfs (`/etc/pve`), which replicates it cluster-wide - the API has no whole-file endpoint for it
@@ -1446,10 +1446,16 @@ Apply all VM/CT configs via pvesh? (y/N): y
 
 For each VM/CT config found in the export:
 - Reads config from `<export>/etc/pve/nodes/<node>/qemu-server/<vmid>.conf`
-- Applies via: `pvesh set /nodes/<node>/qemu/<vmid>/config --filename <config>`
-- Reports success/failure for each VM
+- Loads one cluster-wide inventory with `pvesh get /cluster/resources --type vm --output-format=json` before changing any guest
+- Stops the entire selected guest batch without mutation if the inventory command fails or its JSON is malformed, incomplete, or contains duplicate VMIDs
+- Skips a VMID already owned by another node; SAFE does not move guests between nodes
+- Skips a VMID whose live type (`qemu` or `lxc`) differs from the staged config type
+- Updates a matching guest on the current node with `pvesh set /nodes/<node>/<type>/<vmid>/config --<key>=<value> ...`, excluding create-only keys
+- If that API update fails, writes the staged conf into pmxcfs only after the JSON status probe explicitly reports `stopped`; command errors, malformed status, `running`, and unknown states all skip the fallback
+- Registers a VMID that is absent cluster-wide by writing the staged conf into pmxcfs on the current node
+- Reports success/failure for each VM/CT
 
-**Note**: This creates or updates VM configurations in the cluster. Disk images are NOT affected.
+**Note**: This registers or updates guest configurations only. Disk images are NOT affected.
 
 #### 4. Storage Configuration Apply
 

--- a/docs/RESTORE_GUIDE.md
+++ b/docs/RESTORE_GUIDE.md
@@ -831,7 +831,7 @@ Applied VM/CT config 101 (database)
 
 When restoring from a **cluster backup** and selecting **RECOVERY mode** (option 2):
 
-1. **Same as Standalone** - Direct database restore
+1. **Direct database restore** - The selected `pve_cluster` payload, including `config.db`, is restored
 2. **WARNING displayed** - User must confirm node isolation
 3. **Split-brain risk** - CRITICAL to isolate node before proceeding
 
@@ -887,7 +887,7 @@ syncs via corosync (cluster communication)
 
 ### Cluster Restore Modes: SAFE vs RECOVERY
 
-When the backup was created from a cluster node (detected via manifest `ClusterMode: cluster`) and you select the `pve_cluster` category, the restore workflow presents two options:
+When the analyzed archive contains the `pve_cluster` payload and that category is selected, the restore workflow presents two options. The manifest's `ClusterMode` is used only to warn when its claim disagrees with the payload:
 
 ```text
 Cluster backup detected. Choose how to restore the cluster database:
@@ -1468,7 +1468,8 @@ Parses `storage.cfg` and applies each storage definition:
 - Each `storage: <name>` block is extracted
 - Applied via: `pvesh create /storage --storage=<id> --type=<type> --<key>=<value> ...`
 - Blocks are keyed on the `<type>: <id>` header (`dir: local`, `nfs: backup`); the older `storage: <id>` form is still accepted
-- There is no existence check and no update path: a storage that already exists makes `pvesh create` fail, and it is counted as a failure rather than updated. Remove or rename the existing definition first if you need it replaced
+- If `pvesh create` fails (including when the definition already exists), ProxSave retries with `pvesh set /storage/<id>` and drops keys that the live set schema reports as create-only
+- The storage is counted as failed only when both the create attempt and the set fallback fail
 
 **Note**: Storage directories are NOT created automatically. Run `pvesm status` to verify, then create missing directories manually.
 

--- a/docs/RESTORE_GUIDE.md
+++ b/docs/RESTORE_GUIDE.md
@@ -714,7 +714,7 @@ Exported 23 files/directories
 
 When using Cluster SAFE mode, after extraction:
 ```text
-SAFE cluster restore: applying configs via pvesh (node=pve01)
+SAFE cluster restore: applying configs (node=pve01)
 
 Found 3 VM/CT configs for node pve01
 Apply all VM/CT configs via pvesh? (y/N): y
@@ -819,7 +819,7 @@ Cluster backup detected. Choose how to restore:
 
 Exporting 1 export-only category(ies) to: /opt/proxsave/proxmox-config-export-*/
 
-SAFE cluster restore: applying configs via pvesh (node=pve01)
+SAFE cluster restore: applying configs (node=pve01)
 Found 5 VM/CT configs for node pve01
 Apply all VM/CT configs via pvesh? (y/N): y
 Applied VM/CT config 100 (webserver)
@@ -914,10 +914,10 @@ Cluster backup detected. Choose how to restore the cluster database:
 
 **Post-restore actions (SAFE mode)**:
 After export, the workflow offers interactive options to apply configurations via `pvesh`:
-1. **VM/CT configs**: Scans exported configs (under `/etc/pve/nodes/<node>/...`) and applies them via `pvesh set /nodes/<node>/qemu/<vmid>/config`
+1. **VM/CT configs**: Scans exported configs (under `/etc/pve/nodes/<node>/...`) and applies them via `pvesh set /nodes/<node>/qemu/<vmid>/config` (create-only keys such as `meta`/`ostemplate` are stripped; if the set fails and the guest is not running, the exported conf is written into pmxcfs; a missing guest is registered by writing its conf)
    - If the target node hostname differs from the hostname stored in the backup (common after hardware migration / reinstall), ProxSave detects the mismatch and prompts you to select the exported node directory to import from (instead of silently reporting "No VM/CT configs found").
-2. **Storage configuration**: applies each `storage.cfg` block via `pvesh create /storage --storage=<id> --type=<type> ...`
-3. **Datacenter configuration**: Applies `datacenter.cfg` via `pvesh set /cluster/config`
+2. **Storage configuration**: applies each `storage.cfg` block via `pvesh create /storage --storage=<id> --type=<type> ...`, falling back to `pvesh set /storage/<id>` when the definition already exists (as `local` always does)
+3. **Datacenter configuration**: writes `datacenter.cfg` into pmxcfs (`/etc/pve`), which replicates it cluster-wide - the API has no whole-file endpoint for it
 
 Each action prompts for confirmation before execution.
 
@@ -1470,16 +1470,16 @@ Parses `storage.cfg` and applies each storage definition:
 
 ```text
 Datacenter configuration found: /opt/proxsave/proxmox-config-export-*/etc/pve/datacenter.cfg
-Apply datacenter.cfg via pvesh? (y/N): y
+Apply datacenter.cfg? (y/N): y
 ```
 
 Applies datacenter-wide settings:
-- Applied via: `pvesh set /cluster/config -conf <file>`
-- Affects all cluster nodes
+- Applied via: file write into pmxcfs (`/etc/pve/datacenter.cfg`)
+- Affects all cluster nodes (pmxcfs replicates the file cluster-wide)
 
 **Interactive Flow**:
 ```text
-SAFE cluster restore: applying configs via pvesh (node=pve01)
+SAFE cluster restore: applying configs (node=pve01)
 
 Apply PVE resource mappings (pvesh)? (y/N): y
 Applied pci mapping device1
@@ -1501,7 +1501,7 @@ Applied storage definition backup-nfs
 Storage apply completed: ok=2 failed=0
 
 Datacenter configuration found: .../etc/pve/datacenter.cfg
-Apply datacenter.cfg via pvesh? (y/N): n
+Apply datacenter.cfg? (y/N): n
 Skipping datacenter.cfg apply
 
 Pools apply (membership) completed: ok=1 failed=0
@@ -1583,7 +1583,7 @@ These configurations are included in every backup and can be restored using **th
 
 5. **After extraction completes**, you'll see:
    ```text
-   SAFE cluster restore: applying configs via pvesh (node=pve01)
+   SAFE cluster restore: applying configs (node=pve01)
 
    Found 5 VM/CT configs for node pve01
    Apply all VM/CT configs via pvesh? (y/N): y

--- a/docs/RESTORE_TECHNICAL.md
+++ b/docs/RESTORE_TECHNICAL.md
@@ -1140,44 +1140,37 @@ defer func() {
 
 ### Standalone vs Cluster Detection
 
-The `ClusterMode` field in the backup manifest determines restore behavior:
-
-| Manifest Value | Detection | Prompt Shown | Restore Behavior |
-|----------------|-----------|--------------|------------------|
-| `"standalone"` or empty | Standalone | NO | Direct database restore |
-| `"cluster"` | Cluster | YES | SAFE or RECOVERY choice |
-
-**ClusterMode is set during backup** in `backup_run_helpers.go` (`standaloneClusterMode()`):
-```go
-func standaloneClusterMode(collector *backup.Collector) string {
-    if collector.IsClusteredPVE() {
-        return "cluster"
-    }
-    return "standalone"
-}
-```
+The analyzed archive payload determines restore behavior. `AnalyzeRestoreArchive()`
+sets `RestoreDecisionInfo.ClusterPayload` when the archive contains the
+`pve_cluster` category, and `PlanRestore()` carries that value into the plan. The
+manifest's `ClusterMode` is retained as consistency metadata: a disagreement with
+the payload produces a warning, but does not override the payload decision.
 
 ### Detection Logic
 
-The workflow detects cluster backups via the manifest's `ClusterMode` field:
+The SAFE/RECOVERY prompt is shown only when the selected plan both contains the
+payload and would otherwise restore the `pve_cluster` category normally:
 
 ```go
-if systemType == SystemTypePVE &&
-   strings.EqualFold(strings.TrimSpace(candidate.Manifest.ClusterMode), "cluster") &&
-   hasCategoryID(selectedCategories, "pve_cluster") {
-    // Cluster backup detected, prompt for SAFE vs RECOVERY
+plan := PlanRestore(decisionInfo.ClusterPayload, selectedCategories, systemType, mode)
+if plan.ClusterBackup && plan.NeedsClusterRestore {
+    // Prompt for SAFE vs RECOVERY.
 }
 ```
 
-**For standalone backups**: This condition is FALSE, so:
-- No SAFE/RECOVERY prompt is shown
-- `pve_cluster` remains in `normalCategories`
-- Database is restored directly (same as RECOVERY mode)
+| Analyzed archive and selection | Prompt | `config.db` handling |
+|--------------------------------|--------|----------------------|
+| No `pve_cluster` payload, or category not selected | No | Not restored |
+| Payload selected, manifest says standalone or is empty | Yes | SAFE exports it; RECOVERY restores it |
+| Payload selected, manifest says cluster | Yes | SAFE exports it; RECOVERY restores it |
+| Archive analysis failed and full-restore fallback is used | No | Intentionally skipped |
 
-**For cluster backups**: This condition is TRUE, so:
-- SAFE/RECOVERY prompt is shown
-- User chooses restore strategy
-- SAFE mode redirects to export + pvesh API
+A standalone PVE backup commonly contains `pve_cluster` data, so it normally gets
+the same choice. SAFE moves that category to export-only and leaves
+`/var/lib/pve-cluster/config.db` untouched. RECOVERY keeps it in the normal
+restore set, stops PVE cluster services, unmounts `/etc/pve`, restores the
+database, then restarts the services. Staged `/etc/pve` applies are skipped in
+RECOVERY because the restored database owns that state.
 
 ### SAFE Mode Implementation
 

--- a/docs/RESTORE_TECHNICAL.md
+++ b/docs/RESTORE_TECHNICAL.md
@@ -1231,10 +1231,13 @@ func runSafeClusterApply(ctx context.Context, reader *bufio.Reader, exportRoot s
         applyStorageCfg(ctx, storageCfg, logger)
     }
 
-    // 3. Apply datacenter.cfg
+    // 3. Apply datacenter.cfg - written into pmxcfs: the API has no whole-file
+    // endpoint (a live node answers `pvesh set /cluster/config` with
+    // "No 'set' handler defined"), and /etc/pve is the cluster-replicated
+    // filesystem, so the file write IS the cluster-wide apply.
     dcCfg := filepath.Join(exportRoot, "etc/pve/datacenter.cfg")
-    if fileExists(dcCfg) && promptYesNo("Apply datacenter.cfg via pvesh?") {
-        runPvesh(ctx, logger, []string{"set", "/cluster/config", "-conf", dcCfg})
+    if fileExists(dcCfg) && promptYesNo("Apply datacenter.cfg?") {
+        pmxcfsWriteFile(logger, "datacenter.cfg", readFile(dcCfg))
     }
 }
 ```

--- a/docs/RESTORE_TECHNICAL.md
+++ b/docs/RESTORE_TECHNICAL.md
@@ -1212,9 +1212,12 @@ After extraction in SAFE mode, `runSafeClusterApply()` offers API-based restorat
 
 **Key Functions**:
 - `scanVMConfigs()`: Scans `<export>/etc/pve/nodes/<node>/qemu-server/` and `lxc/`
-- `applyVMConfigs()`: Applies each config via `pvesh set /nodes/<node>/<type>/<vmid>/config`
+- `loadPVEGuestInventory()`: Loads and strictly validates the cluster-wide `qemu`/`lxc` ownership map from `/cluster/resources`
+- `applyVMConfigs()`: Classifies every VMID before mutation; skips remote/type-mismatched guests, updates matching local guests through `pvesh`, and registers cluster-wide-absent guests through pmxcfs
 - `applyStorageCfg()`: Parses storage.cfg blocks and applies via `pvesh set /cluster/storage/<id>`
 - `runPvesh()`: Executes pvesh commands with logging
+
+Guest apply is fail-closed. The inventory is loaded once before the loop; any command, JSON validation, incomplete-record, or duplicate-VMID error marks the selected guest entries failed without mutating them. A failed API update may fall back to the staged pmxcfs file only when a JSON `status/current` response explicitly says `stopped`.
 
 **Flow**:
 ```go

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -226,6 +226,7 @@ cat /proc/self/gid_map
 
 **Resolution**:
 ```bash
+proxsave --daemon-status --log-level debug      # first: READY/REFUSED plus UID and path evidence
 journalctl -u proxsave-daemon.service | grep PERSONAL_SCRIPT   # a gate refusal names the reason
 namei -l /path/to/my-pre-run.sh         # inspect ownership and mode of every path component
 ls -l /usr/local/bin/my-pre-run.sh      # owned by root, mode 0700 or 0755, no group/other write
@@ -234,6 +235,11 @@ head -1 /usr/local/bin/my-pre-run.sh    # a shebang, e.g. #!/bin/sh
 grep PERSONAL_SCRIPT /opt/proxsave/configs/backup.env
 systemctl restart proxsave-daemon.service   # the paths are read at daemon start
 ```
+- The status command is read-only: it does not execute either script, start a backup, acquire the
+  daemon lock, or send a healthcheck ping. `READY` means the path passes the same gate used by the
+  daemon; `REFUSED` gives the exact reason; `NOT CONFIGURED` means the setting is empty. Debug output
+  says whether the UID came from the live daemon or from the current-process fallback and lists the
+  owner/mode evidence. A script refusal does not change the command's daemon-health exit code.
 - Do not change a user's home directory to `root:root`. Copy or move the script to a fully
   root-owned path such as `/usr/local/bin`, update `backup.env`, then restart the daemon.
 - Have the script write its own log if you want a record: ProxSave will not write one for you.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -227,12 +227,15 @@ cat /proc/self/gid_map
 **Resolution**:
 ```bash
 journalctl -u proxsave-daemon.service | grep PERSONAL_SCRIPT   # a gate refusal names the reason
+namei -l /path/to/my-pre-run.sh         # inspect ownership and mode of every path component
 ls -l /usr/local/bin/my-pre-run.sh      # owned by root, mode 0700 or 0755, no group/other write
 head -1 /usr/local/bin/my-pre-run.sh    # a shebang, e.g. #!/bin/sh
 /usr/local/bin/my-pre-run.sh; echo $?   # runs by hand, as root
 grep PERSONAL_SCRIPT /opt/proxsave/configs/backup.env
 systemctl restart proxsave-daemon.service   # the paths are read at daemon start
 ```
+- Do not change a user's home directory to `root:root`. Copy or move the script to a fully
+  root-owned path such as `/usr/local/bin`, update `backup.env`, then restart the daemon.
 - Have the script write its own log if you want a record: ProxSave will not write one for you.
 - A script still running after 10 minutes is killed, silently, and the daemon carries on. The
   one exception is the abandoned-child unwind, where the post script is started and left to

--- a/internal/backup/archiver.go
+++ b/internal/backup/archiver.go
@@ -964,6 +964,8 @@ func (a *Archiver) addToTar(ctx context.Context, tarWriter *tar.Writer, sourceDi
 		if stat, ok := linkInfo.Sys().(*syscall.Stat_t); ok {
 			header.Uid = int(stat.Uid)
 			header.Gid = int(stat.Gid)
+			// ProxSave is built and released only for linux/amd64, where these
+			// Timespec fields are int64; 32-bit syscall widths are unsupported.
 			// Preserve access and modification times
 			header.AccessTime = time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
 			header.ChangeTime = time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec)

--- a/internal/backup/collector.go
+++ b/internal/backup/collector.go
@@ -727,6 +727,8 @@ func (c *Collector) applyMetadata(dest string, info os.FileInfo) {
 	}
 
 	if ok {
+		// ProxSave is built and released only for linux/amd64, where these
+		// Timespec fields are int64; 32-bit syscall widths are unsupported.
 		atime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
 		mtime := time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec)
 		if err := os.Chtimes(dest, atime, mtime); err != nil {

--- a/internal/backup/collector_bricks.go
+++ b/internal/backup/collector_bricks.go
@@ -294,7 +294,7 @@ func runRecipe(ctx context.Context, r recipe, state *collectionState) error {
 	if state == nil {
 		return fmt.Errorf("collection state is required")
 	}
-	for _, brick := range r.Bricks {
+	for i, brick := range r.Bricks {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -302,6 +302,16 @@ func runRecipe(ctx context.Context, r recipe, state *collectionState) error {
 			return fmt.Errorf("recipe %s brick %s has no runner", r.Name, brick.ID)
 		}
 		if err := brick.Run(ctx, state); err != nil {
+			// The abort itself is the caller's error to escalate; what nothing
+			// traced before is the TAIL: bricks that never ran record nothing, not
+			// even in the manifest, so their targets were missing from the archive
+			// with no line at any level. Name the hole before propagating.
+			if rest := r.Bricks[i+1:]; len(rest) > 0 && state.collector != nil && state.collector.logger != nil {
+				for _, skipped := range rest {
+					state.collector.logger.Debug("Collection: recipe %s - brick %q never ran", r.Name, skipped.ID)
+				}
+				state.collector.logger.Warning("Collection: recipe %s aborted at brick %q - %d later bricks never ran, their targets are missing from this backup", r.Name, brick.ID, len(rest))
+			}
 			return err
 		}
 	}

--- a/internal/backup/collector_failure_level_test.go
+++ b/internal/backup/collector_failure_level_test.go
@@ -111,6 +111,88 @@ func TestInterfacesCopyFailureWarnsAndTellsTheTruth(t *testing.T) {
 	}
 }
 
+func TestOptionalNetworkCopyFailuresAreWarnings(t *testing.T) {
+	tests := []struct {
+		path             string
+		isDir            bool
+		warningNeedle    string
+		falseMissingText string
+	}{
+		{
+			path:          "/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg",
+			warningNeedle: "Failed to collect /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg:",
+		},
+		{
+			path:          "/etc/dnsmasq.d/lxc-vmbr1.conf",
+			warningNeedle: "Failed to collect /etc/dnsmasq.d/lxc-vmbr1.conf:",
+		},
+		{
+			path:             "/etc/netplan",
+			isDir:            true,
+			warningNeedle:    "Failed to copy directory Netplan configuration:",
+			falseMissingText: "No /etc/netplan found",
+		},
+		{
+			path:             "/etc/systemd/network",
+			isDir:            true,
+			warningNeedle:    "Failed to copy directory systemd-networkd configuration:",
+			falseMissingText: "No /etc/systemd/network found",
+		},
+		{
+			path:             "/etc/NetworkManager/system-connections",
+			isDir:            true,
+			warningNeedle:    "Failed to copy directory NetworkManager connections:",
+			falseMissingText: "No NetworkManager system-connections found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.TrimPrefix(tt.path, "/etc/"), func(t *testing.T) {
+			sysRoot := t.TempDir()
+			source := filepath.Join(sysRoot, strings.TrimPrefix(tt.path, "/"))
+			if tt.isDir {
+				if err := os.MkdirAll(source, 0o755); err != nil {
+					t.Fatalf("create source directory: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(source, "entry.conf"), []byte("data\n"), 0o600); err != nil {
+					t.Fatalf("create source entry: %v", err)
+				}
+			} else {
+				if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+					t.Fatalf("create source parent: %v", err)
+				}
+				if err := os.WriteFile(source, []byte("data\n"), 0o600); err != nil {
+					t.Fatalf("create source file: %v", err)
+				}
+			}
+
+			c, buf := failureLevelCollector(t, sysRoot, &CollectorConfig{BackupNetworkConfigs: true})
+			destination := filepath.Join(c.tempDir, strings.TrimPrefix(tt.path, "/"))
+			if tt.isDir {
+				if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+					t.Fatalf("create destination parent: %v", err)
+				}
+				if err := os.WriteFile(destination, []byte("block"), 0o600); err != nil {
+					t.Fatalf("create destination blocker: %v", err)
+				}
+			} else if err := os.MkdirAll(destination, 0o755); err != nil {
+				t.Fatalf("create destination blocker: %v", err)
+			}
+
+			if err := c.collectSystemNetworkStatic(context.Background()); err != nil {
+				t.Fatalf("collectSystemNetworkStatic: %v", err)
+			}
+			out := buf.String()
+			if hits := warningsMatching(out, tt.warningNeedle); len(hits) != 1 {
+				t.Fatalf("a real copy failure for %s must produce one WARNING with its cause, got %d:\n%s", tt.path, len(hits), buf.String())
+			}
+			if tt.falseMissingText != "" && strings.Contains(out, tt.falseMissingText) {
+				t.Fatalf("a real copy failure for %s was mislabeled as missing:\n%s", tt.path, out)
+			}
+		})
+	}
+}
+
 func TestCustomPathCopyFailureIsAWarning(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("needs non-root so mode 0000 denies the read")

--- a/internal/backup/collector_failure_level_test.go
+++ b/internal/backup/collector_failure_level_test.go
@@ -1,0 +1,175 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// A REAL copy failure of a single critical file (/etc/shadow class), of
+// /etc/network/interfaces, or of a CUSTOM_BACKUP_PATHS entry was Debug-only since
+// the initial Go port: WarningCount, exit code, notifications and healthchecks all
+// stayed green while the archive silently lacked the file. The same recipe already
+// warns loudly for fstab, logrotate and mount units, so these were the odd mute
+// ones out, not a doctrine. Not-found stays silent by design (safeCopyFile returns
+// nil for it); only real failures speak.
+
+func levelOf(line string) string {
+	_, rest, found := strings.Cut(line, "] ")
+	if !found {
+		return ""
+	}
+	f := strings.Fields(rest)
+	if len(f) == 0 {
+		return ""
+	}
+	return f[0]
+}
+
+func warningsMatching(out, needle string) []string {
+	var hits []string
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, needle) && levelOf(l) == "WARNING" {
+			hits = append(hits, l)
+		}
+	}
+	return hits
+}
+
+func failureLevelCollector(t *testing.T, sysRoot string, cfg *CollectorConfig) (*Collector, *bytes.Buffer) {
+	t.Helper()
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	cfg.SystemRootPrefix = sysRoot
+	return NewCollector(logger, cfg, t.TempDir(), types.ProxmoxVE, false), buf
+}
+
+func writeUnreadable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCriticalFileCopyFailureIsAWarning(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("needs non-root so mode 0000 denies the read")
+	}
+	sysRoot := t.TempDir()
+	writeUnreadable(t, filepath.Join(sysRoot, "etc", "shadow"))
+
+	c, buf := failureLevelCollector(t, sysRoot, &CollectorConfig{})
+	if err := c.collectCriticalFiles(context.Background()); err != nil {
+		t.Fatalf("collectCriticalFiles: %v", err)
+	}
+	out := buf.String()
+
+	if hits := warningsMatching(out, "Failed to copy critical file"); len(hits) != 1 || !strings.Contains(hits[0], "etc/shadow") {
+		t.Fatalf("an unreadable /etc/shadow must produce exactly one WARNING naming it, got %d:\n%s", len(hits), out)
+	}
+	// passwd/group/gshadow/sudoers are simply absent from this root: not-found
+	// stays silent, no warning may name them.
+	for _, quiet := range []string{"passwd", "gshadow", "sudoers"} {
+		if hits := warningsMatching(out, quiet); len(hits) != 0 {
+			t.Fatalf("a missing %s warned; not-found must stay silent:\n%s", quiet, out)
+		}
+	}
+}
+
+func TestInterfacesCopyFailureWarnsAndTellsTheTruth(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("needs non-root so mode 0000 denies the read")
+	}
+	sysRoot := t.TempDir()
+	writeUnreadable(t, filepath.Join(sysRoot, "etc", "network", "interfaces"))
+
+	c, buf := failureLevelCollector(t, sysRoot, &CollectorConfig{BackupNetworkConfigs: true})
+	if err := c.collectSystemNetworkStatic(context.Background()); err != nil {
+		t.Fatalf("collectSystemNetworkStatic: %v", err)
+	}
+	out := buf.String()
+
+	if hits := warningsMatching(out, "Failed to collect /etc/network/interfaces:"); len(hits) != 1 {
+		t.Fatalf("an unreadable interfaces file must WARN with the real cause, got %d:\n%s", len(hits), out)
+	}
+	if strings.Contains(out, "No /etc/network/interfaces found") {
+		t.Fatalf("the lying not-found message is still emitted for a real failure:\n%s", out)
+	}
+}
+
+func TestCustomPathCopyFailureIsAWarning(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("needs non-root so mode 0000 denies the read")
+	}
+	sysRoot := t.TempDir()
+	writeUnreadable(t, filepath.Join(sysRoot, "data", "app.key"))
+
+	c, buf := failureLevelCollector(t, sysRoot, &CollectorConfig{CustomBackupPaths: []string{"/data/app.key"}})
+	if err := c.collectCustomPaths(context.Background()); err != nil {
+		t.Fatalf("collectCustomPaths: %v", err)
+	}
+	if hits := warningsMatching(buf.String(), "Failed to copy custom file"); len(hits) != 1 || !strings.Contains(hits[0], "app.key") {
+		t.Fatalf("an unreadable custom file must WARN naming it, got %d:\n%s", len(hits), buf.String())
+	}
+}
+
+// When a brick returns an error the recipe aborts, and everything scheduled after
+// it used to vanish with no trace at any level (nor in the manifest: bricks that
+// never ran record nothing). The abort now names the recipe, the failed brick and
+// how many bricks never ran, so the absence is visible in the log.
+func TestRunRecipeAbortTracesUnattemptedBricks(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	c := NewCollector(logger, &CollectorConfig{}, t.TempDir(), types.ProxmoxVE, false)
+	state := newCollectionState(c)
+
+	ran := []string{}
+	mk := func(id string, fail bool) collectionBrick {
+		return brick(BrickID(id), id, func(context.Context, *collectionState) error {
+			ran = append(ran, id)
+			if fail {
+				return errors.New("boom")
+			}
+			return nil
+		})
+	}
+	r := recipe{Name: "system", Bricks: []collectionBrick{mk("a", false), mk("b", true), mk("c", false), mk("d", false)}}
+
+	if err := runRecipe(context.Background(), r, state); err == nil {
+		t.Fatal("runRecipe must still propagate the brick error")
+	}
+	if len(ran) != 2 {
+		t.Fatalf("bricks ran = %v; the abort semantics must not change", ran)
+	}
+	out := buf.String()
+	hits := warningsMatching(out, "aborted at brick")
+	if len(hits) != 1 || !strings.Contains(hits[0], "system") || !strings.Contains(hits[0], "\"b\"") || !strings.Contains(hits[0], "2 ") {
+		t.Fatalf("the abort must WARN naming recipe, failed brick and the 2 unattempted bricks, got:\n%s", out)
+	}
+	for _, id := range []string{"c", "d"} {
+		found := false
+		for _, l := range strings.Split(out, "\n") {
+			if levelOf(l) == "DEBUG" && strings.Contains(l, "never ran") && strings.Contains(l, "\""+id+"\"") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("unattempted brick %q has no Debug trace:\n%s", id, out)
+		}
+	}
+}

--- a/internal/backup/collector_pve.go
+++ b/internal/backup/collector_pve.go
@@ -426,8 +426,17 @@ func (c *Collector) collectPVEClusterSnapshot(ctx context.Context, clustered boo
 		if info, err := os.Stat(configDB); err == nil && !info.IsDir() {
 			target := c.targetPathFor(configDB)
 			c.logger.Debug("Copying PVE cluster database %s to %s", configDB, target)
-			if err := c.safeCopyFile(ctx, configDB, target, "PVE cluster database"); err != nil {
-				c.logger.Warning("Failed to copy PVE cluster database %s: %v", configDB, err)
+			// config.db runs in WAL mode under a live pmxcfs: the base file is
+			// stale up to the last checkpoint (measured: base 40KB hours old,
+			// -wal 4.1MB current) and a raw read can tear a page mid-write.
+			// sqlite3's .backup goes through the online-backup API, which reads
+			// base+WAL consistently - and this snapshot lands LAST on the target,
+			// after the clustered directory copy, so it is what RECOVERY restores.
+			if err := c.snapshotSQLiteDB(ctx, configDB, target); err != nil {
+				c.logger.Warning("PVE cluster database %s: sqlite snapshot failed (%v) - falling back to a raw copy, which can tear mid-write and misses WAL data not yet checkpointed", configDB, err)
+				if err := c.safeCopyFile(ctx, configDB, target, "PVE cluster database"); err != nil {
+					c.logger.Warning("Failed to copy PVE cluster database %s: %v", configDB, err)
+				}
 			}
 		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 			c.logger.Warning("Failed to stat PVE cluster database %s: %v", configDB, err)
@@ -898,6 +907,37 @@ func (c *Collector) effectivePVEConfigPath() string {
 		return c.systemPath(path)
 	}
 	return c.systemPath("/etc/pve")
+}
+
+// snapshotSQLiteDB captures a live SQLite database consistently via sqlite3's
+// ".backup" dot-command (the online-backup API): it takes a shared lock, reads
+// base+WAL as one coherent snapshot, and writes a plain journal-less database
+// file - exactly what a verbatim restore wants. The 5s busy timeout rides out a
+// pmxcfs commit holding the write lock. Any failure is the caller's cue to fall
+// back to a raw copy, loudly.
+func (c *Collector) snapshotSQLiteDB(ctx context.Context, src, dest string) error {
+	if _, err := c.depLookPath("sqlite3"); err != nil {
+		return fmt.Errorf("sqlite3 not available: %w", err)
+	}
+	if strings.ContainsAny(dest, `"`+"\n") {
+		return fmt.Errorf("destination %q not representable in a sqlite3 dot-command", dest)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		return fmt.Errorf("create snapshot dir: %w", err)
+	}
+	out, err := c.depRunCommand(ctx, "sqlite3", "-cmd", ".timeout 5000", src, fmt.Sprintf(".backup %q", dest))
+	if err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return fmt.Errorf("%s: %w", msg, err)
+		}
+		return err
+	}
+	c.incFilesProcessed()
+	if info, statErr := os.Stat(dest); statErr == nil {
+		c.addBytesCollected(info.Size())
+	}
+	c.logger.Debug("Successfully captured PVE cluster database via sqlite3 .backup: %s", dest)
+	return nil
 }
 
 func (c *Collector) effectivePVEClusterPath() string {

--- a/internal/backup/collector_pve.go
+++ b/internal/backup/collector_pve.go
@@ -916,6 +916,11 @@ func (c *Collector) effectivePVEConfigPath() string {
 // pmxcfs commit holding the write lock. Any failure is the caller's cue to fall
 // back to a raw copy, loudly.
 func (c *Collector) snapshotSQLiteDB(ctx context.Context, src, dest string) error {
+	if c.dryRun {
+		c.logger.Debug("[DRY RUN] Would capture PVE cluster database via sqlite3 .backup: %s", dest)
+		c.incFilesProcessed()
+		return nil
+	}
 	if _, err := c.depLookPath("sqlite3"); err != nil {
 		return fmt.Errorf("sqlite3 not available: %w", err)
 	}

--- a/internal/backup/collector_pve_configdb_test.go
+++ b/internal/backup/collector_pve_configdb_test.go
@@ -1,0 +1,127 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// config.db is the pmxcfs SQLite backing store, the artifact RECOVERY writes back
+// verbatim - and it runs in WAL mode: on a live node the base file is stale up to
+// the last checkpoint (measured on the test node: base 40KB hours old, -wal 4.1MB
+// current) and a plain io.Copy can also tear a page mid-write. The capture must go
+// through sqlite3's .backup (the online-backup API reads base+WAL consistently);
+// the raw copy survives only as a loudly-announced fallback.
+
+func configDBCollector(t *testing.T, deps CollectorDeps) (*Collector, string, *bytes.Buffer) {
+	t.Helper()
+	clusterDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(clusterDir, "config.db"), []byte("RAW-BASE-BYTES"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	cfg := &CollectorConfig{BackupClusterConfig: true, BackupPVEACL: true, PVEClusterPath: clusterDir}
+	return NewCollectorWithDeps(logger, cfg, t.TempDir(), types.ProxmoxVE, false, deps), clusterDir, buf
+}
+
+func TestConfigDBCaptureGoesThroughSQLiteBackup(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	deps := CollectorDeps{
+		LookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			gotName = name
+			gotArgs = args
+			// The real .backup writes the destination; the fake proves the
+			// collector trusts THIS artifact and does not overwrite it raw.
+			dest := strings.TrimSuffix(strings.TrimPrefix(args[len(args)-1], `.backup "`), `"`)
+			if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+				return nil, err
+			}
+			return nil, os.WriteFile(dest, []byte("SQLITE-SNAPSHOT"), 0o600)
+		},
+	}
+	c, clusterDir, buf := configDBCollector(t, deps)
+
+	if err := c.collectPVEClusterSnapshot(context.Background(), false); err != nil {
+		t.Fatalf("collectPVEClusterSnapshot: %v", err)
+	}
+	if gotName != "sqlite3" {
+		t.Fatalf("config.db was not captured via sqlite3 (ran %q %v):\n%s", gotName, gotArgs, buf.String())
+	}
+	src := filepath.Join(clusterDir, "config.db")
+	wantArgs := fmt.Sprintf("-cmd|.timeout 5000|%s|.backup \"%s\"", src, c.targetPathFor(src))
+	if strings.Join(gotArgs, "|") != wantArgs {
+		t.Fatalf("sqlite3 argv drifted:\n got %q\nwant %q", strings.Join(gotArgs, "|"), wantArgs)
+	}
+	captured, err := os.ReadFile(c.targetPathFor(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(captured) != "SQLITE-SNAPSHOT" {
+		t.Fatalf("the snapshot artifact was overwritten by a raw copy: %q", captured)
+	}
+	if strings.Contains(buf.String(), "WARNING") {
+		t.Fatalf("a clean snapshot must not warn:\n%s", buf.String())
+	}
+}
+
+func TestConfigDBRawFallbackIsLoud(t *testing.T) {
+	deps := CollectorDeps{
+		LookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte("Error: database is locked"), errors.New("exit status 1")
+		},
+	}
+	c, clusterDir, buf := configDBCollector(t, deps)
+
+	if err := c.collectPVEClusterSnapshot(context.Background(), false); err != nil {
+		t.Fatalf("collectPVEClusterSnapshot: %v", err)
+	}
+	src := filepath.Join(clusterDir, "config.db")
+	captured, err := os.ReadFile(c.targetPathFor(src))
+	if err != nil {
+		t.Fatalf("the raw fallback did not capture config.db at all: %v", err)
+	}
+	if string(captured) != "RAW-BASE-BYTES" {
+		t.Fatalf("fallback content drifted: %q", captured)
+	}
+	out := buf.String()
+	var warned bool
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "] WARNING") && strings.Contains(l, "raw copy") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("the raw fallback must WARN that the capture can be torn and misses WAL data:\n%s", out)
+	}
+}
+
+func TestConfigDBWithoutSQLite3FallsBackWithoutRunning(t *testing.T) {
+	ran := false
+	deps := CollectorDeps{
+		LookPath:   func(name string) (string, error) { return "", errors.New("not found") },
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) { ran = true; return nil, nil },
+	}
+	c, clusterDir, buf := configDBCollector(t, deps)
+	if err := c.collectPVEClusterSnapshot(context.Background(), false); err != nil {
+		t.Fatalf("collectPVEClusterSnapshot: %v", err)
+	}
+	if ran {
+		t.Fatal("sqlite3 was executed despite LookPath saying it is absent")
+	}
+	if captured, err := os.ReadFile(c.targetPathFor(filepath.Join(clusterDir, "config.db"))); err != nil || string(captured) != "RAW-BASE-BYTES" {
+		t.Fatalf("raw fallback missing without sqlite3: %q err=%v\n%s", captured, err, buf.String())
+	}
+}

--- a/internal/backup/collector_pve_configdb_test.go
+++ b/internal/backup/collector_pve_configdb_test.go
@@ -34,6 +34,51 @@ func configDBCollector(t *testing.T, deps CollectorDeps) (*Collector, string, *b
 	return NewCollectorWithDeps(logger, cfg, t.TempDir(), types.ProxmoxVE, false, deps), clusterDir, buf
 }
 
+func TestConfigDBDryRunDoesNotWriteOrInvokeSQLite(t *testing.T) {
+	var lookups, runs int
+	deps := CollectorDeps{
+		LookPath: func(name string) (string, error) {
+			lookups++
+			return "/usr/bin/" + name, nil
+		},
+		RunCommand: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			runs++
+			return nil, nil
+		},
+	}
+	c, clusterDir, buf := configDBCollector(t, deps)
+	c.dryRun = true
+	src := filepath.Join(clusterDir, "config.db")
+	dest := c.targetPathFor(src)
+	destDir := filepath.Dir(dest)
+
+	if _, err := os.Stat(destDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("test precondition: destination directory exists before dry-run: %v", err)
+	}
+	if err := c.collectPVEClusterSnapshot(context.Background(), false); err != nil {
+		t.Fatalf("collectPVEClusterSnapshot: %v", err)
+	}
+	if lookups != 0 || runs != 0 {
+		t.Fatalf("dry-run dependency calls = (LookPath=%d, RunCommand=%d), want (0, 0)", lookups, runs)
+	}
+	if _, err := os.Stat(destDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dry-run created destination directory %s: %v", destDir, err)
+	}
+	if _, err := os.Stat(dest); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dry-run created SQLite snapshot %s: %v", dest, err)
+	}
+	stats := c.GetStats()
+	if stats.FilesProcessed != 1 {
+		t.Fatalf("FilesProcessed = %d, want 1 simulated config.db capture", stats.FilesProcessed)
+	}
+	if stats.BytesCollected != 0 {
+		t.Fatalf("BytesCollected = %d, want 0 in dry-run", stats.BytesCollected)
+	}
+	if !strings.Contains(buf.String(), "[DRY RUN] Would capture PVE cluster database via sqlite3 .backup") {
+		t.Fatalf("missing dry-run SQLite capture diagnostic:\n%s", buf.String())
+	}
+}
+
 func TestConfigDBCaptureGoesThroughSQLiteBackup(t *testing.T) {
 	var gotName string
 	var gotArgs []string

--- a/internal/backup/collector_system.go
+++ b/internal/backup/collector_system.go
@@ -164,18 +164,20 @@ func (c *Collector) collectSystemNetworkStatic(ctx context.Context) error {
 	}
 
 	c.logger.Debug("Collecting network configuration files (/etc/network/*)")
+	// Both helpers answer a missing source with nil, so err here is a REAL copy
+	// failure; the old "No ... found" Debug wording was false from the first port.
 	if err := c.safeCopyFile(ctx,
 		c.systemPath("/etc/network/interfaces"),
 		filepath.Join(c.tempDir, "etc/network/interfaces"),
 		"Network interfaces"); err != nil {
-		c.logger.Debug("No /etc/network/interfaces found")
+		c.logger.Warning("Failed to collect /etc/network/interfaces: %v", err)
 	}
 
 	if err := c.safeCopyDir(ctx,
 		c.systemPath("/etc/network/interfaces.d"),
 		filepath.Join(c.tempDir, "etc/network/interfaces.d"),
 		"Network interfaces.d"); err != nil {
-		c.logger.Debug("No /etc/network/interfaces.d found")
+		c.logger.Warning("Failed to collect /etc/network/interfaces.d: %v", err)
 	}
 
 	extraNetworkFiles := []struct {
@@ -1339,8 +1341,11 @@ func (c *Collector) collectCriticalFiles(ctx context.Context) error {
 			return err
 		}
 		dest := filepath.Join(c.tempDir, strings.TrimPrefix(file, "/"))
+		// A returned error is ALWAYS a real failure (safeCopyFile answers a missing
+		// source with nil), and these are the files a restore needs most: mute at
+		// Debug since the initial Go port while fstab and logrotate siblings warned.
 		if err := c.safeCopyFile(ctx, c.systemPath(file), dest, fmt.Sprintf("critical file %s", filepath.Base(file))); err != nil && !errors.Is(err, os.ErrNotExist) {
-			c.logger.Debug("Failed to copy critical file %s: %v", file, err)
+			c.logger.Warning("Failed to copy critical file %s: %v", file, err)
 		}
 	}
 
@@ -1406,19 +1411,21 @@ func (c *Collector) collectCustomPaths(ctx context.Context) error {
 		info, err := os.Lstat(physicalPath)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				c.logger.Debug("Custom path %s not accessible: %v", physicalPath, err)
+				c.logger.Warning("Custom path %s not accessible: %v", physicalPath, err)
 			}
 			continue
 		}
 
 		dest := filepath.Join(c.tempDir, strings.TrimPrefix(logicalPath, "/"))
+		// The operator asked for these by name; a real copy failure (not-found is
+		// answered with nil inside the helpers) must not hide at Debug.
 		if info.IsDir() {
 			if err := c.safeCopyDir(ctx, physicalPath, dest, fmt.Sprintf("custom directory %s", logicalPath)); err != nil {
-				c.logger.Debug("Failed to copy custom directory %s: %v", physicalPath, err)
+				c.logger.Warning("Failed to copy custom directory %s: %v", physicalPath, err)
 			}
 		} else {
 			if err := c.safeCopyFile(ctx, physicalPath, dest, fmt.Sprintf("custom file %s", filepath.Base(logicalPath))); err != nil {
-				c.logger.Debug("Failed to copy custom file %s: %v", physicalPath, err)
+				c.logger.Warning("Failed to copy custom file %s: %v", physicalPath, err)
 			}
 		}
 	}

--- a/internal/backup/collector_system.go
+++ b/internal/backup/collector_system.go
@@ -192,7 +192,7 @@ func (c *Collector) collectSystemNetworkStatic(ctx context.Context) error {
 			c.systemPath(file.path),
 			filepath.Join(c.tempDir, strings.TrimPrefix(file.path, "/")),
 			file.desc); err != nil {
-			c.logger.Debug("Failed to collect %s: %v", file.path, err)
+			c.logger.Warning("Failed to collect %s: %v", file.path, err)
 		}
 	}
 
@@ -200,21 +200,21 @@ func (c *Collector) collectSystemNetworkStatic(ctx context.Context) error {
 		c.systemPath("/etc/netplan"),
 		filepath.Join(c.tempDir, "etc/netplan"),
 		"Netplan configuration"); err != nil {
-		c.logger.Debug("No /etc/netplan found")
+		c.logger.Debug("Failed to collect /etc/netplan: %v", err)
 	}
 
 	if err := c.safeCopyDir(ctx,
 		c.systemPath("/etc/systemd/network"),
 		filepath.Join(c.tempDir, "etc/systemd/network"),
 		"systemd-networkd configuration"); err != nil {
-		c.logger.Debug("No /etc/systemd/network found")
+		c.logger.Debug("Failed to collect /etc/systemd/network: %v", err)
 	}
 
 	if err := c.safeCopyDir(ctx,
 		c.systemPath("/etc/NetworkManager/system-connections"),
 		filepath.Join(c.tempDir, "etc/NetworkManager/system-connections"),
 		"NetworkManager connections"); err != nil {
-		c.logger.Debug("No NetworkManager system-connections found")
+		c.logger.Debug("Failed to collect /etc/NetworkManager/system-connections: %v", err)
 	}
 
 	return nil

--- a/internal/backup/optimizations.go
+++ b/internal/backup/optimizations.go
@@ -541,11 +541,30 @@ func normalizeTextFile(root *os.Root, name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	normalized := bytes.ReplaceAll(data, []byte("\r"), nil)
+	// Only CRLF pairs in plain single-byte text are collapsed - the documented
+	// contract ("removal of \r from CRLF text files"). The extension gate upstream
+	// cannot tell content: a .txt can be UTF-16 (where stripping every 0x0D byte
+	// breaks a code unit in half and shifts everything after it into garbage) and a
+	// .log can carry lone \r progress lines or embedded binary. Measured, not
+	// hypothetical: both corruptions were reproduced live before this guard.
+	if !isPlainSingleByteText(data) {
+		return false, nil
+	}
+	normalized := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 	if bytes.Equal(data, normalized) {
 		return false, nil
 	}
 	return true, atomicRootRewrite(root, name, normalized)
+}
+
+// isPlainSingleByteText reports whether data is safe for byte-level CRLF
+// normalization: no UTF-16/UTF-32 BOM and no NUL byte (the cheapest reliable tell
+// for wide encodings without a BOM and for binary payloads alike).
+func isPlainSingleByteText(data []byte) bool {
+	if bytes.HasPrefix(data, []byte{0xFF, 0xFE}) || bytes.HasPrefix(data, []byte{0xFE, 0xFF}) {
+		return false
+	}
+	return !bytes.ContainsRune(data, 0)
 }
 
 func normalizeConfigFile(root *os.Root, name string) (bool, error) {

--- a/internal/backup/optimizations.go
+++ b/internal/backup/optimizations.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/tis24dev/proxsave/internal/logging"
 )
@@ -558,13 +560,25 @@ func normalizeTextFile(root *os.Root, name string) (bool, error) {
 }
 
 // isPlainSingleByteText reports whether data is safe for byte-level CRLF
-// normalization: no UTF-16/UTF-32 BOM and no NUL byte (the cheapest reliable tell
-// for wide encodings without a BOM and for binary payloads alike).
+// normalization. Invalid UTF-8 and control characters other than common text
+// whitespace are treated as binary so an extension alone can never authorize a
+// destructive rewrite.
 func isPlainSingleByteText(data []byte) bool {
-	if bytes.HasPrefix(data, []byte{0xFF, 0xFE}) || bytes.HasPrefix(data, []byte{0xFE, 0xFF}) {
+	if !utf8.Valid(data) {
 		return false
 	}
-	return !bytes.ContainsRune(data, 0)
+	for len(data) > 0 {
+		r, size := utf8.DecodeRune(data)
+		data = data[size:]
+		switch r {
+		case '\t', '\n', '\r':
+			continue
+		}
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeConfigFile(root *os.Root, name string) (bool, error) {

--- a/internal/backup/optimizations_text_safety_test.go
+++ b/internal/backup/optimizations_text_safety_test.go
@@ -1,0 +1,76 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The prefilter's CR strip was a blind bytes.ReplaceAll(data, "\r", nil) over every
+// small .txt/.log/.md/.conf/.cfg/.ini in the whole staging tree, CUSTOM_BACKUP_PATHS
+// payload included, while CONFIGURATION.md sells it as safe, semantic-preserving
+// removal of \r "from CRLF text files". Measured live before this fix: a UTF-16LE
+// "hi\r\nyo" lost the 0x0D byte of its 0x0D 0x00 pair, the payload went odd-length
+// and every following character shifted into garbage; a lone-\r progress log had its
+// lines silently merged. The backup copy is what gets corrupted - the restore then
+// delivers it. The contract these tests pin: only CRLF pairs in plain single-byte
+// text are touched; anything else stays byte-identical.
+
+func normalizeInDir(t *testing.T, name string, content []byte) (changed bool, after []byte) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, name), content, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	changed, err = normalizeTextFile(root, name)
+	if err != nil {
+		t.Fatalf("normalizeTextFile: %v", err)
+	}
+	after, err = os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return changed, after
+}
+
+func TestNormalizeLeavesUTF16Alone(t *testing.T) {
+	// "hi\r\nyo" in UTF-16LE with BOM - the shape Windows tools export.
+	le := []byte{0xFF, 0xFE, 'h', 0, 'i', 0, '\r', 0, '\n', 0, 'y', 0, 'o', 0}
+	if changed, after := normalizeInDir(t, "note.txt", le); changed || string(after) != string(le) {
+		t.Fatalf("UTF-16LE text was rewritten (changed=%v):\nbefore % x\nafter  % x", changed, le, after)
+	}
+	be := []byte{0xFE, 0xFF, 0, 'h', 0, 'i', 0, '\r', 0, '\n', 0, 'y', 0, 'o'}
+	if changed, after := normalizeInDir(t, "note2.txt", be); changed || string(after) != string(be) {
+		t.Fatalf("UTF-16BE text was rewritten (changed=%v)", changed)
+	}
+}
+
+func TestNormalizeLeavesLoneCRAlone(t *testing.T) {
+	log := []byte("done 10%\rdone 99%\rdone 100%\n")
+	if changed, after := normalizeInDir(t, "progress.log", log); changed || string(after) != string(log) {
+		t.Fatalf("lone \\r lines were merged (changed=%v): %q", changed, after)
+	}
+}
+
+func TestNormalizeLeavesBinaryBearingLogsAlone(t *testing.T) {
+	bin := []byte("prefix\x00\r\nraw\rbytes")
+	if changed, after := normalizeInDir(t, "mixed.log", bin); changed || string(after) != string(bin) {
+		t.Fatalf("a NUL-bearing log was rewritten (changed=%v): %q", changed, after)
+	}
+}
+
+func TestNormalizeStillCollapsesCRLFAndOnlyCRLF(t *testing.T) {
+	in := []byte("a\r\nb\rc\r\nd\n")
+	changed, after := normalizeInDir(t, "doc.md", in)
+	if !changed {
+		t.Fatal("a CRLF file must still be normalized")
+	}
+	if want := "a\nb\rc\nd\n"; string(after) != want {
+		t.Fatalf("only the \\r of CRLF pairs may go:\nwant %q\ngot  %q", want, after)
+	}
+}

--- a/internal/backup/optimizations_text_safety_test.go
+++ b/internal/backup/optimizations_text_safety_test.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,6 +62,13 @@ func TestNormalizeLeavesBinaryBearingLogsAlone(t *testing.T) {
 	bin := []byte("prefix\x00\r\nraw\rbytes")
 	if changed, after := normalizeInDir(t, "mixed.log", bin); changed || string(after) != string(bin) {
 		t.Fatalf("a NUL-bearing log was rewritten (changed=%v): %q", changed, after)
+	}
+}
+
+func TestNormalizeLeavesNULFreeBinaryAlone(t *testing.T) {
+	bin := []byte{0x01, 0x02, 'A', '\r', '\n', 0x7F}
+	if changed, after := normalizeInDir(t, "opaque.log", bin); changed || !bytes.Equal(after, bin) {
+		t.Fatalf("a NUL-free binary log was rewritten (changed=%v):\nbefore % x\nafter  % x", changed, bin, after)
 	}
 }
 

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -372,7 +372,10 @@ func (c *Checker) CheckLockFile() CheckResult {
 					// fall through to create a fresh lock below
 				} else {
 					result.Message = formatInProgress(age, meta)
-					c.logger.Error("%s", result.Message)
+					// Debug, not Error: the caller's logResult already renders this
+					// exact fact as the one red "✗ Lock File (BACKUP_IN_PROGRESS)"
+					// line; a second bare ERROR recapped errors=2 for one skip.
+					c.logger.Debug("%s", result.Message)
 					return result
 				}
 			} else if errors.Is(killErr, syscall.ESRCH) {
@@ -394,7 +397,7 @@ func (c *Checker) CheckLockFile() CheckResult {
 					}
 				} else {
 					result.Message = formatInProgress(age, meta)
-					c.logger.Error("%s", result.Message)
+					c.logger.Debug("%s", result.Message) // see the Debug note above
 					return result
 				}
 			}
@@ -408,7 +411,7 @@ func (c *Checker) CheckLockFile() CheckResult {
 			}
 		} else {
 			result.Message = formatInProgress(age, meta)
-			c.logger.Error("%s", result.Message)
+			c.logger.Debug("%s", result.Message) // see the Debug note above
 			return result
 		}
 	}
@@ -426,7 +429,7 @@ func (c *Checker) CheckLockFile() CheckResult {
 				// spurious failure notification.
 				result.Code = CheckCodeBackupInProgress
 				result.Message = "Another backup acquired the lock"
-				c.logger.Error("%s", result.Message)
+				c.logger.Debug("%s", result.Message) // see the Debug note above
 				return result
 			}
 			result.Error = fmt.Errorf("failed to create lock file: %w", err)

--- a/internal/checks/lock_inprogress_level_test.go
+++ b/internal/checks/lock_inprogress_level_test.go
@@ -1,0 +1,67 @@
+package checks
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// The in-progress lock fact reaches the operator once, through the caller's
+// "✗ Lock File (BACKUP_IN_PROGRESS): ..." line (logResult in the orchestrator).
+// CheckLockFile used to ALSO log the bare message at ERROR right before returning
+// it, so one benign concurrency skip recapped errors=2 with two red lines saying
+// the same thing. The bare pre-log stays for debugging, at Debug.
+func TestCheckLockFileInProgressPreLogIsDebugNotError(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+
+	lockDir := t.TempDir()
+	lockPath := filepath.Join(lockDir, ".backup.lock")
+	host, _ := os.Hostname()
+	content := fmt.Sprintf("pid=%d\nhost=%s\ntime=2026-09-02T17:00:00+02:00\n", os.Getpid(), host)
+	if err := os.WriteFile(lockPath, []byte(content), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewChecker(logger, &CheckerConfig{
+		BackupPath:   lockDir,
+		LogPath:      lockDir,
+		LockDirPath:  lockDir,
+		LockFilePath: lockPath,
+		SafetyFactor: 1.0,
+		MaxLockAge:   time.Hour,
+	})
+	result := c.CheckLockFile()
+
+	if result.Passed || result.Code != CheckCodeBackupInProgress {
+		t.Fatalf("expected the in-progress arm (Passed=false, Code=%s), got Passed=%v Code=%q", CheckCodeBackupInProgress, result.Passed, result.Code)
+	}
+
+	var debugSeen bool
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if !strings.Contains(line, "Another backup is in progress") {
+			continue
+		}
+		_, rest, found := strings.Cut(line, "] ")
+		if !found {
+			continue
+		}
+		switch strings.Fields(rest)[0] {
+		case "ERROR":
+			t.Fatalf("the bare in-progress message still renders at ERROR, duplicating the caller's ✗ line:\n%s", line)
+		case "DEBUG":
+			debugSeen = true
+		}
+	}
+	if !debugSeen {
+		t.Fatalf("the bare in-progress message vanished entirely; it must stay at Debug:\n%s", buf.String())
+	}
+}

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,84 @@
+// Package filelock provides process-scoped advisory file locks.
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// ErrHeld reports that a non-blocking lock acquisition found another owner.
+var ErrHeld = errors.New("file lock is already held")
+
+// Acquire obtains an exclusive lock, waiting until any current owner releases it.
+func Acquire(path string) (release func() error, err error) {
+	return acquire(path, syscall.LOCK_EX)
+}
+
+// TryAcquire obtains an exclusive lock without waiting for another owner.
+func TryAcquire(path string) (release func() error, err error) {
+	return acquire(path, syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func acquire(path string, flags int) (func() error, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, errors.New("file lock path is empty")
+	}
+
+	path = filepath.Clean(path)
+	root, err := os.OpenRoot(filepath.Dir(path))
+	if err != nil {
+		return nil, fmt.Errorf("open file lock directory for %s: %w", path, err)
+	}
+
+	file, err := root.OpenFile(filepath.Base(path), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("open file lock %s: %w", path, err),
+			closeError("close file lock directory", root),
+		)
+	}
+
+	if err := syscall.Flock(int(file.Fd()), flags); err != nil {
+		lockErr := fmt.Errorf("acquire file lock %s: %w", path, err)
+		if flags&syscall.LOCK_NB != 0 &&
+			(errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)) {
+			lockErr = errors.Join(ErrHeld, lockErr)
+		}
+		return nil, errors.Join(
+			lockErr,
+			closeError("close file lock", file),
+			closeError("close file lock directory", root),
+		)
+	}
+
+	return func() error {
+		return errors.Join(
+			flockUnlockError(path, file),
+			closeError("close file lock", file),
+			closeError("close file lock directory", root),
+		)
+	}, nil
+}
+
+func flockUnlockError(path string, file *os.File) error {
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_UN); err != nil {
+		return fmt.Errorf("release file lock %s: %w", path, err)
+	}
+	return nil
+}
+
+type closer interface {
+	Close() error
+}
+
+func closeError(action string, resource closer) error {
+	if err := resource.Close(); err != nil {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+	return nil
+}

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -1,0 +1,189 @@
+package filelock
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	crashHelperEnv       = "PROXSAVE_FILELOCK_CRASH_HELPER"
+	crashHelperLockEnv   = "PROXSAVE_FILELOCK_CRASH_LOCK"
+	crashHelperReadyEnv  = "PROXSAVE_FILELOCK_CRASH_READY"
+	crashHelperPollDelay = 10 * time.Millisecond
+)
+
+var crashHelperRelease func() error
+
+func TestTryAcquireReportsHeldThenReacquiresAfterRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resource.lock")
+
+	releaseFirst, err := TryAcquire(path)
+	if err != nil {
+		t.Fatalf("first TryAcquire: %v", err)
+	}
+
+	if releaseUnexpected, err := TryAcquire(path); !errors.Is(err, ErrHeld) {
+		if err == nil {
+			_ = releaseUnexpected()
+		}
+		_ = releaseFirst()
+		t.Fatalf("second TryAcquire error = %v, want ErrHeld", err)
+	}
+
+	if err := releaseFirst(); err != nil {
+		t.Fatalf("release first lock: %v", err)
+	}
+
+	releaseNext, err := TryAcquire(path)
+	if err != nil {
+		t.Fatalf("reacquire after release: %v", err)
+	}
+	if err := releaseNext(); err != nil {
+		t.Fatalf("release reacquired lock: %v", err)
+	}
+}
+
+func TestAcquireWaitsUntilRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resource.lock")
+	releaseFirst, err := TryAcquire(path)
+	if err != nil {
+		t.Fatalf("first TryAcquire: %v", err)
+	}
+
+	type acquireResult struct {
+		release func() error
+		err     error
+	}
+	result := make(chan acquireResult, 1)
+	go func() {
+		release, err := Acquire(path)
+		result <- acquireResult{release: release, err: err}
+	}()
+
+	select {
+	case got := <-result:
+		if got.err == nil {
+			_ = got.release()
+		}
+		_ = releaseFirst()
+		t.Fatalf("Acquire returned before the held lock was released: %v", got.err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	if err := releaseFirst(); err != nil {
+		t.Fatalf("release first lock: %v", err)
+	}
+
+	select {
+	case got := <-result:
+		if got.err != nil {
+			t.Fatalf("blocked Acquire after release: %v", got.err)
+		}
+		if err := got.release(); err != nil {
+			t.Fatalf("release blocked acquisition: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Acquire remained blocked after the first lock was released")
+	}
+}
+
+func TestAcquireRequiresExistingParent(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "missing")
+	path := filepath.Join(parent, "resource.lock")
+
+	if release, err := Acquire(path); err == nil {
+		_ = release()
+		t.Fatal("Acquire succeeded with a missing parent directory")
+	}
+	if _, err := os.Stat(parent); !os.IsNotExist(err) {
+		t.Fatalf("parent directory state after Acquire = %v, want not exist", err)
+	}
+}
+
+func TestLockIsReleasedWhenOwnerProcessDies(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resource.lock")
+	readyPath := filepath.Join(dir, "ready")
+
+	var stderr bytes.Buffer
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCrashRecoveryHelper$")
+	cmd.Env = append(os.Environ(),
+		crashHelperEnv+"=1",
+		crashHelperLockEnv+"="+path,
+		crashHelperReadyEnv+"="+readyPath,
+	)
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start lock owner helper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat helper ready marker: %v", err)
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+			t.Fatalf("lock owner helper did not become ready: %s", stderr.String())
+		}
+		time.Sleep(crashHelperPollDelay)
+	}
+
+	if releaseUnexpected, err := TryAcquire(path); !errors.Is(err, ErrHeld) {
+		if err == nil {
+			_ = releaseUnexpected()
+		}
+		t.Fatalf("TryAcquire while helper is alive error = %v, want ErrHeld", err)
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill lock owner helper: %v", err)
+	}
+	state, err := cmd.Process.Wait()
+	if err != nil {
+		t.Fatalf("wait for killed lock owner helper: %v", err)
+	}
+	if state.Success() {
+		t.Fatal("killed lock owner helper exited successfully")
+	}
+
+	release, err := TryAcquire(path)
+	if err != nil {
+		t.Fatalf("TryAcquire after helper death: %v", err)
+	}
+	if err := release(); err != nil {
+		t.Fatalf("release lock acquired after helper death: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("persistent lock sidecar after helper death: %v", err)
+	}
+}
+
+func TestCrashRecoveryHelper(t *testing.T) {
+	if os.Getenv(crashHelperEnv) != "1" {
+		t.Skip("helper process only")
+	}
+
+	var err error
+	crashHelperRelease, err = Acquire(os.Getenv(crashHelperLockEnv))
+	if err != nil {
+		t.Fatalf("Acquire in helper: %v", err)
+	}
+	if err := os.WriteFile(os.Getenv(crashHelperReadyEnv), []byte("ready"), 0o600); err != nil {
+		t.Fatalf("write helper ready marker: %v", err)
+	}
+
+	time.Sleep(24 * time.Hour)
+}

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -21,9 +21,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
+	"github.com/tis24dev/proxsave/internal/filelock"
 	"github.com/tis24dev/proxsave/internal/logging"
 	"github.com/tis24dev/proxsave/internal/safeexec"
 )
@@ -193,8 +193,9 @@ func readFileUnderRoot(dir, name string) ([]byte, error) {
 // It exists because a concurrent hook a (installer) and hook b (enable-now daemon) can run
 // against the same server_id, and two DISTINCT minted secrets strand the host (last-write
 // wins on disk vs confirm-locks-reissue on the server). It returns an unlock func the
-// caller MUST defer and call exactly once. The lock file is opened confined to the identity
-// directory via os.Root (the basename is a constant, mirroring LoadNotifySecret).
+// caller MUST defer and call exactly once. The shared filelock primitive opens the lock file
+// confined to the identity directory via os.Root (the basename is a constant, mirroring
+// LoadNotifySecret).
 func LockNotifySecret(baseDir string) (unlock func(), err error) {
 	baseDir = strings.TrimSpace(baseDir)
 	if baseDir == "" {
@@ -204,24 +205,12 @@ func LockNotifySecret(baseDir string) (unlock func(), err error) {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, fmt.Errorf("failed to create identity directory %s: %w", dir, err)
 	}
-	root, err := os.OpenRoot(dir)
+	releaseLock, err := filelock.Acquire(filepath.Join(dir, notifySecretLockFileName))
 	if err != nil {
-		return nil, err
-	}
-	f, err := root.OpenFile(notifySecretLockFileName, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		_ = root.Close()
-		return nil, err
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		_ = f.Close()
-		_ = root.Close()
-		return nil, fmt.Errorf("flock notify secret: %w", err)
+		return nil, fmt.Errorf("lock notify secret: %w", err)
 	}
 	return func() {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
-		_ = root.Close()
+		_ = releaseLock()
 	}, nil
 }
 

--- a/internal/logging/level_filter_truth_test.go
+++ b/internal/logging/level_filter_truth_test.go
@@ -68,6 +68,25 @@ func TestErrorsBelowConsoleLevelStillCountAndReachTheFile(t *testing.T) {
 	}
 }
 
+func TestMirrorReceivesRecordedLinesBelowConsoleLevel(t *testing.T) {
+	logger, console, _ := muteLevelLogger(t, types.LogLevelCritical)
+	var mirror bytes.Buffer
+	logger.SetMirror(&mirror)
+
+	logger.Warning("muted warning")
+	logger.Error("muted error")
+	logger.Critical("visible critical")
+
+	if got := console.String(); strings.Contains(got, "muted warning") || strings.Contains(got, "muted error") {
+		t.Fatalf("console threshold leaked muted lines:\n%s", got)
+	}
+	for _, want := range []string{"muted warning", "muted error", "visible critical"} {
+		if !strings.Contains(mirror.String(), want) {
+			t.Fatalf("mirror lost recorded line %q:\n%s", want, mirror.String())
+		}
+	}
+}
+
 func TestBelowWarningTheThresholdKeepsItsFullMeaning(t *testing.T) {
 	logger, console, logPath := muteLevelLogger(t, types.LogLevelError)
 

--- a/internal/logging/level_filter_truth_test.go
+++ b/internal/logging/level_filter_truth_test.go
@@ -1,0 +1,83 @@
+package logging
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// `--log-level error` used to make warnings vanish from EVERY channel at once:
+// the threshold check sat before the counters, the issue capture and the file
+// sink, so HasWarnings()==false painted the footer green, the re-parse found
+// nothing in the file, and the run exited 0 - for a run that DID warn. The
+// maintainer call (2026-09-02): the threshold is a CONSOLE filter. Warning-weight
+// lines and above are always counted and always reach the log file (which is the
+// artifact notifications ship); only their display is muted. Below warning the
+// filter keeps its old full meaning.
+
+func muteLevelLogger(t *testing.T, level types.LogLevel) (*Logger, *bytes.Buffer, string) {
+	t.Helper()
+	logger := New(level, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	logPath := filepath.Join(t.TempDir(), "run.log")
+	if err := logger.OpenLogFile(logPath); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = logger.CloseLogFile() })
+	return logger, buf, logPath
+}
+
+func TestWarningsBelowConsoleLevelStillCountAndReachTheFile(t *testing.T) {
+	logger, console, logPath := muteLevelLogger(t, types.LogLevelError)
+
+	logger.Warning("secondary copy failed: %s", "io timeout")
+
+	if got := logger.WarningCount(); got != 1 {
+		t.Fatalf("WarningCount = %d, want 1: a muted console must not blind the counters (footer/exit)", got)
+	}
+	if s := console.String(); strings.Contains(s, "secondary copy failed") {
+		t.Fatalf("--log-level error must still mute the console display:\n%s", s)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "WARNING") || !strings.Contains(string(data), "secondary copy failed") {
+		t.Fatalf("the shipped log file lost the warning line, the evidence for the exit code:\n%s", data)
+	}
+}
+
+func TestErrorsBelowConsoleLevelStillCountAndReachTheFile(t *testing.T) {
+	logger, console, logPath := muteLevelLogger(t, types.LogLevelCritical)
+
+	logger.Error("store blew up")
+
+	if got := logger.ErrorCount(); got != 1 {
+		t.Fatalf("ErrorCount = %d, want 1", got)
+	}
+	if strings.Contains(console.String(), "store blew up") {
+		t.Fatalf("console must stay muted at level critical:\n%s", console.String())
+	}
+	if data, _ := os.ReadFile(logPath); !strings.Contains(string(data), "store blew up") {
+		t.Fatalf("error line missing from the file:\n%s", data)
+	}
+}
+
+func TestBelowWarningTheThresholdKeepsItsFullMeaning(t *testing.T) {
+	logger, console, logPath := muteLevelLogger(t, types.LogLevelError)
+
+	logger.Info("chatty")
+	logger.Debug("chattier")
+
+	if s := console.String(); strings.Contains(s, "chatt") {
+		t.Fatalf("info/debug leaked to console:\n%s", s)
+	}
+	if data, _ := os.ReadFile(logPath); strings.Contains(string(data), "chatt") {
+		t.Fatalf("info/debug below the threshold must not reach the file either:\n%s", data)
+	}
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -392,7 +392,15 @@ func (l *Logger) log(level types.LogLevel, format string, args ...interface{}) {
 func (l *Logger) logWithLabel(level types.LogLevel, label string, colorOverride string, format string, args ...interface{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if level > l.level {
+	// The threshold is a CONSOLE filter (maintainer call, 2026-09-02). It used to
+	// return here for every level, before the counters, the issue capture and the
+	// file sink - so `--log-level error` made a warning vanish from the footer,
+	// the exit code AND the shipped log at once. Warning-weight lines and above
+	// are always counted and always reach the file; only their display is muted.
+	// Below warning the threshold keeps its full meaning.
+	consoleMuted := level > l.level
+	if consoleMuted && level != types.LogLevelWarning &&
+		level != types.LogLevelError && level != types.LogLevelCritical {
 		return
 	}
 
@@ -466,13 +474,16 @@ func (l *Logger) logWithLabel(level types.LogLevel, label string, colorOverride 
 		l.issueLines = append(l.issueLines, issue)
 	}
 
-	// Write to stdout with colors.
-	_, _ = fmt.Fprint(l.output, outputStdout)
+	// Write to stdout with colors - unless the console threshold mutes it. The
+	// mirror is a display tap, so it mutes with the console.
+	if !consoleMuted {
+		_, _ = fmt.Fprint(l.output, outputStdout)
 
-	// Mirror the COLORED line to the optional tap (parallel to the file sink, so a
-	// muted console never starves it). In-memory, non-blocking; never wedges l.mu.
-	if l.mirror != nil {
-		_, _ = io.WriteString(l.mirror, outputStdout)
+		// Mirror the COLORED line to the optional tap (parallel to the file sink, so a
+		// muted console never starves it). In-memory, non-blocking; never wedges l.mu.
+		if l.mirror != nil {
+			_, _ = io.WriteString(l.mirror, outputStdout)
+		}
 	}
 
 	// If a log file is open and not disabled, write there too (without colors),

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -474,16 +474,15 @@ func (l *Logger) logWithLabel(level types.LogLevel, label string, colorOverride 
 		l.issueLines = append(l.issueLines, issue)
 	}
 
-	// Write to stdout with colors - unless the console threshold mutes it. The
-	// mirror is a display tap, so it mutes with the console.
+	// Write to stdout with colors - unless the console threshold mutes it.
 	if !consoleMuted {
 		_, _ = fmt.Fprint(l.output, outputStdout)
+	}
 
-		// Mirror the COLORED line to the optional tap (parallel to the file sink, so a
-		// muted console never starves it). In-memory, non-blocking; never wedges l.mu.
-		if l.mirror != nil {
-			_, _ = io.WriteString(l.mirror, outputStdout)
-		}
+	// Mirror the COLORED line to the optional tap independently of console
+	// visibility, so every recorded line remains available for a later UI replay.
+	if l.mirror != nil {
+		_, _ = io.WriteString(l.mirror, outputStdout)
 	}
 
 	// If a log file is open and not disabled, write there too (without colors),

--- a/internal/orchestrator/backup_run_phases.go
+++ b/internal/orchestrator/backup_run_phases.go
@@ -103,18 +103,27 @@ func (o *Orchestrator) initBackupRun(run *backupRunContext) *BackupStats {
 
 func (o *Orchestrator) exportBackupMetrics(run *backupRunContext, runErr error) {
 	stats := run.stats
+	// On a successful, non-dry run the pre-notification issue snapshot was taken before
+	// notifications ran, so a notify/communication failure logged during dispatch is not
+	// yet counted. Re-parse the log so it surfaces as a warning (status 1) instead of
+	// vanishing to success (0). Idempotent: a clean run stays success.
+	//
+	// This runs BEFORE the metrics gate on purpose: it decides the PROCESS exit code
+	// (this whole function is a defer inside RunGoBackup, and the cmd layer exits with
+	// stats.ExitCode), and it sat behind the gate for two releases - the same notify
+	// failure exited 1 with METRICS_ENABLED=true and 0 on a default install. The
+	// contract (maintainer call, 2026-09-02): a notification failure is warning-weight
+	// ALWAYS, whatever the metrics setting - monitoring must learn notifications are
+	// broken exactly when email cannot say so. NOTIFICATIONS.md states the same.
+	if runErr == nil && !o.dryRun && stats != nil {
+		o.finalizeSuccessIssueStats(stats)
+	}
+
 	if !o.shouldExportBackupMetrics(stats) {
 		return
 	}
 
 	o.ensureBackupStatsTiming(stats)
-	// On a successful, non-dry run the pre-notification issue snapshot was taken before
-	// notifications ran, so a notify/communication failure logged during dispatch is not
-	// yet counted. Re-parse the log so it surfaces as a warning (status 1) instead of
-	// vanishing to success (0). Idempotent: a clean run stays success.
-	if runErr == nil && !o.dryRun {
-		o.finalizeSuccessIssueStats(stats)
-	}
 	stats.ExitCode = backupMetricsExitCode(stats, runErr)
 	o.exportPrometheusBackupMetrics(stats)
 }

--- a/internal/orchestrator/livepve_test.go
+++ b/internal/orchestrator/livepve_test.go
@@ -1,0 +1,156 @@
+//go:build livepve
+
+package orchestrator
+
+// Live validation harness for the staged-apply series (fable-check bugs 1-5).
+// Build:  CGO_ENABLED=0 go test -c -tags livepve ./internal/orchestrator -o livepve.test
+// Run AS ROOT ON A PVE TEST NODE:  ./livepve.test -test.run TestLivePVE -test.v
+//
+// Every test is idempotent on purpose: identical bytes for the files, identical
+// values for the API calls, and the one thing it CREATES (CT 990, config only)
+// it deletes again. Still: test node only, file-level backups first.
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func livePVEGuard(t *testing.T) *logging.Logger {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("live PVE checks need root")
+	}
+	if _, err := os.Stat("/etc/pve/local"); err != nil {
+		t.Skip("not a PVE node (no /etc/pve/local)")
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+	logger.SetOutput(os.Stdout)
+	return logger
+}
+
+func liveStage(t *testing.T, rel string, data []byte) string {
+	t.Helper()
+	root := t.TempDir()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, data, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestLivePVEDatacenterCfg(t *testing.T) {
+	logger := livePVEGuard(t)
+	before, err := os.ReadFile("/etc/pve/datacenter.cfg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage := liveStage(t, "etc/pve/datacenter.cfg", before)
+	if err := applyPVEDatacenterCfgFromStage(context.Background(), logger, stage); err != nil {
+		t.Fatalf("datacenter apply: %v", err)
+	}
+	after, err := os.ReadFile("/etc/pve/datacenter.cfg")
+	if err != nil || string(after) != string(before) {
+		t.Fatalf("datacenter.cfg changed or unreadable after identical apply: err=%v\nbefore=%q\nafter=%q", err, before, after)
+	}
+}
+
+func TestLivePVEVzdumpCron(t *testing.T) {
+	logger := livePVEGuard(t)
+	before, err := os.ReadFile("/etc/pve/vzdump.cron")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage := liveStage(t, "etc/pve/vzdump.cron", before)
+	if err := applyPVEVzdumpCronFromStage(logger, stage); err != nil {
+		t.Fatalf("vzdump.cron apply: %v", err)
+	}
+	after, err := os.ReadFile("/etc/pve/vzdump.cron")
+	if err != nil || string(after) != string(before) {
+		t.Fatalf("vzdump.cron changed after identical apply: err=%v", err)
+	}
+}
+
+func TestLivePVEStorageCreateThenSet(t *testing.T) {
+	logger := livePVEGuard(t)
+	// The current `local` block, identical values: create must fail (already
+	// defined), the set fallback must apply cleanly.
+	cfg := "dir: local\n\tpath /var/lib/vz\n\tcontent iso,vztmpl,backup,import\n"
+	stage := liveStage(t, "etc/pve/storage.cfg", []byte(cfg))
+	applied, failed, err := applyStorageCfg(context.Background(), filepath.Join(stage, "etc/pve/storage.cfg"), logger)
+	if err != nil {
+		t.Fatalf("applyStorageCfg: %v", err)
+	}
+	if applied != 1 || failed != 0 {
+		t.Fatalf("applied=%d failed=%d, want 1/0 (create-then-set on existing 'local')", applied, failed)
+	}
+}
+
+func TestLivePVEExistingGuestWithMeta(t *testing.T) {
+	logger := livePVEGuard(t)
+	const conf = "/etc/pve/qemu-server/101.conf"
+	before, err := os.ReadFile(conf)
+	if err != nil {
+		t.Skipf("no VM 101 on this node: %v", err)
+	}
+	if !strings.Contains(string(before), "meta:") {
+		t.Skip("VM 101 has no meta line; the bug-2 shape is not on this node")
+	}
+	node := localNodeName()
+	stage := liveStage(t, "etc/pve/nodes/"+node+"/qemu-server/101.conf", before)
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "101", Kind: "qemu", Name: "openwrt25",
+		Path: filepath.Join(stage, "etc/pve/nodes", node, "qemu-server", "101.conf"),
+	}}, logger)
+	if applied != 1 || failed != 0 {
+		t.Fatalf("applied=%d failed=%d, want 1/0 for the meta-carrying stopped guest", applied, failed)
+	}
+	after, err := os.ReadFile(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), "meta: creation-qemu") {
+		t.Fatalf("the guest lost its meta line:\n%s", after)
+	}
+}
+
+func TestLivePVEMissingLxcRegistration(t *testing.T) {
+	logger := livePVEGuard(t)
+	const vmid = "990"
+	confPath := "/etc/pve/lxc/" + vmid + ".conf"
+	if _, err := os.Stat(confPath); err == nil {
+		t.Fatalf("CT %s already exists on this node; refusing to touch it", vmid)
+	}
+	t.Cleanup(func() {
+		if err := exec.Command("pvesh", "delete", "/nodes/"+localNodeName()+"/lxc/"+vmid).Run(); err != nil {
+			_ = os.Remove(confPath)
+		}
+	})
+
+	conf := "hostname: proxsave-livecheck\nmemory: 128\ncores: 1\nostype: unmanaged\n"
+	node := localNodeName()
+	stage := liveStage(t, "etc/pve/nodes/"+node+"/lxc/"+vmid+".conf", []byte(conf))
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: vmid, Kind: "lxc", Name: "proxsave-livecheck",
+		Path: filepath.Join(stage, "etc/pve/nodes", node, "lxc", vmid+".conf"),
+	}}, logger)
+	if applied != 1 || failed != 0 {
+		t.Fatalf("applied=%d failed=%d, want 1/0 for the missing-guest registration", applied, failed)
+	}
+	out, err := exec.Command("pvesh", "get", "/nodes/"+node+"/lxc/"+vmid+"/config", "--output-format=json").Output()
+	if err != nil {
+		t.Fatalf("the registered CT does not answer on the API: %v", err)
+	}
+	if !strings.Contains(string(out), "proxsave-livecheck") {
+		t.Fatalf("API answers but without our hostname: %s", out)
+	}
+}

--- a/internal/orchestrator/livepve_test.go
+++ b/internal/orchestrator/livepve_test.go
@@ -217,3 +217,66 @@ func TestLivePVEMissingLxcRegistration(t *testing.T) {
 		t.Fatalf("API answers but without our hostname: %s", out)
 	}
 }
+
+func TestLivePVELockedGuestApplyRejectsExistingVMIDAsAbsent(t *testing.T) {
+	logger := livePVEGuard(t)
+	const (
+		vmid     = "101"
+		confPath = "/etc/pve/qemu-server/101.conf"
+	)
+	before, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Skipf("no VM %s on this node: %v", vmid, err)
+	}
+	node := localNodeName()
+	stage := liveStage(t, "etc/pve/nodes/"+node+"/qemu-server/"+vmid+".conf", []byte("name: must-not-apply\n"))
+	err = writeGuestConfToPmxcfs(context.Background(), logger, node, vmEntry{
+		VMID: vmid,
+		Kind: "qemu",
+		Path: filepath.Join(stage, "etc/pve/nodes", node, "qemu-server", vmid+".conf"),
+	}, guestMustBeAbsent)
+	if err == nil {
+		t.Fatalf("expected an existing VMID to fail the absent precondition")
+	}
+	after, readErr := os.ReadFile(confPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("VM %s configuration changed despite failed absent precondition", vmid)
+	}
+}
+
+func TestLivePVELockedGuestApplyRejectsRunningGuest(t *testing.T) {
+	logger := livePVEGuard(t)
+	const (
+		vmid     = "102"
+		confPath = "/etc/pve/qemu-server/102.conf"
+	)
+	node := localNodeName()
+	vm := vmEntry{VMID: vmid, Kind: "qemu"}
+	status, err := pveshGuestStatus(context.Background(), node, vm)
+	if err != nil {
+		t.Skipf("cannot read VM %s status: %v", vmid, err)
+	}
+	if status != "running" {
+		t.Skipf("VM %s is %q, need a running test guest", vmid, status)
+	}
+	before, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage := liveStage(t, "etc/pve/nodes/"+node+"/qemu-server/"+vmid+".conf", []byte("name: must-not-apply\n"))
+	vm.Path = filepath.Join(stage, "etc/pve/nodes", node, "qemu-server", vmid+".conf")
+	err = writeGuestConfToPmxcfs(context.Background(), logger, node, vm, guestMustBeStopped)
+	if err == nil {
+		t.Fatalf("expected a running guest to fail the stopped precondition")
+	}
+	after, readErr := os.ReadFile(confPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("VM %s configuration changed despite failed stopped precondition", vmid)
+	}
+}

--- a/internal/orchestrator/livepve_test.go
+++ b/internal/orchestrator/livepve_test.go
@@ -11,7 +11,9 @@ package orchestrator
 // it deletes again. Still: test node only, file-level backups first.
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -126,6 +128,29 @@ func TestLivePVEExistingGuestWithMeta(t *testing.T) {
 func TestLivePVEMissingLxcRegistration(t *testing.T) {
 	logger := livePVEGuard(t)
 	const vmid = "990"
+	inventoryOut, err := exec.Command("pvesh", "get", "/cluster/resources", "--type", "vm", "--output-format=json").CombinedOutput()
+	if err != nil {
+		t.Fatalf("cannot prove that CT %s is absent cluster-wide: %v (output: %s)", vmid, err, strings.TrimSpace(string(inventoryOut)))
+	}
+	inventoryOut = bytes.TrimSpace(inventoryOut)
+	if len(inventoryOut) == 0 || inventoryOut[0] != '[' {
+		t.Fatalf("cannot prove that CT %s is absent cluster-wide: expected a JSON array", vmid)
+	}
+	var guests []struct {
+		VMID int    `json:"vmid"`
+		Node string `json:"node"`
+	}
+	if err := json.Unmarshal(inventoryOut, &guests); err != nil {
+		t.Fatalf("cannot prove that CT %s is absent cluster-wide: parse inventory: %v", vmid, err)
+	}
+	for index, guest := range guests {
+		if guest.VMID <= 0 || strings.TrimSpace(guest.Node) == "" {
+			t.Fatalf("cannot prove that CT %s is absent cluster-wide: incomplete inventory item %d", vmid, index)
+		}
+		if guest.VMID == 990 {
+			t.Fatalf("CT %s already exists in the cluster on node %s; refusing to touch it", vmid, guest.Node)
+		}
+	}
 	confPath := "/etc/pve/lxc/" + vmid + ".conf"
 	if _, err := os.Stat(confPath); err == nil {
 		t.Fatalf("CT %s already exists on this node; refusing to touch it", vmid)

--- a/internal/orchestrator/livepve_test.go
+++ b/internal/orchestrator/livepve_test.go
@@ -50,6 +50,41 @@ func liveStage(t *testing.T, rel string, data []byte) string {
 	return root
 }
 
+func liveStorageBlock(t *testing.T, data []byte, storageID string) []byte {
+	t.Helper()
+	var block []string
+	collecting := false
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		isHeader := line == strings.TrimLeft(line, " \t")
+		_, id, ok := parseSectionHeader(trimmed)
+		if isHeader && ok {
+			if collecting {
+				break
+			}
+			collecting = id == storageID
+		}
+		if collecting {
+			if trimmed == "" {
+				break
+			}
+			block = append(block, line)
+		}
+	}
+	if len(block) == 0 {
+		t.Fatalf("storage %q is not defined in /etc/pve/storage.cfg", storageID)
+	}
+	return []byte(strings.Join(block, "\n") + "\n")
+}
+
+func TestLiveStorageBlockExtractsOnlyRequestedDefinition(t *testing.T) {
+	const config = "dir: local\n\tpath /var/lib/vz\n\tcomment local: storage\n\tcontent iso,vztmpl\n\nlvmthin: local-lvm\n\tthinpool data\n"
+	want := []byte("dir: local\n\tpath /var/lib/vz\n\tcomment local: storage\n\tcontent iso,vztmpl\n")
+	if got := liveStorageBlock(t, []byte(config), "local"); !bytes.Equal(got, want) {
+		t.Fatalf("local storage block mismatch:\nwant %q\ngot  %q", want, got)
+	}
+}
+
 func TestLivePVEDatacenterCfg(t *testing.T) {
 	logger := livePVEGuard(t)
 	before, err := os.ReadFile("/etc/pve/datacenter.cfg")
@@ -84,10 +119,13 @@ func TestLivePVEVzdumpCron(t *testing.T) {
 
 func TestLivePVEStorageCreateThenSet(t *testing.T) {
 	logger := livePVEGuard(t)
-	// The current `local` block, identical values: create must fail (already
-	// defined), the set fallback must apply cleanly.
-	cfg := "dir: local\n\tpath /var/lib/vz\n\tcontent iso,vztmpl,backup,import\n"
-	stage := liveStage(t, "etc/pve/storage.cfg", []byte(cfg))
+	current, err := os.ReadFile("/etc/pve/storage.cfg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Reapply only the node's current `local` block: create must fail (already
+	// defined), then the set fallback must apply the existing values unchanged.
+	stage := liveStage(t, "etc/pve/storage.cfg", liveStorageBlock(t, current, "local"))
 	applied, failed, err := applyStorageCfg(context.Background(), filepath.Join(stage, "etc/pve/storage.cfg"), logger)
 	if err != nil {
 		t.Fatalf("applyStorageCfg: %v", err)

--- a/internal/orchestrator/notify_exit_unconditional_test.go
+++ b/internal/orchestrator/notify_exit_unconditional_test.go
@@ -1,0 +1,52 @@
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// The post-notification re-parse decides the PROCESS exit code (exportBackupMetrics
+// runs as a defer inside RunGoBackup and mutates the same stats the cmd layer
+// returns), yet it lived behind the Prometheus gate: the same notify failure meant
+// exit 1 with METRICS_ENABLED=true and exit 0 on a default install. Maintainer
+// call (2026-09-02): a notification failure is warning-weight ALWAYS - exit 1 -
+// because monitoring must learn notifications are broken exactly when email
+// cannot say so. NOTIFICATIONS.md is aligned in the same change.
+func TestNotifyFailurePromotesExitEvenWithMetricsOff(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "run.log")
+	content := "[2026-09-02 10:00:00] INFO     Backup completed\n" +
+		"[2026-09-02 10:00:01] NOTIFY-ERR Telegram: failed: connection refused\n"
+	if err := os.WriteFile(logFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{cfg: &config.Config{MetricsEnabled: false}}
+	stats := &BackupStats{LogFilePath: logFile, ExitCode: types.ExitSuccess.Int()}
+	o.exportBackupMetrics(&backupRunContext{stats: stats}, nil)
+
+	if stats.ExitCode != types.ExitGenericError.Int() {
+		t.Fatalf("ExitCode = %d, want %d: with metrics off the notify failure vanished to success", stats.ExitCode, types.ExitGenericError.Int())
+	}
+	if stats.NotifyCount != 1 {
+		t.Fatalf("NotifyCount = %d, want 1", stats.NotifyCount)
+	}
+}
+
+// The other half of the contract stays: a genuinely failed run keeps its error
+// path (no success re-parse), and dry runs are untouched.
+func TestFailedOrDryRunSkipsTheSuccessReparse(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "run.log")
+	if err := os.WriteFile(logFile, []byte("[2026-09-02 10:00:01] NOTIFY-ERR x: failed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{cfg: &config.Config{MetricsEnabled: false}, dryRun: true}
+	stats := &BackupStats{LogFilePath: logFile, ExitCode: types.ExitSuccess.Int()}
+	o.exportBackupMetrics(&backupRunContext{stats: stats}, nil)
+	if stats.ExitCode != types.ExitSuccess.Int() || stats.NotifyCount != 0 {
+		t.Fatalf("dry run must not re-parse: exit=%d notify=%d", stats.ExitCode, stats.NotifyCount)
+	}
+}

--- a/internal/orchestrator/notify_exit_unconditional_test.go
+++ b/internal/orchestrator/notify_exit_unconditional_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,10 +44,22 @@ func TestFailedOrDryRunSkipsTheSuccessReparse(t *testing.T) {
 	if err := os.WriteFile(logFile, []byte("[2026-09-02 10:00:01] NOTIFY-ERR x: failed\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	o := &Orchestrator{cfg: &config.Config{MetricsEnabled: false}, dryRun: true}
-	stats := &BackupStats{LogFilePath: logFile, ExitCode: types.ExitSuccess.Int()}
-	o.exportBackupMetrics(&backupRunContext{stats: stats}, nil)
-	if stats.ExitCode != types.ExitSuccess.Int() || stats.NotifyCount != 0 {
-		t.Fatalf("dry run must not re-parse: exit=%d notify=%d", stats.ExitCode, stats.NotifyCount)
-	}
+
+	t.Run("dry run", func(t *testing.T) {
+		o := &Orchestrator{cfg: &config.Config{MetricsEnabled: false}, dryRun: true}
+		stats := &BackupStats{LogFilePath: logFile, ExitCode: types.ExitSuccess.Int()}
+		o.exportBackupMetrics(&backupRunContext{stats: stats}, nil)
+		if stats.ExitCode != types.ExitSuccess.Int() || stats.NotifyCount != 0 {
+			t.Fatalf("dry run must not re-parse: exit=%d notify=%d", stats.ExitCode, stats.NotifyCount)
+		}
+	})
+
+	t.Run("failed run", func(t *testing.T) {
+		o := &Orchestrator{cfg: &config.Config{MetricsEnabled: false}}
+		stats := &BackupStats{LogFilePath: logFile, ExitCode: types.ExitBackupError.Int()}
+		o.exportBackupMetrics(&backupRunContext{stats: stats}, errors.New("archive failed"))
+		if stats.ExitCode != types.ExitBackupError.Int() || stats.NotifyCount != 0 {
+			t.Fatalf("failed run must not re-parse: exit=%d notify=%d", stats.ExitCode, stats.NotifyCount)
+		}
+	})
 }

--- a/internal/orchestrator/pmxcfs_apply.go
+++ b/internal/orchestrator/pmxcfs_apply.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,7 @@ import (
 var (
 	pmxcfsRoot      = "/etc/pve"
 	pmxcfsIsMounted = isMounted
+	pmxcfsCloseRoot = func(root *os.Root) error { return root.Close() }
 )
 
 func pmxcfsWriteFile(logger *logging.Logger, relPath string, data []byte) error {
@@ -68,12 +70,16 @@ func cleanPmxcfsRelativePath(relPath string) (string, error) {
 	return cleanPath, nil
 }
 
-func pmxcfsWriteFileAtRoot(logger *logging.Logger, relPath string, data []byte) error {
+func pmxcfsWriteFileAtRoot(logger *logging.Logger, relPath string, data []byte) (retErr error) {
 	root, err := os.OpenRoot(pmxcfsRoot)
 	if err != nil {
 		return fmt.Errorf("open pmxcfs root %s: %w", pmxcfsRoot, err)
 	}
-	defer root.Close()
+	defer func() {
+		if closeErr := pmxcfsCloseRoot(root); closeErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("close pmxcfs root %s: %w", pmxcfsRoot, closeErr))
+		}
+	}()
 
 	mounted, err := pmxcfsIsMounted(pmxcfsRoot)
 	if err != nil {

--- a/internal/orchestrator/pmxcfs_apply.go
+++ b/internal/orchestrator/pmxcfs_apply.go
@@ -2,7 +2,9 @@ package orchestrator
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/tis24dev/proxsave/internal/logging"
 )
@@ -29,6 +31,14 @@ var (
 )
 
 func pmxcfsWriteFile(logger *logging.Logger, relPath string, data []byte) error {
+	cleanPath, err := cleanPmxcfsRelativePath(relPath)
+	if err != nil {
+		return err
+	}
+	if isRealRestoreFS(restoreFS) {
+		return pmxcfsWriteFileAtRoot(logger, cleanPath, data)
+	}
+
 	mounted, err := pmxcfsIsMounted(pmxcfsRoot)
 	if err != nil {
 		return fmt.Errorf("check pmxcfs mount %s: %w", pmxcfsRoot, err)
@@ -36,11 +46,63 @@ func pmxcfsWriteFile(logger *logging.Logger, relPath string, data []byte) error 
 	if !mounted {
 		return fmt.Errorf("%s is not mounted; refusing a shadow write on the root filesystem", pmxcfsRoot)
 	}
-	dest := filepath.Join(pmxcfsRoot, relPath)
+	dest := filepath.Join(pmxcfsRoot, cleanPath)
 	if err := restoreFS.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		return fmt.Errorf("create %s: %w", filepath.Dir(dest), err)
 	}
 	if err := restoreFS.WriteFile(dest, data, 0o640); err != nil {
+		return fmt.Errorf("write %s: %w", dest, err)
+	}
+	logger.Debug("pmxcfs write: %s (%d bytes)", dest, len(data))
+	return nil
+}
+
+func cleanPmxcfsRelativePath(relPath string) (string, error) {
+	if relPath == "" || filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("invalid pmxcfs path %q: expected a relative path below %s", relPath, pmxcfsRoot)
+	}
+	cleanPath := filepath.Clean(relPath)
+	if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid pmxcfs path %q: expected a relative path below %s", relPath, pmxcfsRoot)
+	}
+	return cleanPath, nil
+}
+
+func pmxcfsWriteFileAtRoot(logger *logging.Logger, relPath string, data []byte) error {
+	root, err := os.OpenRoot(pmxcfsRoot)
+	if err != nil {
+		return fmt.Errorf("open pmxcfs root %s: %w", pmxcfsRoot, err)
+	}
+	defer root.Close()
+
+	mounted, err := pmxcfsIsMounted(pmxcfsRoot)
+	if err != nil {
+		return fmt.Errorf("check pmxcfs mount %s: %w", pmxcfsRoot, err)
+	}
+	if !mounted {
+		return fmt.Errorf("%s is not mounted; refusing a shadow write on the root filesystem", pmxcfsRoot)
+	}
+
+	openedInfo, err := root.Stat(".")
+	if err != nil {
+		return fmt.Errorf("stat opened pmxcfs root %s: %w", pmxcfsRoot, err)
+	}
+	currentInfo, err := os.Stat(pmxcfsRoot)
+	if err != nil {
+		return fmt.Errorf("stat current pmxcfs root %s: %w", pmxcfsRoot, err)
+	}
+	if !os.SameFile(openedInfo, currentInfo) {
+		return fmt.Errorf("pmxcfs root %s changed while preparing write; refusing to continue", pmxcfsRoot)
+	}
+
+	dir := filepath.Dir(relPath)
+	if dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create %s: %w", filepath.Join(pmxcfsRoot, dir), err)
+		}
+	}
+	dest := filepath.Join(pmxcfsRoot, relPath)
+	if err := root.WriteFile(relPath, data, 0o640); err != nil {
 		return fmt.Errorf("write %s: %w", dest, err)
 	}
 	logger.Debug("pmxcfs write: %s (%d bytes)", dest, len(data))

--- a/internal/orchestrator/pmxcfs_apply.go
+++ b/internal/orchestrator/pmxcfs_apply.go
@@ -1,0 +1,48 @@
+package orchestrator
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+)
+
+// pmxcfsWriteFile writes ONE file under /etc/pve. That path is pmxcfs, the
+// cluster-replicated configuration filesystem: a write on one node propagates
+// cluster-wide exactly the way a pvesh call does, because pvesh itself ends in a
+// pmxcfs write. The staged-apply arms use this where the API surface has no usable
+// endpoint (datacenter.cfg, vzdump.cron, guest conf creation) and as the fidelity
+// net where the endpoint half-works (guest set rejected on a create-only key); see
+// diagnostics/design-staged-apply-pmxcfs-2026-09-02.md, verified live on PVE 9.1.9.
+//
+// The mounted guard is the same rule restore_ha.go and restore_access_control_ui.go
+// already enforce: with /etc/pve NOT mounted, a write here would land on the root
+// filesystem as a shadow file that the real mount hides forever and the cluster
+// never sees. Refusing is the only honest answer.
+//
+// No rollback capture here, on the maintainer's call (2026-09-02): the restore
+// workflow's safety backup (createSafetyBackup) has already archived every file
+// these writes can touch before any apply arm runs.
+var (
+	pmxcfsRoot      = "/etc/pve"
+	pmxcfsIsMounted = isMounted
+)
+
+func pmxcfsWriteFile(logger *logging.Logger, relPath string, data []byte) error {
+	mounted, err := pmxcfsIsMounted(pmxcfsRoot)
+	if err != nil {
+		return fmt.Errorf("check pmxcfs mount %s: %w", pmxcfsRoot, err)
+	}
+	if !mounted {
+		return fmt.Errorf("%s is not mounted; refusing a shadow write on the root filesystem", pmxcfsRoot)
+	}
+	dest := filepath.Join(pmxcfsRoot, relPath)
+	if err := restoreFS.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(dest), err)
+	}
+	if err := restoreFS.WriteFile(dest, data, 0o640); err != nil {
+		return fmt.Errorf("write %s: %w", dest, err)
+	}
+	logger.Debug("pmxcfs write: %s (%d bytes)", dest, len(data))
+	return nil
+}

--- a/internal/orchestrator/pmxcfs_apply_test.go
+++ b/internal/orchestrator/pmxcfs_apply_test.go
@@ -67,6 +67,47 @@ func TestPmxcfsWriteFileSurfacesTheMountCheckError(t *testing.T) {
 	}
 }
 
+func TestPmxcfsWriteFileSurfacesRootCloseError(t *testing.T) {
+	root := t.TempDir()
+	seamPmxcfs(t, root, true, nil)
+	useRealPmxcfsRestoreFS(t)
+
+	origClose := pmxcfsCloseRoot
+	t.Cleanup(func() { pmxcfsCloseRoot = origClose })
+	closeErr := errors.New("close root failed")
+	pmxcfsCloseRoot = func(root *os.Root) error {
+		_ = root.Close()
+		return closeErr
+	}
+
+	err := pmxcfsWriteFile(logging.New(types.LogLevelDebug, false), "datacenter.cfg", []byte("keyboard: it\n"))
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("want root close error, got %v", err)
+	}
+	if got, readErr := os.ReadFile(filepath.Join(root, "datacenter.cfg")); readErr != nil || string(got) != "keyboard: it\n" {
+		t.Fatalf("successful write was lost: content=%q err=%v", got, readErr)
+	}
+}
+
+func TestPmxcfsWriteFileRetainsOperationAndRootCloseErrors(t *testing.T) {
+	operationErr := errors.New("mount check failed")
+	closeErr := errors.New("close root failed")
+	seamPmxcfs(t, t.TempDir(), false, operationErr)
+	useRealPmxcfsRestoreFS(t)
+
+	origClose := pmxcfsCloseRoot
+	t.Cleanup(func() { pmxcfsCloseRoot = origClose })
+	pmxcfsCloseRoot = func(root *os.Root) error {
+		_ = root.Close()
+		return closeErr
+	}
+
+	err := pmxcfsWriteFile(logging.New(types.LogLevelDebug, false), "datacenter.cfg", []byte("x"))
+	if !errors.Is(err, operationErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("want operation and close errors retained, got %v", err)
+	}
+}
+
 func TestPmxcfsWriteFileRejectsUnsafeRelativePaths(t *testing.T) {
 	logger := logging.New(types.LogLevelDebug, false)
 	tests := []struct {

--- a/internal/orchestrator/pmxcfs_apply_test.go
+++ b/internal/orchestrator/pmxcfs_apply_test.go
@@ -1,0 +1,61 @@
+package orchestrator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func seamPmxcfs(t *testing.T, root string, mounted bool, mountErr error) {
+	t.Helper()
+	origRoot, origMounted := pmxcfsRoot, pmxcfsIsMounted
+	t.Cleanup(func() { pmxcfsRoot, pmxcfsIsMounted = origRoot, origMounted })
+	pmxcfsRoot = root
+	pmxcfsIsMounted = func(string) (bool, error) { return mounted, mountErr }
+}
+
+func TestPmxcfsWriteFileWritesUnderTheRoot(t *testing.T) {
+	root := t.TempDir()
+	seamPmxcfs(t, root, true, nil)
+	logger := logging.New(types.LogLevelDebug, false)
+
+	if err := pmxcfsWriteFile(logger, "nodes/pve/qemu-server/101.conf", []byte("cores: 2\n")); err != nil {
+		t.Fatalf("pmxcfsWriteFile: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "nodes/pve/qemu-server/101.conf"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "cores: 2\n" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestPmxcfsWriteFileRefusesWhenNotMounted(t *testing.T) {
+	root := t.TempDir()
+	seamPmxcfs(t, root, false, nil)
+	logger := logging.New(types.LogLevelDebug, false)
+
+	err := pmxcfsWriteFile(logger, "datacenter.cfg", []byte("keyboard: it\n"))
+	if err == nil || !strings.Contains(err.Error(), "not mounted") {
+		t.Fatalf("want a not-mounted refusal, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "datacenter.cfg")); !os.IsNotExist(statErr) {
+		t.Fatalf("a shadow write happened despite the guard: %v", statErr)
+	}
+}
+
+func TestPmxcfsWriteFileSurfacesTheMountCheckError(t *testing.T) {
+	seamPmxcfs(t, t.TempDir(), false, errors.New("proc unreadable"))
+	logger := logging.New(types.LogLevelDebug, false)
+
+	err := pmxcfsWriteFile(logger, "datacenter.cfg", []byte("x"))
+	if err == nil || !strings.Contains(err.Error(), "proc unreadable") {
+		t.Fatalf("want the mount-check cause surfaced, got %v", err)
+	}
+}

--- a/internal/orchestrator/pmxcfs_apply_test.go
+++ b/internal/orchestrator/pmxcfs_apply_test.go
@@ -19,6 +19,13 @@ func seamPmxcfs(t *testing.T, root string, mounted bool, mountErr error) {
 	pmxcfsIsMounted = func(string) (bool, error) { return mounted, mountErr }
 }
 
+func useRealPmxcfsRestoreFS(t *testing.T) {
+	t.Helper()
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+	restoreFS = osFS{}
+}
+
 func TestPmxcfsWriteFileWritesUnderTheRoot(t *testing.T) {
 	root := t.TempDir()
 	seamPmxcfs(t, root, true, nil)
@@ -57,5 +64,106 @@ func TestPmxcfsWriteFileSurfacesTheMountCheckError(t *testing.T) {
 	err := pmxcfsWriteFile(logger, "datacenter.cfg", []byte("x"))
 	if err == nil || !strings.Contains(err.Error(), "proc unreadable") {
 		t.Fatalf("want the mount-check cause surfaced, got %v", err)
+	}
+}
+
+func TestPmxcfsWriteFileRejectsUnsafeRelativePaths(t *testing.T) {
+	logger := logging.New(types.LogLevelDebug, false)
+	tests := []struct {
+		name    string
+		relPath func(base string) string
+	}{
+		{name: "empty", relPath: func(string) string { return "" }},
+		{name: "current directory", relPath: func(string) string { return "." }},
+		{name: "parent traversal", relPath: func(string) string { return "../outside.conf" }},
+		{name: "nested parent traversal", relPath: func(string) string { return "nodes/../../outside.conf" }},
+		{name: "absolute", relPath: func(base string) string { return filepath.Join(base, "absolute.conf") }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			root := filepath.Join(base, "pmxcfs")
+			if err := os.Mkdir(root, 0o755); err != nil {
+				t.Fatalf("create pmxcfs root: %v", err)
+			}
+			seamPmxcfs(t, root, true, nil)
+			useRealPmxcfsRestoreFS(t)
+
+			err := pmxcfsWriteFile(logger, tt.relPath(base), []byte("unsafe"))
+			if err == nil || !strings.Contains(err.Error(), "invalid pmxcfs path") {
+				t.Fatalf("want an invalid-path refusal, got %v", err)
+			}
+			if _, statErr := os.Stat(filepath.Join(base, "outside.conf")); !os.IsNotExist(statErr) {
+				t.Fatalf("a parent traversal created a file outside pmxcfs: %v", statErr)
+			}
+			if _, statErr := os.Stat(filepath.Join(base, "absolute.conf")); !os.IsNotExist(statErr) {
+				t.Fatalf("an absolute path created a file outside pmxcfs: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestPmxcfsWriteFileRefusesEscapingSymlink(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "pmxcfs")
+	outside := filepath.Join(base, "outside")
+	for _, dir := range []string{root, outside} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatalf("create escaping symlink: %v", err)
+	}
+	seamPmxcfs(t, root, true, nil)
+	useRealPmxcfsRestoreFS(t)
+	logger := logging.New(types.LogLevelDebug, false)
+
+	err := pmxcfsWriteFile(logger, "escape/guest.conf", []byte("unsafe"))
+	if err == nil {
+		t.Fatal("want an escaping-symlink refusal, got nil")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "guest.conf")); !os.IsNotExist(statErr) {
+		t.Fatalf("an escaping symlink created a file outside pmxcfs: %v", statErr)
+	}
+}
+
+func TestPmxcfsWriteFileRefusesReplacedMountRoot(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "pmxcfs")
+	detached := filepath.Join(base, "pmxcfs-detached")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("create pmxcfs root: %v", err)
+	}
+
+	origRoot, origMounted, origFS := pmxcfsRoot, pmxcfsIsMounted, restoreFS
+	t.Cleanup(func() {
+		pmxcfsRoot, pmxcfsIsMounted, restoreFS = origRoot, origMounted, origFS
+	})
+	pmxcfsRoot = root
+	restoreFS = osFS{}
+	pmxcfsIsMounted = func(string) (bool, error) {
+		if err := os.Rename(root, detached); err != nil {
+			return false, err
+		}
+		if err := os.Mkdir(root, 0o755); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+
+	err := pmxcfsWriteFile(logger, "nodes/pve/qemu-server/101.conf", []byte("unsafe"))
+	if err == nil || !strings.Contains(err.Error(), "changed while preparing write") {
+		t.Fatalf("want a mount-root identity refusal, got %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(root, "nodes/pve/qemu-server/101.conf"),
+		filepath.Join(detached, "nodes/pve/qemu-server/101.conf"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("mount replacement received a write at %s: %v", path, statErr)
+		}
 	}
 }

--- a/internal/orchestrator/pve_datacenter_pmxcfs_test.go
+++ b/internal/orchestrator/pve_datacenter_pmxcfs_test.go
@@ -1,0 +1,109 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// The live PVE 9.1.9 node answers `pvesh set /cluster/config` with
+// "No 'set' handler defined for '/cluster/config'": the endpoint the old arm
+// called does not exist, so datacenter.cfg was NEVER restored on a staged
+// apply. The fix writes the staged file into pmxcfs (which replicates
+// cluster-wide, same as pvesh would have); pvesh is not involved at all.
+func TestApplyPVEDatacenterCfgFromStageWritesThroughPmxcfs(t *testing.T) {
+	origFS, origCmd := restoreFS, restoreCmd
+	t.Cleanup(func() { restoreFS, restoreCmd = origFS, origCmd })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	pvesh := newSchemaAwarePvesh("local")
+	restoreCmd = pvesh
+	seamPmxcfs(t, "/etc/pve", true, nil)
+
+	if err := fakeFS.AddFile("/stage/etc/pve/datacenter.cfg", []byte("keyboard: it\nmigration: secure\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := logging.New(types.LogLevelDebug, false)
+	if err := applyPVEDatacenterCfgFromStage(context.Background(), logger, "/stage"); err != nil {
+		t.Fatalf("staged datacenter.cfg apply failed against the real pvesh surface: %v", err)
+	}
+
+	got, err := fakeFS.ReadFile("/etc/pve/datacenter.cfg")
+	if err != nil {
+		t.Fatalf("datacenter.cfg never landed in pmxcfs: %v", err)
+	}
+	if string(got) != "keyboard: it\nmigration: secure\n" {
+		t.Fatalf("pmxcfs content differs from the staged file: %q", got)
+	}
+	for _, call := range pvesh.calls {
+		if strings.Contains(call, "/cluster/config") {
+			t.Fatalf("the arm still calls the endpoint the live node refuses: %s", call)
+		}
+	}
+}
+
+func TestApplyPVEDatacenterCfgFromStageRefusesWithoutPmxcfs(t *testing.T) {
+	origFS, origCmd := restoreFS, restoreCmd
+	t.Cleanup(func() { restoreFS, restoreCmd = origFS, origCmd })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	restoreCmd = newSchemaAwarePvesh()
+	seamPmxcfs(t, "/etc/pve", false, nil)
+
+	if err := fakeFS.AddFile("/stage/etc/pve/datacenter.cfg", []byte("keyboard: it\n")); err != nil {
+		t.Fatal(err)
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+	err := applyPVEDatacenterCfgFromStage(context.Background(), logger, "/stage")
+	if err == nil || !strings.Contains(err.Error(), "not mounted") {
+		t.Fatalf("an unmounted pmxcfs must refuse the write, got %v", err)
+	}
+	if _, readErr := fakeFS.ReadFile("/etc/pve/datacenter.cfg"); readErr == nil {
+		t.Fatal("a shadow datacenter.cfg was written despite the guard")
+	}
+}
+
+// The SAFE-apply UI rail called the same dead endpoint; it now shares the
+// pmxcfs write, and the user's confirmation still gates it.
+func TestConfirmAndApplyDatacenterCfgWritesThroughPmxcfs(t *testing.T) {
+	origFS, origCmd := restoreFS, restoreCmd
+	t.Cleanup(func() { restoreFS, restoreCmd = origFS, origCmd })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	pvesh := newSchemaAwarePvesh()
+	restoreCmd = pvesh
+	seamPmxcfs(t, "/etc/pve", true, nil)
+
+	if err := fakeFS.AddFile("/export/etc/pve/datacenter.cfg", []byte("console: xtermjs\n")); err != nil {
+		t.Fatal(err)
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+	f := &safeClusterApplyUIFlow{
+		ctx:    context.Background(),
+		ui:     &fakeRestoreWorkflowUI{applyDatacenterCfg: true},
+		logger: logger,
+	}
+	if err := f.confirmAndApplyDatacenterCfg("/export/etc/pve/datacenter.cfg", 17); err != nil {
+		t.Fatalf("confirmAndApplyDatacenterCfg: %v", err)
+	}
+	got, err := fakeFS.ReadFile("/etc/pve/datacenter.cfg")
+	if err != nil {
+		t.Fatalf("datacenter.cfg never landed in pmxcfs: %v", err)
+	}
+	if string(got) != "console: xtermjs\n" {
+		t.Fatalf("pmxcfs content differs from the export file: %q", got)
+	}
+	for _, call := range pvesh.calls {
+		if strings.Contains(call, "/cluster/config") {
+			t.Fatalf("the UI rail still calls the dead endpoint: %s", call)
+		}
+	}
+}

--- a/internal/orchestrator/pve_guest_apply_race_test.go
+++ b/internal/orchestrator/pve_guest_apply_race_test.go
@@ -1,0 +1,71 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// A cluster-wide absence observed before the loop is not permission to write
+// later: another PVE actor may have claimed the VMID in the meantime. The final
+// decision and write must share PVE's native guest lock.
+func TestGuestCreatedAfterInventoryIsNotOverwritten(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	stagePath := "/export/etc/pve/nodes/" + node() + "/lxc/101.conf"
+	if err := fakeFS.AddFile(stagePath, []byte("hostname: restored-ct\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	pmxcfsIsMounted = func(string) (bool, error) {
+		// This hook is reached by the old direct writer after its one-time
+		// inventory decision, modelling a concurrent successful PVE create.
+		pvesh.guests["101"] = true
+		pvesh.guestKinds["101"] = "lxc"
+		pvesh.guestNodes["101"] = node()
+		return true, nil
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "101", Kind: "lxc", Name: "restored-ct", Path: stagePath,
+	}}, logger)
+	if applied != 0 || failed != 1 {
+		t.Fatalf("applied=%d failed=%d, want 0/1", applied, failed)
+	}
+	if _, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/lxc/101.conf"); !os.IsNotExist(err) {
+		t.Fatalf("concurrently created guest was overwritten: %v", err)
+	}
+}
+
+// A stopped result from status/current can become stale before a direct write.
+// Starting the guest must serialize with the final state check and prevent the
+// staged bytes from replacing its persistent configuration.
+func TestGuestStartedAfterStatusProbeIsNotOverwritten(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.guests["100"] = true
+	pvesh.failSet = map[string]bool{"100": true}
+
+	stagePath := "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf"
+	if err := fakeFS.AddFile(stagePath, []byte("name: restored-vm\ncores: 4\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	pmxcfsIsMounted = func(string) (bool, error) {
+		// The old path reaches this only after status/current said stopped.
+		pvesh.running["100"] = true
+		return true, nil
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "100", Kind: "qemu", Name: "restored-vm", Path: stagePath,
+	}}, logger)
+	if applied != 0 || failed != 1 {
+		t.Fatalf("applied=%d failed=%d, want 0/1", applied, failed)
+	}
+	if _, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/qemu-server/100.conf"); !os.IsNotExist(err) {
+		t.Fatalf("guest started after the status probe was overwritten: %v", err)
+	}
+	if calls := strings.Join(pvesh.calls, "\n"); !strings.Contains(calls, "/status/current") {
+		t.Fatalf("test did not reach the status/write race window:\n%s", calls)
+	}
+}

--- a/internal/orchestrator/pve_guest_apply_test.go
+++ b/internal/orchestrator/pve_guest_apply_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -104,16 +103,7 @@ func TestRunningGuestSkipsTheFileFallback(t *testing.T) {
 	if err := fakeFS.AddFile(stagePath, []byte(conf)); err != nil {
 		t.Fatal(err)
 	}
-	// Force the API to fail even without create-only keys: an exact-key error on
-	// the filtered set would need the fake to know the filtered args; simplest is
-	// a conf whose only content beyond the name is the rejected key, so the
-	// filtered set still succeeds - instead make the guest set fail by pointing
-	// the entry at a conf with a key the fake refuses on qemu: none exists, so
-	// drive the failure through --meta NOT being filtered is impossible once the
-	// filter works. The honest failure seam is the fake itself: mark the set as
-	// failing via a bogus storage-style rejection is not available - so this test
-	// plants meta AND teaches the fake that vm100's set always fails by using the
-	// running flag only for the fallback decision and an explicit set failure:
+	// Force the filtered set to fail so the test reaches the running-status guard.
 	pvesh.failSet = map[string]bool{"100": true}
 
 	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
@@ -152,7 +142,6 @@ func TestStoppedGuestFallsBackToTheConfFile(t *testing.T) {
 	if err != nil || string(got) != conf {
 		t.Fatalf("fallback conf not written: %q err=%v", got, err)
 	}
-	_ = filepath.Join
 }
 
 func assertUncertainGuestStatusSkipsFileFallback(t *testing.T, statusOutput []byte, statusErr error, logMarkers ...string) {

--- a/internal/orchestrator/pve_guest_apply_test.go
+++ b/internal/orchestrator/pve_guest_apply_test.go
@@ -1,0 +1,155 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func guestApplyFixture(t *testing.T) (*FakeFS, *schemaAwarePvesh, *logging.Logger, func() string) {
+	t.Helper()
+	origFS, origCmd := restoreFS, restoreCmd
+	t.Cleanup(func() { restoreFS, restoreCmd = origFS, origCmd })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	pvesh := newSchemaAwarePvesh()
+	restoreCmd = pvesh
+	seamPmxcfs(t, "/etc/pve", true, nil)
+	logBuf := logging.New(types.LogLevelDebug, false)
+	return fakeFS, pvesh, logBuf, localNodeName
+}
+
+// Every VM created on PVE >= 7.2 carries `meta:` in its conf, and the live
+// node's qemu set-schema has no --meta ("meta: property is not defined in
+// schema", probed 2026-09-02): one rejected key failed the WHOLE set, so no
+// config was ever applied for a modern guest (fable-check bug 2). The API is
+// still tried first minus the create-only keys; the staged conf file is the
+// fidelity net.
+func TestExistingGuestConfigSurvivesTheMetaRejection(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.guests["100"] = true
+
+	conf := "name: vm100\nmeta: creation-qemu=10.1.2,ctime=1776092687\ncores: 2\n"
+	if err := fakeFS.AddFile("/export/etc/pve/nodes/"+node()+"/qemu-server/100.conf", []byte(conf)); err != nil {
+		t.Fatal(err)
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "100", Kind: "qemu", Name: "vm100",
+		Path: "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf",
+	}}, logger)
+	if applied != 1 || failed != 0 {
+		t.Fatalf("applied=%d failed=%d, want 1/0", applied, failed)
+	}
+	// The API attempt must NOT carry the create-only key the schema refuses.
+	for _, call := range pvesh.calls {
+		if strings.Contains(call, "set /nodes/") && strings.Contains(call, "--meta=") {
+			t.Fatalf("the set still sends --meta, the key the live schema refuses: %s", call)
+		}
+	}
+	if _, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/qemu-server/100.conf"); err == nil {
+		t.Fatal("the API path succeeded, the file net must stay unused")
+	}
+}
+
+// A missing LXC could never be created: pveshCreateGuestArgs demanded an
+// ostemplate no real conf carries (create-time-only parameter; the passing
+// unit test hand-fed it). Writing the conf into pmxcfs IS how a guest comes
+// into existence; disks are not part of a config restore and the log says so.
+func TestMissingLxcIsRegisteredByWritingItsConf(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+
+	conf := "hostname: ct101\nunprivileged: 1\nrootfs: local:101/vm-101-disk-0.raw,size=8G\n"
+	stagePath := "/export/etc/pve/nodes/" + node() + "/lxc/101.conf"
+	if err := fakeFS.AddFile(stagePath, []byte(conf)); err != nil {
+		t.Fatal(err)
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "101", Kind: "lxc", Name: "ct101", Path: stagePath,
+	}}, logger)
+	if applied != 1 || failed != 0 {
+		t.Fatalf("applied=%d failed=%d, want 1/0", applied, failed)
+	}
+	got, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/lxc/101.conf")
+	if err != nil || string(got) != conf {
+		t.Fatalf("conf not registered in pmxcfs: %q err=%v", got, err)
+	}
+	for _, call := range pvesh.calls {
+		if strings.Contains(call, "create /nodes/") {
+			t.Fatalf("pvesh create is a dead end (ostemplate) and must be gone: %s", call)
+		}
+	}
+}
+
+// The maintainer's guard: a set that fails on a RUNNING guest does not get the
+// file fallback - a config race with a live guest - and the warning names it.
+func TestRunningGuestSkipsTheFileFallback(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.guests["100"] = true
+	pvesh.running["100"] = true
+
+	buf := &strings.Builder{}
+	logger.SetOutput(buf)
+
+	conf := "name: vm100\nmeta: creation-qemu=10.1.2\n"
+	stagePath := "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf"
+	if err := fakeFS.AddFile(stagePath, []byte(conf)); err != nil {
+		t.Fatal(err)
+	}
+	// Force the API to fail even without create-only keys: an exact-key error on
+	// the filtered set would need the fake to know the filtered args; simplest is
+	// a conf whose only content beyond the name is the rejected key, so the
+	// filtered set still succeeds - instead make the guest set fail by pointing
+	// the entry at a conf with a key the fake refuses on qemu: none exists, so
+	// drive the failure through --meta NOT being filtered is impossible once the
+	// filter works. The honest failure seam is the fake itself: mark the set as
+	// failing via a bogus storage-style rejection is not available - so this test
+	// plants meta AND teaches the fake that vm100's set always fails by using the
+	// running flag only for the fallback decision and an explicit set failure:
+	pvesh.failSet = map[string]bool{"100": true}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "100", Kind: "qemu", Name: "vm100", Path: stagePath,
+	}}, logger)
+	if applied != 0 || failed != 1 {
+		t.Fatalf("applied=%d failed=%d, want 0/1", applied, failed)
+	}
+	if _, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/qemu-server/100.conf"); err == nil {
+		t.Fatal("the file was written under a running guest")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "100") || !strings.Contains(out, "running") {
+		t.Fatalf("the warning does not name the guest and the reason:\n%s", out)
+	}
+}
+
+// A stopped guest whose set fails for any reason gets the file: fidelity net.
+func TestStoppedGuestFallsBackToTheConfFile(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.guests["100"] = true
+	pvesh.failSet = map[string]bool{"100": true}
+
+	conf := "name: vm100\ncores: 4\n"
+	stagePath := "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf"
+	if err := fakeFS.AddFile(stagePath, []byte(conf)); err != nil {
+		t.Fatal(err)
+	}
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "100", Kind: "qemu", Name: "vm100", Path: stagePath,
+	}}, logger)
+	if applied != 1 || failed != 0 {
+		t.Fatalf("applied=%d failed=%d, want 1/0", applied, failed)
+	}
+	got, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/qemu-server/100.conf")
+	if err != nil || string(got) != conf {
+		t.Fatalf("fallback conf not written: %q err=%v", got, err)
+	}
+	_ = filepath.Join
+}

--- a/internal/orchestrator/pve_guest_apply_test.go
+++ b/internal/orchestrator/pve_guest_apply_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,4 +153,57 @@ func TestStoppedGuestFallsBackToTheConfFile(t *testing.T) {
 		t.Fatalf("fallback conf not written: %q err=%v", got, err)
 	}
 	_ = filepath.Join
+}
+
+func assertUncertainGuestStatusSkipsFileFallback(t *testing.T, statusOutput []byte, statusErr error, logMarkers ...string) {
+	t.Helper()
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.guests["100"] = true
+	pvesh.failSet = map[string]bool{"100": true}
+	if statusOutput != nil {
+		pvesh.statusOutput["100"] = statusOutput
+	}
+	if statusErr != nil {
+		pvesh.statusError["100"] = statusErr
+	}
+
+	buf := &strings.Builder{}
+	logger.SetOutput(buf)
+	conf := "name: vm100\ncores: 4\n"
+	stagePath := "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf"
+	if err := fakeFS.AddFile(stagePath, []byte(conf)); err != nil {
+		t.Fatal(err)
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "100", Kind: "qemu", Name: "vm100", Path: stagePath,
+	}}, logger)
+	if applied != 0 || failed != 1 {
+		t.Fatalf("applied=%d failed=%d, want 0/1", applied, failed)
+	}
+	if _, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/qemu-server/100.conf"); err == nil {
+		t.Fatal("the file fallback ran without an explicit stopped status")
+	}
+	logOutput := buf.String()
+	for _, marker := range append([]string{"100"}, logMarkers...) {
+		if !strings.Contains(logOutput, marker) {
+			t.Fatalf("warning does not contain %q:\n%s", marker, logOutput)
+		}
+	}
+}
+
+func TestGuestStatusProbeFailureSkipsFileFallback(t *testing.T) {
+	assertUncertainGuestStatusSkipsFileFallback(t, nil, errors.New("status unavailable"), "status unavailable")
+}
+
+func TestMalformedGuestStatusSkipsFileFallback(t *testing.T) {
+	assertUncertainGuestStatusSkipsFileFallback(t, []byte(`{"status":`), nil, "status")
+}
+
+func TestPrettyPrintedRunningStatusSkipsFileFallback(t *testing.T) {
+	assertUncertainGuestStatusSkipsFileFallback(t, []byte("{\n  \"vmid\": 100,\n  \"status\": \"running\"\n}"), nil, "running")
+}
+
+func TestUnknownGuestStatusSkipsFileFallback(t *testing.T) {
+	assertUncertainGuestStatusSkipsFileFallback(t, []byte(`{"status":"unknown","vmid":100}`), nil, "unknown")
 }

--- a/internal/orchestrator/pve_guest_apply_test.go
+++ b/internal/orchestrator/pve_guest_apply_test.go
@@ -3,7 +3,9 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,8 +15,10 @@ import (
 
 func guestApplyFixture(t *testing.T) (*FakeFS, *schemaAwarePvesh, *logging.Logger, func() string) {
 	t.Helper()
-	origFS, origCmd := restoreFS, restoreCmd
-	t.Cleanup(func() { restoreFS, restoreCmd = origFS, origCmd })
+	origFS, origCmd, origLockedWriter := restoreFS, restoreCmd, pveGuestLockedWriter
+	t.Cleanup(func() {
+		restoreFS, restoreCmd, pveGuestLockedWriter = origFS, origCmd, origLockedWriter
+	})
 	fakeFS := NewFakeFS()
 	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
 	restoreFS = fakeFS
@@ -22,6 +26,58 @@ func guestApplyFixture(t *testing.T) (*FakeFS, *schemaAwarePvesh, *logging.Logge
 	restoreCmd = pvesh
 	seamPmxcfs(t, "/etc/pve", true, nil)
 	logBuf := logging.New(types.LogLevelDebug, false)
+	pveGuestLockedWriter = func(
+		_ context.Context,
+		logger *logging.Logger,
+		currentNode string,
+		vm vmEntry,
+		precondition guestApplyPrecondition,
+		data []byte,
+	) error {
+		// Run the test hook before the simulated locked decision. Race tests use
+		// pmxcfsIsMounted to inject a create/start at this exact boundary.
+		mounted, err := pmxcfsIsMounted(pmxcfsRoot)
+		if err != nil {
+			return err
+		}
+		if !mounted {
+			return fmt.Errorf("%s is not mounted", pmxcfsRoot)
+		}
+
+		exists := pvesh.guests[vm.VMID]
+		switch precondition {
+		case guestMustBeAbsent:
+			if exists {
+				return fmt.Errorf("guest %s appeared before locked apply", vm.VMID)
+			}
+		case guestMustBeStopped:
+			if !exists {
+				return fmt.Errorf("guest %s disappeared before locked apply", vm.VMID)
+			}
+			owner := pvesh.guestNodes[vm.VMID]
+			if owner == "" {
+				owner = currentNode
+			}
+			if owner != currentNode {
+				return fmt.Errorf("guest %s belongs to node %s", vm.VMID, owner)
+			}
+			kind := pvesh.guestKinds[vm.VMID]
+			if kind == "" {
+				kind = "qemu"
+			}
+			if kind != vm.Kind {
+				return fmt.Errorf("guest %s is %s, not %s", vm.VMID, kind, vm.Kind)
+			}
+			if pvesh.running[vm.VMID] {
+				return fmt.Errorf("guest %s is running", vm.VMID)
+			}
+		default:
+			return fmt.Errorf("invalid guest apply precondition %q", precondition)
+		}
+
+		rel := filepath.Join("nodes", currentNode, guestConfDir(vm.Kind), vm.VMID+".conf")
+		return pmxcfsWriteFile(logger, rel, data)
+	}
 	return fakeFS, pvesh, logBuf, localNodeName
 }
 

--- a/internal/orchestrator/pve_guest_apply_test.go
+++ b/internal/orchestrator/pve_guest_apply_test.go
@@ -207,3 +207,126 @@ func TestPrettyPrintedRunningStatusSkipsFileFallback(t *testing.T) {
 func TestUnknownGuestStatusSkipsFileFallback(t *testing.T) {
 	assertUncertainGuestStatusSkipsFileFallback(t, []byte(`{"status":"unknown","vmid":100}`), nil, "unknown")
 }
+
+func TestRemoteGuestIsNeverAppliedOnTheCurrentNode(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.guests["100"] = true
+	pvesh.guestNodes["100"] = "pve-remote"
+
+	buf := &strings.Builder{}
+	logger.SetOutput(buf)
+	stagePath := "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf"
+	if err := fakeFS.AddFile(stagePath, []byte("name: vm100\ncores: 4\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "100", Kind: "qemu", Name: "vm100", Path: stagePath,
+	}}, logger)
+	if applied != 0 || failed != 1 {
+		t.Fatalf("applied=%d failed=%d, want 0/1", applied, failed)
+	}
+	if _, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/qemu-server/100.conf"); err == nil {
+		t.Fatal("remote guest config was written on the current node")
+	}
+	for _, call := range pvesh.calls {
+		if strings.Contains(call, "set /nodes/") || strings.Contains(call, "/status/current") {
+			t.Fatalf("remote guest reached a mutating or fallback-probe call: %s", call)
+		}
+	}
+	output := buf.String()
+	for _, marker := range []string{"100", "pve-remote", "Start pve guest configs apply", "End pve guest configs apply"} {
+		if !strings.Contains(output, marker) {
+			t.Fatalf("log does not contain %q:\n%s", marker, output)
+		}
+	}
+}
+
+func TestGuestKindMismatchIsNeverApplied(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.guests["100"] = true
+	pvesh.guestKinds["100"] = "lxc"
+
+	buf := &strings.Builder{}
+	logger.SetOutput(buf)
+	stagePath := "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf"
+	if err := fakeFS.AddFile(stagePath, []byte("name: vm100\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "100", Kind: "qemu", Name: "vm100", Path: stagePath,
+	}}, logger)
+	if applied != 0 || failed != 1 {
+		t.Fatalf("applied=%d failed=%d, want 0/1", applied, failed)
+	}
+	if _, err := fakeFS.ReadFile("/etc/pve/nodes/" + node() + "/qemu-server/100.conf"); err == nil {
+		t.Fatal("type-mismatched guest config was written")
+	}
+	for _, call := range pvesh.calls {
+		if strings.Contains(call, "set /nodes/") || strings.Contains(call, "/status/current") {
+			t.Fatalf("type-mismatched guest reached a mutating or fallback-probe call: %s", call)
+		}
+	}
+	if output := buf.String(); !strings.Contains(output, "100") || !strings.Contains(output, "lxc") || !strings.Contains(output, "qemu") {
+		t.Fatalf("warning does not explain the type mismatch:\n%s", output)
+	}
+}
+
+func TestGuestInventoryFailureSkipsEveryMutation(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.guests["100"] = true
+	pvesh.guests["101"] = true
+	pvesh.guestKinds["101"] = "lxc"
+	pvesh.inventoryError = errors.New("cluster inventory unavailable")
+
+	buf := &strings.Builder{}
+	logger.SetOutput(buf)
+	qemuPath := "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf"
+	lxcPath := "/export/etc/pve/nodes/" + node() + "/lxc/101.conf"
+	if err := fakeFS.AddFile(qemuPath, []byte("name: vm100\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := fakeFS.AddFile(lxcPath, []byte("hostname: ct101\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{
+		{VMID: "100", Kind: "qemu", Name: "vm100", Path: qemuPath},
+		{VMID: "101", Kind: "lxc", Name: "ct101", Path: lxcPath},
+	}, logger)
+	if applied != 0 || failed != 2 {
+		t.Fatalf("applied=%d failed=%d, want 0/2", applied, failed)
+	}
+	if len(pvesh.calls) != 1 || !strings.Contains(pvesh.calls[0], "get /cluster/resources --type vm") {
+		t.Fatalf("inventory failure must stop after one read-only query: %v", pvesh.calls)
+	}
+	if output := buf.String(); !strings.Contains(output, "cluster inventory unavailable") {
+		t.Fatalf("warning does not report the inventory failure:\n%s", output)
+	}
+}
+
+func TestMalformedGuestInventorySkipsEveryMutation(t *testing.T) {
+	fakeFS, pvesh, logger, node := guestApplyFixture(t)
+	pvesh.inventoryOutput = []byte(`{"vmid":100}`)
+
+	buf := &strings.Builder{}
+	logger.SetOutput(buf)
+	stagePath := "/export/etc/pve/nodes/" + node() + "/qemu-server/100.conf"
+	if err := fakeFS.AddFile(stagePath, []byte("name: vm100\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	applied, failed := applyVMConfigs(context.Background(), []vmEntry{{
+		VMID: "100", Kind: "qemu", Name: "vm100", Path: stagePath,
+	}}, logger)
+	if applied != 0 || failed != 1 {
+		t.Fatalf("applied=%d failed=%d, want 0/1", applied, failed)
+	}
+	if len(pvesh.calls) != 1 || !strings.Contains(pvesh.calls[0], "get /cluster/resources --type vm") {
+		t.Fatalf("malformed inventory must stop after one read-only query: %v", pvesh.calls)
+	}
+	if output := buf.String(); !strings.Contains(output, "expected a JSON array") {
+		t.Fatalf("warning does not report malformed inventory:\n%s", output)
+	}
+}

--- a/internal/orchestrator/pve_guest_inventory.go
+++ b/internal/orchestrator/pve_guest_inventory.go
@@ -1,0 +1,60 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type pveGuestResource struct {
+	VMID   int    `json:"vmid"`
+	Node   string `json:"node"`
+	Kind   string `json:"type"`
+	Status string `json:"status"`
+	Name   string `json:"name"`
+}
+
+func loadPVEGuestInventory(ctx context.Context) (map[string]pveGuestResource, error) {
+	const endpoint = "/cluster/resources"
+	out, err := restoreCmd.Run(ctx, "pvesh", "get", endpoint, "--type", "vm", "--output-format=json")
+	if err != nil {
+		return nil, fmt.Errorf("pvesh get %s: %w", endpoint, err)
+	}
+
+	payload := bytes.TrimSpace(out)
+	if len(payload) == 0 || payload[0] != '[' {
+		return nil, fmt.Errorf("parse PVE guest inventory: expected a JSON array")
+	}
+
+	var resources []pveGuestResource
+	if err := json.Unmarshal(payload, &resources); err != nil {
+		return nil, fmt.Errorf("parse PVE guest inventory: %w", err)
+	}
+
+	inventory := make(map[string]pveGuestResource, len(resources))
+	for index, resource := range resources {
+		resource.Node = strings.TrimSpace(resource.Node)
+		resource.Kind = strings.ToLower(strings.TrimSpace(resource.Kind))
+		resource.Status = strings.ToLower(strings.TrimSpace(resource.Status))
+		resource.Name = strings.TrimSpace(resource.Name)
+		if resource.VMID <= 0 {
+			return nil, fmt.Errorf("parse PVE guest inventory: item %d has an invalid vmid", index)
+		}
+		if resource.Node == "" {
+			return nil, fmt.Errorf("parse PVE guest inventory: vmid %d has no node", resource.VMID)
+		}
+		if resource.Kind != "qemu" && resource.Kind != "lxc" {
+			return nil, fmt.Errorf("parse PVE guest inventory: vmid %d has invalid type %q", resource.VMID, resource.Kind)
+		}
+
+		vmid := strconv.Itoa(resource.VMID)
+		if _, exists := inventory[vmid]; exists {
+			return nil, fmt.Errorf("parse PVE guest inventory: duplicate vmid %s", vmid)
+		}
+		inventory[vmid] = resource
+	}
+	return inventory, nil
+}

--- a/internal/orchestrator/pve_guest_inventory_test.go
+++ b/internal/orchestrator/pve_guest_inventory_test.go
@@ -1,0 +1,78 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const pveGuestInventoryCommand = "pvesh get /cluster/resources --type vm --output-format=json"
+
+func guestInventoryJSON(t *testing.T, resources ...pveGuestResource) []byte {
+	t.Helper()
+	if resources == nil {
+		resources = []pveGuestResource{}
+	}
+	out, err := json.Marshal(resources)
+	if err != nil {
+		t.Fatalf("marshal guest inventory: %v", err)
+	}
+	return out
+}
+
+func TestLoadPVEGuestInventoryParsesCompleteResources(t *testing.T) {
+	origCmd := restoreCmd
+	t.Cleanup(func() { restoreCmd = origCmd })
+	restoreCmd = &FakeCommandRunner{Outputs: map[string][]byte{
+		pveGuestInventoryCommand: []byte(`[
+			{"vmid":100,"node":"pve-a","type":"qemu","status":"running","name":"vm100"},
+			{"vmid":101,"node":"pve-b","type":"lxc","status":"stopped","name":"ct101"}
+		]`),
+	}}
+
+	got, err := loadPVEGuestInventory(context.Background())
+	if err != nil {
+		t.Fatalf("loadPVEGuestInventory: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("inventory size=%d, want 2", len(got))
+	}
+	if guest := got["100"]; guest.Node != "pve-a" || guest.Kind != "qemu" || guest.Status != "running" {
+		t.Fatalf("guest 100=%+v", guest)
+	}
+	if guest := got["101"]; guest.Node != "pve-b" || guest.Kind != "lxc" || guest.Status != "stopped" {
+		t.Fatalf("guest 101=%+v", guest)
+	}
+}
+
+func TestLoadPVEGuestInventoryRejectsUnsafeResponses(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		marker string
+	}{
+		{name: "malformed JSON", output: `{"vmid":`, marker: "parse"},
+		{name: "non-array JSON", output: `{"vmid":100}`, marker: "array"},
+		{name: "null JSON", output: `null`, marker: "array"},
+		{name: "missing node", output: `[{"vmid":100,"type":"qemu"}]`, marker: "node"},
+		{name: "missing kind", output: `[{"vmid":100,"node":"pve-a"}]`, marker: "type"},
+		{name: "invalid kind", output: `[{"vmid":100,"node":"pve-a","type":"storage"}]`, marker: "type"},
+		{name: "duplicate VMID", output: `[{"vmid":100,"node":"pve-a","type":"qemu"},{"vmid":100,"node":"pve-b","type":"qemu"}]`, marker: "duplicate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origCmd := restoreCmd
+			t.Cleanup(func() { restoreCmd = origCmd })
+			restoreCmd = &FakeCommandRunner{Outputs: map[string][]byte{
+				pveGuestInventoryCommand: []byte(tt.output),
+			}}
+
+			_, err := loadPVEGuestInventory(context.Background())
+			if err == nil || !strings.Contains(strings.ToLower(err.Error()), tt.marker) {
+				t.Fatalf("error=%v, want marker %q", err, tt.marker)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/pve_guest_locked_apply.go
+++ b/internal/orchestrator/pve_guest_locked_apply.go
@@ -1,0 +1,196 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/safeexec"
+	"github.com/tis24dev/proxsave/internal/ui/components"
+)
+
+type guestApplyPrecondition string
+
+const (
+	guestMustBeAbsent  guestApplyPrecondition = "absent"
+	guestMustBeStopped guestApplyPrecondition = "stopped"
+	pvePerlPath                               = "/usr/bin/perl"
+)
+
+type pveGuestLockedWriterFunc func(
+	ctx context.Context,
+	logger *logging.Logger,
+	node string,
+	vm vmEntry,
+	precondition guestApplyPrecondition,
+	data []byte,
+) error
+
+var pveGuestLockedWriter pveGuestLockedWriterFunc = writeGuestConfigWithPVELock
+
+var runPVEGuestLockHelper = func(ctx context.Context, args ...string) ([]byte, error) {
+	cmd, err := safeexec.TrustedCommandContext(ctx, pvePerlPath, args...)
+	if err != nil {
+		return nil, err
+	}
+	return cmd.CombinedOutput()
+}
+
+// pveGuestLockedApplyPerl deliberately uses PVE's own QEMU and LXC lock
+// implementations. Both locks are acquired in one fixed order so a VMID cannot
+// race through the other guest kind while cluster ownership is revalidated.
+// All dynamic values arrive through @ARGV; none is interpolated into the code.
+const pveGuestLockedApplyPerl = `
+use strict;
+use warnings;
+
+use Digest::SHA qw(sha256_hex);
+use PVE::Cluster ();
+use PVE::INotify ();
+use PVE::LXC ();
+use PVE::LXC::Config ();
+use PVE::QemuConfig ();
+use PVE::QemuServer ();
+use PVE::Tools ();
+
+my ($expected, $kind, $vmid, $node, $source, $digest) = @ARGV;
+
+die "invalid guest apply precondition\n"
+    if !defined($expected) || ($expected ne 'absent' && $expected ne 'stopped');
+die "invalid guest kind\n"
+    if !defined($kind) || ($kind ne 'qemu' && $kind ne 'lxc');
+die "invalid guest VMID\n"
+    if !defined($vmid) || $vmid !~ m/\A[1-9][0-9]*\z/;
+die "invalid PVE node\n"
+    if !defined($node) || $node ne PVE::INotify::nodename();
+die "invalid staged configuration path\n"
+    if !defined($source) || $source !~ m!\A/!;
+die "invalid staged configuration digest\n"
+    if !defined($digest) || $digest !~ m/\A[0-9a-f]{64}\z/;
+
+my $class = $kind eq 'qemu' ? 'PVE::QemuConfig' : 'PVE::LXC::Config';
+my $is_running = $kind eq 'qemu'
+    ? sub { return PVE::QemuServer::check_running($vmid) ? 1 : 0; }
+    : sub { return PVE::LXC::check_running($vmid) ? 1 : 0; };
+
+my $apply = sub {
+    PVE::Cluster::cfs_update();
+    PVE::Cluster::check_cfs_quorum();
+
+    open(my $src, '<:raw', $source)
+        or die "open staged guest configuration failed: $!\n";
+    local $/;
+    my $data = <$src>;
+    $data = '' if !defined($data);
+    close($src) or die "close staged guest configuration failed: $!\n";
+    die "staged guest configuration changed before locked apply\n"
+        if sha256_hex($data) ne $digest;
+
+    my $vmlist = PVE::Cluster::get_vmlist();
+    my $record = $vmlist->{ids}->{$vmid};
+    my $target = $class->config_file($vmid, $node);
+    my $registered = 0;
+
+    if ($expected eq 'absent') {
+        die "guest $vmid appeared before locked apply\n" if defined($record);
+        PVE::Cluster::check_vmid_unused($vmid);
+
+        # Register a create-locked placeholder through PVE's configuration
+        # writer first. This gives pmxcfs/PVE the same atomic VMID claim used by
+        # normal guest creation before the exact staged bytes replace it.
+        $class->write_config($vmid, { lock => 'create' });
+        $registered = 1;
+    } else {
+        die "guest $vmid disappeared before locked apply\n" if !defined($record);
+        die "guest $vmid belongs to node '$record->{node}', not '$node'\n"
+            if !defined($record->{node}) || $record->{node} ne $node;
+        die "guest $vmid is '$record->{type}', not '$kind'\n"
+            if !defined($record->{type}) || $record->{type} ne $kind;
+
+        # Loading the canonical same-kind config inside the lock also refuses a
+        # concurrent move or deletion before the runtime-state decision.
+        $class->load_config($vmid, $node);
+        die "guest $vmid is running; refusing locked file apply\n" if $is_running->();
+    }
+
+    eval { PVE::Tools::file_set_contents($target, $data, 0640); };
+    my $write_error = $@;
+    if ($write_error) {
+        if ($registered) {
+            eval { $class->destroy_config($vmid); };
+            my $cleanup_error = $@;
+            $write_error .= "cleanup of create placeholder failed: $cleanup_error"
+                if $cleanup_error;
+        }
+        die $write_error;
+    }
+};
+
+# QEMU and LXC use different local lock files for the same numeric VMID. Take
+# both in this invariant order, then make the cluster decision and write once.
+PVE::QemuConfig->lock_config($vmid, sub {
+    PVE::LXC::Config->lock_config($vmid, $apply);
+});
+`
+
+func writeGuestConfigWithPVELock(
+	ctx context.Context,
+	logger *logging.Logger,
+	node string,
+	vm vmEntry,
+	precondition guestApplyPrecondition,
+	data []byte,
+) error {
+	if precondition != guestMustBeAbsent && precondition != guestMustBeStopped {
+		return fmt.Errorf("invalid guest apply precondition %q", precondition)
+	}
+	if vm.Kind != "qemu" && vm.Kind != "lxc" {
+		return fmt.Errorf("invalid guest kind %q", vm.Kind)
+	}
+	vmid, err := strconv.Atoi(vm.VMID)
+	if err != nil || vmid <= 0 || strconv.Itoa(vmid) != vm.VMID {
+		return fmt.Errorf("invalid guest VMID %q", vm.VMID)
+	}
+	if strings.TrimSpace(node) == "" {
+		return fmt.Errorf("invalid empty PVE node")
+	}
+	if !filepath.IsAbs(vm.Path) {
+		return fmt.Errorf("staged guest configuration path must be absolute: %s", vm.Path)
+	}
+
+	digest := sha256.Sum256(data)
+	out, runErr := runPVEGuestLockHelper(
+		ctx,
+		"-e", pveGuestLockedApplyPerl, "--",
+		string(precondition), vm.Kind, vm.VMID, node, vm.Path, hex.EncodeToString(digest[:]),
+	)
+	if runErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		detail := compactPVEGuestHelperOutput(out)
+		if detail != "" {
+			return fmt.Errorf("PVE locked guest apply failed: %w (output: %s)", runErr, detail)
+		}
+		return fmt.Errorf("PVE locked guest apply failed: %w", runErr)
+	}
+	if detail := compactPVEGuestHelperOutput(out); detail != "" {
+		logger.Debug("PVE locked guest apply vmid=%s output: %s", vm.VMID, detail)
+	}
+	return nil
+}
+
+func compactPVEGuestHelperOutput(out []byte) string {
+	const maxRunes = 512
+	detail := components.SanitizeLine(strings.TrimSpace(string(out)))
+	runes := []rune(detail)
+	if len(runes) > maxRunes {
+		detail = string(runes[:maxRunes]) + "…"
+	}
+	return detail
+}

--- a/internal/orchestrator/pve_guest_locked_apply_test.go
+++ b/internal/orchestrator/pve_guest_locked_apply_test.go
@@ -1,0 +1,113 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+func TestPVEGuestLockedWriterUsesFixedPerlProgramAndArgv(t *testing.T) {
+	orig := runPVEGuestLockHelper
+	t.Cleanup(func() { runPVEGuestLockHelper = orig })
+
+	var gotArgs []string
+	runPVEGuestLockHelper = func(_ context.Context, args ...string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		return nil, nil
+	}
+
+	data := []byte("hostname: ct101\n")
+	err := writeGuestConfigWithPVELock(
+		context.Background(),
+		logging.New(types.LogLevelDebug, false),
+		"pve",
+		vmEntry{VMID: "101", Kind: "lxc", Path: "/var/tmp/staged/101.conf"},
+		guestMustBeAbsent,
+		data,
+	)
+	if err != nil {
+		t.Fatalf("writeGuestConfigWithPVELock: %v", err)
+	}
+	if len(gotArgs) != 9 {
+		t.Fatalf("helper args=%d, want 9: %#v", len(gotArgs), gotArgs)
+	}
+	if gotArgs[0] != "-e" || gotArgs[1] != pveGuestLockedApplyPerl || gotArgs[2] != "--" {
+		t.Fatalf("helper is not a fixed perl -e invocation: %#v", gotArgs[:3])
+	}
+	wantDigest := sha256.Sum256(data)
+	wantTail := []string{"absent", "lxc", "101", "pve", "/var/tmp/staged/101.conf", hex.EncodeToString(wantDigest[:])}
+	for i, want := range wantTail {
+		if got := gotArgs[i+3]; got != want {
+			t.Fatalf("helper arg %d=%q, want %q", i+3, got, want)
+		}
+	}
+	for _, arg := range gotArgs[3:] {
+		if arg == string(data) {
+			t.Fatal("configuration bytes were embedded into argv")
+		}
+	}
+}
+
+func TestPVEGuestLockedWriterFailsClosedWithSanitizedBoundedOutput(t *testing.T) {
+	orig := runPVEGuestLockHelper
+	t.Cleanup(func() { runPVEGuestLockHelper = orig })
+
+	runErr := errors.New("exit status 255")
+	runPVEGuestLockHelper = func(context.Context, ...string) ([]byte, error) {
+		return []byte("\x1b[31mguest started\x1b[0m\n" + strings.Repeat("x", 700)), runErr
+	}
+	err := writeGuestConfigWithPVELock(
+		context.Background(),
+		logging.New(types.LogLevelDebug, false),
+		"pve",
+		vmEntry{VMID: "100", Kind: "qemu", Path: "/var/tmp/staged/100.conf"},
+		guestMustBeStopped,
+		[]byte("name: vm100\n"),
+	)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("want helper error retained, got %v", err)
+	}
+	message := err.Error()
+	if strings.Contains(message, "\x1b") || strings.Contains(message, "\n") {
+		t.Fatalf("helper output was not reduced to a safe single line: %q", message)
+	}
+	if !strings.Contains(message, "guest started") || !strings.HasSuffix(message, "…)") {
+		t.Fatalf("helper output was not preserved and bounded: %q", message)
+	}
+}
+
+func TestPVEGuestLockedWriterRejectsInvalidInputsBeforeExecution(t *testing.T) {
+	orig := runPVEGuestLockHelper
+	t.Cleanup(func() { runPVEGuestLockHelper = orig })
+	runPVEGuestLockHelper = func(context.Context, ...string) ([]byte, error) {
+		t.Fatal("helper executed for invalid input")
+		return nil, nil
+	}
+
+	logger := logging.New(types.LogLevelDebug, false)
+	tests := []struct {
+		name         string
+		node         string
+		vm           vmEntry
+		precondition guestApplyPrecondition
+	}{
+		{name: "unknown precondition", node: "pve", vm: vmEntry{VMID: "100", Kind: "qemu", Path: "/tmp/100.conf"}, precondition: "unknown"},
+		{name: "unknown kind", node: "pve", vm: vmEntry{VMID: "100", Kind: "other", Path: "/tmp/100.conf"}, precondition: guestMustBeAbsent},
+		{name: "non-canonical vmid", node: "pve", vm: vmEntry{VMID: "0100", Kind: "qemu", Path: "/tmp/100.conf"}, precondition: guestMustBeAbsent},
+		{name: "empty node", node: " ", vm: vmEntry{VMID: "100", Kind: "qemu", Path: "/tmp/100.conf"}, precondition: guestMustBeAbsent},
+		{name: "relative source", node: "pve", vm: vmEntry{VMID: "100", Kind: "qemu", Path: "100.conf"}, precondition: guestMustBeAbsent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := writeGuestConfigWithPVELock(context.Background(), logger, tt.node, tt.vm, tt.precondition, []byte("x")); err == nil {
+				t.Fatal("invalid input accepted")
+			}
+		})
+	}
+}

--- a/internal/orchestrator/pve_staged_apply.go
+++ b/internal/orchestrator/pve_staged_apply.go
@@ -87,6 +87,10 @@ func maybeApplyPVEConfigsFromStage(ctx context.Context, logger *logging.Logger, 
 				logger.Warning("PVE staged apply: jobs.cfg: %v", err)
 				failedItems = append(failedItems, "jobs.cfg")
 			}
+			if err := applyPVEVzdumpCronFromStage(logger, stageRoot); err != nil {
+				logger.Warning("PVE staged apply: vzdump.cron: %v", err)
+				failedItems = append(failedItems, "vzdump.cron")
+			}
 		}
 	}
 
@@ -180,6 +184,33 @@ func applyPVEDatacenterCfgFromStage(_ context.Context, logger *logging.Logger, s
 		return fmt.Errorf("apply staged datacenter.cfg: %w", err)
 	}
 	logger.Info("PVE staged apply: datacenter.cfg written to pmxcfs (cluster-wide)")
+	return nil
+}
+
+// applyPVEVzdumpCronFromStage writes the staged vzdump.cron into pmxcfs. The
+// file was collected under pve_jobs and documented as staged-applied, but no
+// restore path ever read it back (fable-check bug 5): legacy cron backup jobs
+// silently vanished from every staged restore. There is no pvesh endpoint for
+// vzdump.cron; the file lives in pmxcfs, so the write IS the cluster-wide
+// apply, the same way datacenter.cfg is handled.
+func applyPVEVzdumpCronFromStage(logger *logging.Logger, stageRoot string) error {
+	stagePath := filepath.Join(stageRoot, "etc/pve/vzdump.cron")
+	data, err := restoreFS.ReadFile(stagePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			logging.DebugStep(logger, "pve staged apply vzdump.cron", "Skipped: vzdump.cron not present in staging directory")
+			return nil
+		}
+		return fmt.Errorf("read staged vzdump.cron: %w", err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		logging.DebugStep(logger, "pve staged apply vzdump.cron", "Staged vzdump.cron is empty; skipping apply")
+		return nil
+	}
+	if err := pmxcfsWriteFile(logger, "vzdump.cron", data); err != nil {
+		return fmt.Errorf("apply staged vzdump.cron: %w", err)
+	}
+	logger.Info("PVE staged apply: vzdump.cron written to pmxcfs (cluster-wide)")
 	return nil
 }
 

--- a/internal/orchestrator/pve_staged_apply.go
+++ b/internal/orchestrator/pve_staged_apply.go
@@ -154,12 +154,14 @@ func applyPVEStorageCfgFromStage(ctx context.Context, logger *logging.Logger, st
 	return nil
 }
 
-func applyPVEDatacenterCfgFromStage(ctx context.Context, logger *logging.Logger, stageRoot string) error {
-	if _, err := restoreCmd.Run(ctx, "which", "pvesh"); err != nil {
-		logger.Warning("pvesh not found; skipping PVE datacenter.cfg apply")
-		return nil
-	}
-
+// applyPVEDatacenterCfgFromStage writes the staged datacenter.cfg into pmxcfs.
+// The old arm called `pvesh set /cluster/config -conf <file>`, an endpoint a live
+// PVE 9.1.9 node answers with "No 'set' handler defined for '/cluster/config'"
+// (probed 2026-09-02): datacenter.cfg was therefore NEVER restored on a staged
+// apply. The API has no whole-file endpoint (options live per-key under
+// /cluster/options); the file write replicates cluster-wide because /etc/pve IS
+// pmxcfs, and pvesh is not needed at all.
+func applyPVEDatacenterCfgFromStage(_ context.Context, logger *logging.Logger, stageRoot string) error {
 	stagePath := filepath.Join(stageRoot, "etc/pve/datacenter.cfg")
 	data, err := restoreFS.ReadFile(stagePath)
 	if err != nil {
@@ -174,10 +176,10 @@ func applyPVEDatacenterCfgFromStage(ctx context.Context, logger *logging.Logger,
 		return nil
 	}
 
-	if err := runPvesh(ctx, logger, []string{"set", "/cluster/config", "-conf", stagePath}); err != nil {
-		return err
+	if err := pmxcfsWriteFile(logger, "datacenter.cfg", data); err != nil {
+		return fmt.Errorf("apply staged datacenter.cfg: %w", err)
 	}
-	logger.Info("PVE staged apply: datacenter.cfg applied")
+	logger.Info("PVE staged apply: datacenter.cfg written to pmxcfs (cluster-wide)")
 	return nil
 }
 

--- a/internal/orchestrator/pve_staged_apply_additional_test.go
+++ b/internal/orchestrator/pve_staged_apply_additional_test.go
@@ -405,7 +405,12 @@ func TestApplyPVEDatacenterCfgFromStage_Branches(t *testing.T) {
 		}
 	})
 
-	t.Run("runPvesh error and success", func(t *testing.T) {
+	t.Run("pmxcfs refusal and pmxcfs success", func(t *testing.T) {
+		// The pvesh endpoint the old arm called does not exist on a live node
+		// ("No 'set' handler defined for '/cluster/config'", probed 2026-09-02);
+		// the arm now writes the staged file into pmxcfs and pvesh is not
+		// involved. The two arms pinned here are the mounted-guard refusal and
+		// the write itself.
 		origFS := restoreFS
 		origCmd := restoreCmd
 		t.Cleanup(func() {
@@ -416,30 +421,25 @@ func TestApplyPVEDatacenterCfgFromStage_Branches(t *testing.T) {
 		fakeFS := NewFakeFS()
 		t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
 		restoreFS = fakeFS
+		restoreCmd = &FakeCommandRunner{}
 
 		stagePath := "/stage/etc/pve/datacenter.cfg"
 		if err := fakeFS.AddFile(stagePath, []byte("keyboard: it\n")); err != nil {
 			t.Fatalf("write staged datacenter.cfg: %v", err)
 		}
 
-		failCmd := &FakeCommandRunner{
-			Errors: map[string]error{
-				"pvesh set /cluster/config -conf " + stagePath: errors.New("pvesh failed"),
-			},
-		}
-		restoreCmd = failCmd
-		if err := applyPVEDatacenterCfgFromStage(ctx, logger, "/stage"); err == nil || !strings.Contains(err.Error(), "pvesh [set /cluster/config -conf") {
-			t.Fatalf("expected pvesh failure, got %v", err)
+		seamPmxcfs(t, "/etc/pve", false, nil)
+		if err := applyPVEDatacenterCfgFromStage(ctx, logger, "/stage"); err == nil || !strings.Contains(err.Error(), "not mounted") {
+			t.Fatalf("expected the mounted-guard refusal, got %v", err)
 		}
 
-		okCmd := &FakeCommandRunner{}
-		restoreCmd = okCmd
+		seamPmxcfs(t, "/etc/pve", true, nil)
 		if err := applyPVEDatacenterCfgFromStage(ctx, logger, "/stage"); err != nil {
 			t.Fatalf("expected success, got %v", err)
 		}
-		calls := strings.Join(okCmd.CallsList(), "\n")
-		if !strings.Contains(calls, "pvesh set /cluster/config -conf "+stagePath) {
-			t.Fatalf("missing datacenter apply call; calls=%v", okCmd.CallsList())
+		got, err := fakeFS.ReadFile("/etc/pve/datacenter.cfg")
+		if err != nil || string(got) != "keyboard: it\n" {
+			t.Fatalf("datacenter.cfg not written into pmxcfs: %q err=%v", got, err)
 		}
 	})
 }

--- a/internal/orchestrator/pve_storage_fallback_test.go
+++ b/internal/orchestrator/pve_storage_fallback_test.go
@@ -1,0 +1,89 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// `dir: local` exists on every node and in every backup, so the create-only
+// apply failed on it on every live restore ("create storage failed: storage ID
+// 'local' already defined", probed 2026-09-02) and existing definitions were
+// never updated (fable-check bug 4). The jobs apply twenty lines away has had
+// the create-then-set fallback all along; storage.cfg now gets the same one.
+func TestApplyStorageCfgFallsBackToSetOnAnExistingStorage(t *testing.T) {
+	origFS, origCmd := restoreFS, restoreCmd
+	t.Cleanup(func() { restoreFS, restoreCmd = origFS, origCmd })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	pvesh := newSchemaAwarePvesh("local")
+	restoreCmd = pvesh
+
+	cfg := strings.Join([]string{
+		"dir: local",
+		"\tpath /var/lib/vz",
+		"\tcontent iso,vztmpl,backup",
+		"",
+		"nfs: backup_ext",
+		"\tserver 10.0.0.1",
+		"\texport /srv/backups",
+		"",
+	}, "\n")
+	if err := fakeFS.AddFile("/stage/etc/pve/storage.cfg", []byte(cfg)); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := logging.New(types.LogLevelDebug, false)
+	applied, failed, err := applyStorageCfg(context.Background(), "/stage/etc/pve/storage.cfg", logger)
+	if err != nil {
+		t.Fatalf("applyStorageCfg: %v", err)
+	}
+	if applied != 2 || failed != 0 {
+		t.Fatalf("applied=%d failed=%d, want 2/0: the existing 'local' must fall back to set", applied, failed)
+	}
+
+	calls := strings.Join(pvesh.calls, "\n")
+	if !strings.Contains(calls, "pvesh set /storage/local") {
+		t.Fatalf("no set fallback on the existing storage; calls:\n%s", calls)
+	}
+	if strings.Contains(calls, "set /storage/local --storage=") || strings.Contains(calls, "set /storage/local --type=") {
+		t.Fatalf("the set fallback re-sends create-only keys (--storage/--type); calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "pvesh create /storage --storage=backup_ext") {
+		t.Fatalf("the new storage must still go through create; calls:\n%s", calls)
+	}
+}
+
+func TestApplyStorageCfgStillFailsWhenCreateAndSetBothFail(t *testing.T) {
+	origFS, origCmd := restoreFS, restoreCmd
+	t.Cleanup(func() { restoreFS, restoreCmd = origFS, origCmd })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	// The fake refuses set on a storage it does not know; forcing the create to
+	// also fail needs an exact-key runner layered on top - simplest: an id the
+	// fake treats as existing for create but unknown for set cannot exist, so use
+	// a FakeCommandRunner that fails both calls explicitly.
+	restoreCmd = &FakeCommandRunner{Errors: map[string]error{
+		"pvesh create /storage --storage=local --type=dir --path=/var/lib/vz": errString("storage ID 'local' already defined"),
+		"pvesh set /storage/local --path=/var/lib/vz":                         errString("update storage failed: permission denied"),
+	}}
+
+	cfg := "dir: local\n\tpath /var/lib/vz\n"
+	if err := fakeFS.AddFile("/stage/etc/pve/storage.cfg", []byte(cfg)); err != nil {
+		t.Fatal(err)
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+	applied, failed, err := applyStorageCfg(context.Background(), "/stage/etc/pve/storage.cfg", logger)
+	if err != nil {
+		t.Fatalf("applyStorageCfg: %v", err)
+	}
+	if applied != 0 || failed != 1 {
+		t.Fatalf("applied=%d failed=%d, want 0/1 when both create and set fail", applied, failed)
+	}
+}

--- a/internal/orchestrator/pve_vzdump_cron_pmxcfs_test.go
+++ b/internal/orchestrator/pve_vzdump_cron_pmxcfs_test.go
@@ -1,0 +1,96 @@
+package orchestrator
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// vzdump.cron is collected under pve_jobs (categories.go) and RESTORE_GUIDE.md
+// says it is staged-applied, but no restore path ever read it back: legacy cron
+// backup jobs silently vanished from every staged restore (fable-check bug 5).
+// There is no pvesh endpoint for it; the file lives in pmxcfs and the write IS
+// the cluster-wide apply.
+func TestApplyPVEVzdumpCronFromStageWritesThroughPmxcfs(t *testing.T) {
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	seamPmxcfs(t, "/etc/pve", true, nil)
+
+	const cron = "0 2 * * 6 root vzdump 101 --storage local --mode snapshot\n"
+	if err := fakeFS.AddFile("/stage/etc/pve/vzdump.cron", []byte(cron)); err != nil {
+		t.Fatal(err)
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+	if err := applyPVEVzdumpCronFromStage(logger, "/stage"); err != nil {
+		t.Fatalf("applyPVEVzdumpCronFromStage: %v", err)
+	}
+	got, err := fakeFS.ReadFile("/etc/pve/vzdump.cron")
+	if err != nil || string(got) != cron {
+		t.Fatalf("vzdump.cron not written into pmxcfs: %q err=%v", got, err)
+	}
+}
+
+func TestApplyPVEVzdumpCronFromStageSkipsAbsentAndEmpty(t *testing.T) {
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	seamPmxcfs(t, "/etc/pve", true, nil)
+	logger := logging.New(types.LogLevelDebug, false)
+
+	if err := applyPVEVzdumpCronFromStage(logger, "/stage"); err != nil {
+		t.Fatalf("absent vzdump.cron must be a silent skip: %v", err)
+	}
+	if err := fakeFS.AddFile("/stage/etc/pve/vzdump.cron", []byte(" \n\t")); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyPVEVzdumpCronFromStage(logger, "/stage"); err != nil {
+		t.Fatalf("empty vzdump.cron must be a silent skip: %v", err)
+	}
+	if _, err := fakeFS.ReadFile("/etc/pve/vzdump.cron"); err == nil {
+		t.Fatal("a skip must not write anything")
+	}
+}
+
+func TestApplyPVEVzdumpCronFromStageRefusesWithoutPmxcfs(t *testing.T) {
+	origFS := restoreFS
+	t.Cleanup(func() { restoreFS = origFS })
+	fakeFS := NewFakeFS()
+	t.Cleanup(func() { _ = os.RemoveAll(fakeFS.Root) })
+	restoreFS = fakeFS
+	seamPmxcfs(t, "/etc/pve", false, nil)
+
+	if err := fakeFS.AddFile("/stage/etc/pve/vzdump.cron", []byte("0 2 * * 6 root vzdump 101\n")); err != nil {
+		t.Fatal(err)
+	}
+	logger := logging.New(types.LogLevelDebug, false)
+	err := applyPVEVzdumpCronFromStage(logger, "/stage")
+	if err == nil || !strings.Contains(err.Error(), "not mounted") {
+		t.Fatalf("want the mounted-guard refusal, got %v", err)
+	}
+}
+
+// The arm is worthless unwired: this pins that maybeApplyPVEConfigsFromStage
+// runs it in the pve_jobs branch, beside jobs.cfg, gated off cluster RECOVERY
+// like its sibling (config.db owns the file there).
+func TestVzdumpCronArmIsWiredIntoTheStagedApply(t *testing.T) {
+	data, err := os.ReadFile("pve_staged_apply.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	jobs := strings.Index(src, `if plan.HasCategoryID("pve_jobs")`)
+	if jobs < 0 {
+		t.Fatal("pve_jobs branch not found")
+	}
+	if !strings.Contains(src[jobs:], "applyPVEVzdumpCronFromStage(") {
+		t.Fatal("applyPVEVzdumpCronFromStage is not wired into the pve_jobs branch: the arm is dead code")
+	}
+}

--- a/internal/orchestrator/pvesh_schema_fake_test.go
+++ b/internal/orchestrator/pvesh_schema_fake_test.go
@@ -2,6 +2,9 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -22,23 +25,29 @@ type schemaAwarePvesh struct {
 	// storages holds the ids that "exist"; create on an existing id fails the way
 	// the live node failed on 'local', set on a missing id fails too.
 	storages map[string]bool
-	// guests maps vmid -> exists; running maps vmid -> the guest answers
-	// status/current with "running". A get on a missing guest answers the
-	// not-found shape isPveshNotFoundError matches.
-	guests  map[string]bool
-	running map[string]bool
+	// guests maps vmid -> exists cluster-wide. guestNodes and guestKinds may
+	// override the generated /cluster/resources record; running controls the
+	// status/current response.
+	guests     map[string]bool
+	guestNodes map[string]string
+	guestKinds map[string]string
+	running    map[string]bool
 	// failSet forces `set .../<vmid>/config` to fail regardless of args, for
 	// exercising the file-fallback arms.
-	failSet      map[string]bool
-	statusOutput map[string][]byte
-	statusError  map[string]error
-	calls        []string
+	failSet         map[string]bool
+	statusOutput    map[string][]byte
+	statusError     map[string]error
+	inventoryOutput []byte
+	inventoryError  error
+	calls           []string
 }
 
 func newSchemaAwarePvesh(existingStorages ...string) *schemaAwarePvesh {
 	s := &schemaAwarePvesh{
 		storages:     map[string]bool{},
 		guests:       map[string]bool{},
+		guestNodes:   map[string]string{},
+		guestKinds:   map[string]string{},
 		running:      map[string]bool{},
 		statusOutput: map[string][]byte{},
 		statusError:  map[string]error{},
@@ -53,6 +62,44 @@ func (s *schemaAwarePvesh) Run(_ context.Context, name string, args ...string) (
 	s.calls = append(s.calls, commandKey(name, args))
 	if name != "pvesh" {
 		return nil, nil // which, etc.
+	}
+	if len(args) == 5 && args[0] == "get" && args[1] == "/cluster/resources" && args[2] == "--type" && args[3] == "vm" && args[4] == "--output-format=json" {
+		if s.inventoryError != nil {
+			return s.inventoryOutput, s.inventoryError
+		}
+		if s.inventoryOutput != nil {
+			return s.inventoryOutput, nil
+		}
+		vmids := make([]string, 0, len(s.guests))
+		for vmid, exists := range s.guests {
+			if exists {
+				vmids = append(vmids, vmid)
+			}
+		}
+		sort.Strings(vmids)
+		resources := make([]pveGuestResource, 0, len(vmids))
+		for _, vmid := range vmids {
+			numericVMID, err := strconv.Atoi(vmid)
+			if err != nil {
+				return nil, err
+			}
+			node := s.guestNodes[vmid]
+			if node == "" {
+				node = localNodeName()
+			}
+			kind := s.guestKinds[vmid]
+			if kind == "" {
+				kind = "qemu"
+			}
+			status := "stopped"
+			if s.running[vmid] {
+				status = "running"
+			}
+			resources = append(resources, pveGuestResource{
+				VMID: numericVMID, Node: node, Kind: kind, Status: status, Name: "guest-" + vmid,
+			})
+		}
+		return json.Marshal(resources)
 	}
 	if len(args) >= 2 && args[0] == "get" && strings.HasSuffix(args[1], "/status/current") {
 		vmid := pveshFakePathVMID(strings.TrimSuffix(args[1], "/status/current"))

--- a/internal/orchestrator/pvesh_schema_fake_test.go
+++ b/internal/orchestrator/pvesh_schema_fake_test.go
@@ -22,11 +22,19 @@ type schemaAwarePvesh struct {
 	// storages holds the ids that "exist"; create on an existing id fails the way
 	// the live node failed on 'local', set on a missing id fails too.
 	storages map[string]bool
-	calls    []string
+	// guests maps vmid -> exists; running maps vmid -> the guest answers
+	// status/current with "running". A get on a missing guest answers the
+	// not-found shape isPveshNotFoundError matches.
+	guests  map[string]bool
+	running map[string]bool
+	// failSet forces `set .../<vmid>/config` to fail regardless of args, for
+	// exercising the file-fallback arms.
+	failSet map[string]bool
+	calls   []string
 }
 
 func newSchemaAwarePvesh(existingStorages ...string) *schemaAwarePvesh {
-	s := &schemaAwarePvesh{storages: map[string]bool{}}
+	s := &schemaAwarePvesh{storages: map[string]bool{}, guests: map[string]bool{}, running: map[string]bool{}}
 	for _, id := range existingStorages {
 		s.storages[id] = true
 	}
@@ -38,13 +46,36 @@ func (s *schemaAwarePvesh) Run(_ context.Context, name string, args ...string) (
 	if name != "pvesh" {
 		return nil, nil // which, etc.
 	}
+	if len(args) >= 2 && args[0] == "get" && strings.HasSuffix(args[1], "/status/current") {
+		vmid := pveshFakePathVMID(strings.TrimSuffix(args[1], "/status/current"))
+		if s.running[vmid] {
+			return []byte(`{"status":"running","vmid":` + vmid + `}`), nil
+		}
+		return []byte(`{"status":"stopped","vmid":` + vmid + `}`), nil
+	}
+	if len(args) >= 2 && args[0] == "get" && strings.HasSuffix(args[1], "/config") && (strings.Contains(args[1], "/qemu/") || strings.Contains(args[1], "/lxc/")) {
+		if !s.guests[pveshFakePathVMID(strings.TrimSuffix(args[1], "/config"))] {
+			return nil, errString("no such guest (500 Configuration file does not exist)")
+		}
+		return []byte("{}"), nil
+	}
 	if len(args) >= 2 && args[0] == "set" && args[1] == "/cluster/config" {
 		return nil, errString("No 'set' handler defined for '/cluster/config'")
+	}
+	if len(args) >= 2 && args[0] == "set" && strings.HasSuffix(args[1], "/config") && s.failSet[pveshFakePathVMID(strings.TrimSuffix(args[1], "/config"))] {
+		return nil, errString("500 unable to apply configuration")
 	}
 	if len(args) >= 2 && args[0] == "set" && strings.Contains(args[1], "/qemu/") && strings.HasSuffix(args[1], "/config") {
 		for _, a := range args[2:] {
 			if strings.HasPrefix(a, "--meta=") {
 				return nil, errString("400 Parameter verification failed. meta: property is not defined in schema and the schema does not allow additional properties")
+			}
+		}
+	}
+	if len(args) >= 2 && args[0] == "set" && strings.Contains(args[1], "/lxc/") && strings.HasSuffix(args[1], "/config") {
+		for _, a := range args[2:] {
+			if strings.HasPrefix(a, "--ostemplate=") {
+				return nil, errString("400 Parameter verification failed. ostemplate: property is not defined in schema and the schema does not allow additional properties")
 			}
 		}
 	}
@@ -109,4 +140,12 @@ func TestSchemaAwarePveshReproducesTheLiveRejections(t *testing.T) {
 	if _, err = f.Run(ctx, "pvesh", "set", "/cluster/options", "--keyboard=it"); err != nil {
 		t.Fatalf("set /cluster/options exists on the live node: %v", err)
 	}
+}
+
+func pveshFakePathVMID(path string) string {
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
 }

--- a/internal/orchestrator/pvesh_schema_fake_test.go
+++ b/internal/orchestrator/pvesh_schema_fake_test.go
@@ -55,7 +55,11 @@ func (s *schemaAwarePvesh) Run(_ context.Context, name string, args ...string) (
 	}
 	if len(args) >= 2 && args[0] == "get" && strings.HasSuffix(args[1], "/config") && (strings.Contains(args[1], "/qemu/") || strings.Contains(args[1], "/lxc/")) {
 		if !s.guests[pveshFakePathVMID(strings.TrimSuffix(args[1], "/config"))] {
-			return nil, errString("no such guest (500 Configuration file does not exist)")
+			// Live shape (measured on PVE 9.1.9): the reason lands on the
+			// command's OUTPUT, the Go error is a bare exit status. An earlier
+			// fake put the reason inside the error and masked that
+			// pveshGuestExists never matched it on a real node.
+			return []byte("Configuration file 'nodes/pve/lxc/990.conf' does not exist"), errString("exit status 2")
 		}
 		return []byte("{}"), nil
 	}
@@ -91,6 +95,14 @@ func (s *schemaAwarePvesh) Run(_ context.Context, name string, args ...string) (
 		id := strings.TrimPrefix(args[1], "/storage/")
 		if !s.storages[id] {
 			return nil, errString("no such storage '" + id + "'")
+		}
+		// Live shape (measured on PVE 9.1.9): `path` is create-only for storage
+		// too - "Unknown option: path" on the OUTPUT, bare exit status as the
+		// error. Any --path in a set is refused.
+		for _, a := range args[2:] {
+			if strings.HasPrefix(a, "--path=") {
+				return []byte("Unknown option: path\n400 unable to parse option"), errString("exit status 255")
+			}
 		}
 		return nil, nil
 	}

--- a/internal/orchestrator/pvesh_schema_fake_test.go
+++ b/internal/orchestrator/pvesh_schema_fake_test.go
@@ -29,12 +29,20 @@ type schemaAwarePvesh struct {
 	running map[string]bool
 	// failSet forces `set .../<vmid>/config` to fail regardless of args, for
 	// exercising the file-fallback arms.
-	failSet map[string]bool
-	calls   []string
+	failSet      map[string]bool
+	statusOutput map[string][]byte
+	statusError  map[string]error
+	calls        []string
 }
 
 func newSchemaAwarePvesh(existingStorages ...string) *schemaAwarePvesh {
-	s := &schemaAwarePvesh{storages: map[string]bool{}, guests: map[string]bool{}, running: map[string]bool{}}
+	s := &schemaAwarePvesh{
+		storages:     map[string]bool{},
+		guests:       map[string]bool{},
+		running:      map[string]bool{},
+		statusOutput: map[string][]byte{},
+		statusError:  map[string]error{},
+	}
 	for _, id := range existingStorages {
 		s.storages[id] = true
 	}
@@ -48,10 +56,25 @@ func (s *schemaAwarePvesh) Run(_ context.Context, name string, args ...string) (
 	}
 	if len(args) >= 2 && args[0] == "get" && strings.HasSuffix(args[1], "/status/current") {
 		vmid := pveshFakePathVMID(strings.TrimSuffix(args[1], "/status/current"))
-		if s.running[vmid] {
-			return []byte(`{"status":"running","vmid":` + vmid + `}`), nil
+		if err, ok := s.statusError[vmid]; ok {
+			return s.statusOutput[vmid], err
 		}
-		return []byte(`{"status":"stopped","vmid":` + vmid + `}`), nil
+		if out, ok := s.statusOutput[vmid]; ok {
+			return out, nil
+		}
+		if !s.guests[vmid] {
+			return []byte("Configuration file 'nodes/pve/lxc/" + vmid + ".conf' does not exist"), errString("exit status 2")
+		}
+		parts := strings.Split(strings.Trim(args[1], "/"), "/")
+		node, kind := "pve", "qemu"
+		if len(parts) >= 4 {
+			node, kind = parts[1], parts[2]
+		}
+		status := "stopped"
+		if s.running[vmid] {
+			status = "running"
+		}
+		return []byte(`{"name":"guest-` + vmid + `","node":"` + node + `","status":"` + status + `","type":"` + kind + `","vmid":` + vmid + `}`), nil
 	}
 	if len(args) >= 2 && args[0] == "get" && strings.HasSuffix(args[1], "/config") && (strings.Contains(args[1], "/qemu/") || strings.Contains(args[1], "/lxc/")) {
 		if !s.guests[pveshFakePathVMID(strings.TrimSuffix(args[1], "/config"))] {

--- a/internal/orchestrator/pvesh_schema_fake_test.go
+++ b/internal/orchestrator/pvesh_schema_fake_test.go
@@ -1,0 +1,112 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// schemaAwarePvesh is a CommandRunner that answers the way the REAL pvesh answered on
+// a live PVE 9.1.9 node (probed 2026-09-02; the strings below are verbatim from that
+// session, recorded in diagnostics/design-staged-apply-pmxcfs-2026-09-02.md). The
+// exact-key FakeCommandRunner can only echo whatever a test teaches it, which is how
+// the staged-apply arms stayed green for months against endpoints that do not exist:
+// this fake exists so every arm is exercised against the surface that actually
+// rejected them, and every arm test from the fix series drives it instead of the
+// exact-key fake.
+//
+// It deliberately stays permissive for the pvesh callers the fix does NOT touch
+// (applyPVEClusterResourceMapping, applyPveshObject): anything it does not
+// recognize succeeds, so their tests keep meaning what they meant.
+type schemaAwarePvesh struct {
+	// storages holds the ids that "exist"; create on an existing id fails the way
+	// the live node failed on 'local', set on a missing id fails too.
+	storages map[string]bool
+	calls    []string
+}
+
+func newSchemaAwarePvesh(existingStorages ...string) *schemaAwarePvesh {
+	s := &schemaAwarePvesh{storages: map[string]bool{}}
+	for _, id := range existingStorages {
+		s.storages[id] = true
+	}
+	return s
+}
+
+func (s *schemaAwarePvesh) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	s.calls = append(s.calls, commandKey(name, args))
+	if name != "pvesh" {
+		return nil, nil // which, etc.
+	}
+	if len(args) >= 2 && args[0] == "set" && args[1] == "/cluster/config" {
+		return nil, errString("No 'set' handler defined for '/cluster/config'")
+	}
+	if len(args) >= 2 && args[0] == "set" && strings.Contains(args[1], "/qemu/") && strings.HasSuffix(args[1], "/config") {
+		for _, a := range args[2:] {
+			if strings.HasPrefix(a, "--meta=") {
+				return nil, errString("400 Parameter verification failed. meta: property is not defined in schema and the schema does not allow additional properties")
+			}
+		}
+	}
+	if len(args) >= 2 && args[0] == "create" && args[1] == "/storage" {
+		id := pveshFakeArg(args, "--storage=")
+		if s.storages[id] {
+			return nil, errString("create storage failed: storage ID '" + id + "' already defined")
+		}
+		s.storages[id] = true
+		return nil, nil
+	}
+	if len(args) >= 2 && args[0] == "set" && strings.HasPrefix(args[1], "/storage/") {
+		id := strings.TrimPrefix(args[1], "/storage/")
+		if !s.storages[id] {
+			return nil, errString("no such storage '" + id + "'")
+		}
+		return nil, nil
+	}
+	return nil, nil
+}
+
+func pveshFakeArg(args []string, prefix string) string {
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return strings.TrimPrefix(a, prefix)
+		}
+	}
+	return ""
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// The fake itself is pinned against the live session, so a future "fix" that
+// loosens it cannot silently un-teach it the rejections.
+func TestSchemaAwarePveshReproducesTheLiveRejections(t *testing.T) {
+	f := newSchemaAwarePvesh("local")
+	ctx := context.Background()
+
+	_, err := f.Run(ctx, "pvesh", "set", "/cluster/config", "-conf", "/tmp/datacenter.cfg")
+	if err == nil || !strings.Contains(err.Error(), "No 'set' handler defined for '/cluster/config'") {
+		t.Fatalf("set /cluster/config: got %v", err)
+	}
+
+	_, err = f.Run(ctx, "pvesh", "set", "/nodes/pve/qemu/101/config", "--cores=2", "--meta=creation-qemu=10.1.2")
+	if err == nil || !strings.Contains(err.Error(), "meta: property is not defined in schema") {
+		t.Fatalf("qemu set with --meta: got %v", err)
+	}
+
+	_, err = f.Run(ctx, "pvesh", "create", "/storage", "--storage=local", "--type=dir", "--path=/var/lib/vz")
+	if err == nil || !strings.Contains(err.Error(), "storage ID 'local' already defined") {
+		t.Fatalf("duplicate storage create: got %v", err)
+	}
+
+	if _, err = f.Run(ctx, "pvesh", "set", "/storage/local", "--content=iso"); err != nil {
+		t.Fatalf("set on existing storage must succeed (the live node has the handler): %v", err)
+	}
+	if _, err = f.Run(ctx, "pvesh", "create", "/storage", "--storage=nas", "--type=nfs"); err != nil {
+		t.Fatalf("create of a new storage must succeed: %v", err)
+	}
+	if _, err = f.Run(ctx, "pvesh", "set", "/cluster/options", "--keyboard=it"); err != nil {
+		t.Fatalf("set /cluster/options exists on the live node: %v", err)
+	}
+}

--- a/internal/orchestrator/restore_cluster_apply.go
+++ b/internal/orchestrator/restore_cluster_apply.go
@@ -244,9 +244,10 @@ func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logg
 			// never persists into a CT conf, so an LXC could NEVER be created this
 			// way (fable-check bug 3), and for qemu the conf itself is the
 			// registration. Writing the staged conf into pmxcfs IS how a guest
-			// comes into existence on PVE; its disks are not part of a config
-			// restore and the log says so.
-			if err := writeGuestConfToPmxcfs(logger, node, vm); err != nil {
+			// comes into existence on PVE; the native guest locks below repeat
+			// the cluster-wide absence check before doing so. Its disks are not
+			// part of a config restore and the log says so.
+			if err := writeGuestConfToPmxcfs(ctx, logger, node, vm, guestMustBeAbsent); err != nil {
 				logger.Warning("Failed to register VM/CT config %s (vmid=%s kind=%s): %v", target, vm.VMID, vm.Kind, err)
 				failed++
 				continue
@@ -268,8 +269,9 @@ func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logg
 		// schema refuses (`meta` on qemu, `ostemplate` on lxc - one rejected key
 		// fails the WHOLE set, which is how no modern guest ever got its config
 		// applied, fable-check bug 2). The staged conf file is the fidelity net,
-		// guarded off a RUNNING guest: a config race with a live guest is the one
-		// case where the file must not win (maintainer's call, 2026-09-02).
+		// guarded off a RUNNING guest both before and inside PVE's native guest
+		// locks: a config race with a live guest is the one case where the file
+		// must not win (maintainer's call, 2026-09-02).
 		args := append([]string{"set", target}, filterGuestCreateOnlyArgs(configArgs)...)
 		if err := runPvesh(ctx, logger, args); err != nil {
 			status, statusErr := pveshGuestStatus(ctx, node, vm)
@@ -283,7 +285,7 @@ func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logg
 				failed++
 				continue
 			}
-			if wErr := writeGuestConfToPmxcfs(logger, node, vm); wErr != nil {
+			if wErr := writeGuestConfToPmxcfs(ctx, logger, node, vm, guestMustBeStopped); wErr != nil {
 				logger.Warning("Failed to apply %s (vmid=%s kind=%s): %v (pmxcfs fallback: %v)", target, vm.VMID, vm.Kind, err, wErr)
 				failed++
 				continue
@@ -306,15 +308,14 @@ func guestConfDir(kind string) string {
 	return kind
 }
 
-// writeGuestConfToPmxcfs writes the staged conf byte-for-byte to
-// /etc/pve/nodes/<node>/<kind-dir>/<vmid>.conf.
-func writeGuestConfToPmxcfs(logger *logging.Logger, node string, vm vmEntry) error {
+// writeGuestConfToPmxcfs applies the staged conf byte-for-byte while PVE's
+// native guest locks protect the required cluster and runtime precondition.
+func writeGuestConfToPmxcfs(ctx context.Context, logger *logging.Logger, node string, vm vmEntry, precondition guestApplyPrecondition) error {
 	data, err := restoreFS.ReadFile(vm.Path)
 	if err != nil {
 		return fmt.Errorf("read staged conf %s: %w", vm.Path, err)
 	}
-	rel := filepath.Join("nodes", node, guestConfDir(vm.Kind), vm.VMID+".conf")
-	return pmxcfsWriteFile(logger, rel, data)
+	return pveGuestLockedWriter(ctx, logger, node, vm, precondition, data)
 }
 
 // filterGuestCreateOnlyArgs drops the keys the live update schemas refuse

--- a/internal/orchestrator/restore_cluster_apply.go
+++ b/internal/orchestrator/restore_cluster_apply.go
@@ -408,8 +408,24 @@ func applyStorageCfg(ctx context.Context, cfgPath string, logger *logging.Logger
 		args := append([]string{"create", "/storage"}, createArgs...)
 
 		if runErr := runPvesh(ctx, logger, args); runErr != nil {
-			logger.Warning("Failed to apply storage %s: %v", blk.ID, runErr)
-			failed++
+			// Fallback: the definition already exists (`dir: local` does on every
+			// node, probed live 2026-09-02: "storage ID 'local' already defined"),
+			// so update it - the same create-then-set shape the backup-jobs apply
+			// has always had. --storage and --type are create-only and stay out.
+			setArgs := []string{"set", "/storage/" + blk.ID}
+			for _, arg := range createArgs {
+				if strings.HasPrefix(arg, "--storage=") || strings.HasPrefix(arg, "--type=") {
+					continue
+				}
+				setArgs = append(setArgs, arg)
+			}
+			if setErr := runPvesh(ctx, logger, setArgs); setErr != nil {
+				logger.Warning("Failed to apply storage %s: %v (create: %v)", blk.ID, setErr, runErr)
+				failed++
+			} else {
+				logger.Info("Updated existing storage definition %s", blk.ID)
+				applied++
+			}
 		} else {
 			logger.Info("Applied storage definition %s", blk.ID)
 			applied++

--- a/internal/orchestrator/restore_cluster_apply.go
+++ b/internal/orchestrator/restore_cluster_apply.go
@@ -194,6 +194,24 @@ func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logg
 		logging.DebugStep(logger, "pve guest configs apply", "Result: ok=%d failed=%d", applied, failed)
 		done(traceErr)
 	}()
+	if len(entries) == 0 {
+		return 0, 0
+	}
+	if err := ctx.Err(); err != nil {
+		traceErr = err
+		logger.Warning("VM apply aborted: %v", err)
+		return applied, failed
+	}
+
+	inventory, err := loadPVEGuestInventory(ctx)
+	if err != nil {
+		traceErr = err
+		failed = len(entries)
+		logger.Warning("Failed to load the cluster-wide VM/CT inventory; refusing to apply %d guest config(s): %v", len(entries), err)
+		return applied, failed
+	}
+	logging.DebugStep(logger, "pve guest configs apply", "Loaded cluster-wide inventory: guests=%d", len(inventory))
+
 	for _, vm := range entries {
 		if err := ctx.Err(); err != nil {
 			traceErr = err
@@ -201,25 +219,27 @@ func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logg
 			return applied, failed
 		}
 		target := fmt.Sprintf("/nodes/%s/%s/%s/config", node, vm.Kind, vm.VMID)
-		configArgs, err := pveshArgsFromColonConfigFile(vm.Path)
-		if err != nil {
-			logger.Warning("Failed to read %s (vmid=%s kind=%s): %v", vm.Path, vm.VMID, vm.Kind, err)
-			failed++
-			continue
-		}
-
-		exists, err := pveshGuestExists(ctx, logger, target)
-		if err != nil {
-			logger.Warning("Failed to check existing VM/CT config %s (vmid=%s kind=%s): %v", target, vm.VMID, vm.Kind, err)
-			failed++
-			continue
-		}
 		display := vm.VMID
 		if vm.Name != "" {
 			display = fmt.Sprintf("%s (%s)", vm.VMID, vm.Name)
 		}
 
+		resource, exists := inventory[vm.VMID]
+		if exists && resource.Node != node {
+			logging.DebugStep(logger, "pve guest configs apply", "vmid=%s classification=remote owner_node=%s current_node=%s", vm.VMID, resource.Node, node)
+			logger.Warning("Skipping VM/CT config %s: vmid=%s already belongs to remote node %s (current node: %s)", display, vm.VMID, resource.Node, node)
+			failed++
+			continue
+		}
+		if exists && resource.Kind != vm.Kind {
+			logging.DebugStep(logger, "pve guest configs apply", "vmid=%s classification=type-mismatch inventory_kind=%s staged_kind=%s", vm.VMID, resource.Kind, vm.Kind)
+			logger.Warning("Skipping VM/CT config %s: vmid=%s is %s in the cluster inventory but the staged config is %s", display, vm.VMID, resource.Kind, vm.Kind)
+			failed++
+			continue
+		}
+
 		if !exists {
+			logging.DebugStep(logger, "pve guest configs apply", "vmid=%s classification=absent action=register-pmxcfs", vm.VMID)
 			// pvesh create is a dead end here: ostemplate is create-time-only and
 			// never persists into a CT conf, so an LXC could NEVER be created this
 			// way (fable-check bug 3), and for qemu the conf itself is the
@@ -233,6 +253,14 @@ func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logg
 			}
 			logger.Info("Registered VM/CT config %s via pmxcfs (config only: disks are not part of a config restore)", display)
 			applied++
+			continue
+		}
+
+		logging.DebugStep(logger, "pve guest configs apply", "vmid=%s classification=local kind=%s action=pvesh-set", vm.VMID, vm.Kind)
+		configArgs, err := pveshArgsFromColonConfigFile(vm.Path)
+		if err != nil {
+			logger.Warning("Failed to read %s (vmid=%s kind=%s): %v", vm.Path, vm.VMID, vm.Kind, err)
+			failed++
 			continue
 		}
 
@@ -332,49 +360,6 @@ func localNodeName() string {
 		return host
 	}
 	return "localhost"
-}
-
-func pveshGuestExists(ctx context.Context, logger *logging.Logger, target string) (bool, error) {
-	// The reason for a missing guest lands on pvesh's OUTPUT ("Configuration
-	// file '...' does not exist", measured live on PVE 9.1.9); the Go error is a
-	// bare "exit status 2". Matching the error alone never fired on a real node,
-	// so a missing guest read as a failed check instead of as absent - which is
-	// why the not-found match must read the output too.
-	out, err := restoreCmd.Run(ctx, "pvesh", "get", target)
-	if len(out) > 0 {
-		logger.Debug("pvesh [get %s] output: %s", target, strings.TrimSpace(string(out)))
-	}
-	if err == nil {
-		return true, nil
-	}
-	if isPveshNotFoundError(err) || isPveshNotFoundText(string(out)) {
-		return false, nil
-	}
-	return false, fmt.Errorf("pvesh [get %s] failed: %w", target, err)
-}
-
-// isPveshNotFoundText matches the not-found reasons pvesh prints on its output.
-func isPveshNotFoundText(out string) bool {
-	lower := strings.ToLower(out)
-	for _, marker := range []string{"does not exist", "not found", "no such"} {
-		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-	return false
-}
-
-func isPveshNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	for _, marker := range []string{"not found", "does not exist", "no such", "unable to find", "404"} {
-		if strings.Contains(msg, marker) {
-			return true
-		}
-	}
-	return false
 }
 
 type storageBlock struct {

--- a/internal/orchestrator/restore_cluster_apply.go
+++ b/internal/orchestrator/restore_cluster_apply.go
@@ -312,13 +312,33 @@ func localNodeName() string {
 }
 
 func pveshGuestExists(ctx context.Context, logger *logging.Logger, target string) (bool, error) {
-	if err := runPvesh(ctx, logger, []string{"get", target}); err != nil {
-		if isPveshNotFoundError(err) {
-			return false, nil
-		}
-		return false, err
+	// The reason for a missing guest lands on pvesh's OUTPUT ("Configuration
+	// file '...' does not exist", measured live on PVE 9.1.9); the Go error is a
+	// bare "exit status 2". Matching the error alone never fired on a real node,
+	// so a missing guest read as a failed check instead of as absent - which is
+	// why the not-found match must read the output too.
+	out, err := restoreCmd.Run(ctx, "pvesh", "get", target)
+	if len(out) > 0 {
+		logger.Debug("pvesh [get %s] output: %s", target, strings.TrimSpace(string(out)))
 	}
-	return true, nil
+	if err == nil {
+		return true, nil
+	}
+	if isPveshNotFoundError(err) || isPveshNotFoundText(string(out)) {
+		return false, nil
+	}
+	return false, fmt.Errorf("pvesh [get %s] failed: %w", target, err)
+}
+
+// isPveshNotFoundText matches the not-found reasons pvesh prints on its output.
+func isPveshNotFoundText(out string) bool {
+	lower := strings.ToLower(out)
+	for _, marker := range []string{"does not exist", "not found", "no such"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func isPveshNotFoundError(err error) bool {
@@ -374,6 +394,61 @@ func pveshArgsFromProxmoxEntries(entries []proxmoxNotificationEntry) []string {
 		args = append(args, fmt.Sprintf("--%s=%s", key, value))
 	}
 	return args
+}
+
+// pveshSetStorageDroppingCreateOnly runs `pvesh set /storage/<id>` and, on the
+// live "Unknown option: <key>" refusal (create-only keys: `path` on a dir
+// storage, measured on PVE 9.1.9; server/export on nfs are the same family),
+// drops the named key and retries. The set schema varies by storage type and
+// PVE version, so the refusal itself is the authoritative list - a hardcoded
+// whitelist would drift.
+func pveshSetStorageDroppingCreateOnly(ctx context.Context, logger *logging.Logger, id string, args []string) error {
+	for attempt := 0; attempt <= len(args); attempt++ {
+		full := append([]string{"set", "/storage/" + id}, args...)
+		out, err := restoreCmd.Run(ctx, "pvesh", full...)
+		if len(out) > 0 {
+			logger.Debug("pvesh %v output: %s", full, strings.TrimSpace(string(out)))
+		}
+		if err == nil {
+			return nil
+		}
+		key := pveshUnknownOptionFrom(string(out))
+		if key == "" {
+			return fmt.Errorf("pvesh %v failed: %w", full, err)
+		}
+		trimmed := args[:0:0]
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "--"+key+"=") {
+				logger.Debug("storage %s: dropping create-only key --%s from the set fallback", id, key)
+				continue
+			}
+			trimmed = append(trimmed, arg)
+		}
+		if len(trimmed) == len(args) {
+			return fmt.Errorf("pvesh %v failed: %w", full, err)
+		}
+		if len(trimmed) == 0 {
+			// Nothing left to update: the definition already matches on every
+			// settable key, which is a success, not a failure.
+			return nil
+		}
+		args = trimmed
+	}
+	return fmt.Errorf("storage %s: the set fallback did not converge", id)
+}
+
+// pveshUnknownOptionFrom extracts the key from pvesh's "Unknown option: <key>" output.
+func pveshUnknownOptionFrom(out string) string {
+	const marker = "Unknown option: "
+	idx := strings.Index(out, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := out[idx+len(marker):]
+	if end := strings.IndexAny(rest, " \t\r\n"); end >= 0 {
+		rest = rest[:end]
+	}
+	return strings.TrimSpace(rest)
 }
 
 func storageBlockPveshArgs(block storageBlock) ([]string, bool) {
@@ -448,14 +523,14 @@ func applyStorageCfg(ctx context.Context, cfgPath string, logger *logging.Logger
 			// node, probed live 2026-09-02: "storage ID 'local' already defined"),
 			// so update it - the same create-then-set shape the backup-jobs apply
 			// has always had. --storage and --type are create-only and stay out.
-			setArgs := []string{"set", "/storage/" + blk.ID}
+			setArgs := make([]string, 0, len(createArgs))
 			for _, arg := range createArgs {
 				if strings.HasPrefix(arg, "--storage=") || strings.HasPrefix(arg, "--type=") {
 					continue
 				}
 				setArgs = append(setArgs, arg)
 			}
-			if setErr := runPvesh(ctx, logger, setArgs); setErr != nil {
+			if setErr := pveshSetStorageDroppingCreateOnly(ctx, logger, blk.ID, setArgs); setErr != nil {
 				logger.Warning("Failed to apply storage %s: %v (create: %v)", blk.ID, setErr, runErr)
 				failed++
 			} else {

--- a/internal/orchestrator/restore_cluster_apply.go
+++ b/internal/orchestrator/restore_cluster_apply.go
@@ -206,34 +206,100 @@ func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logg
 			failed++
 			continue
 		}
-		if !exists {
-			createArgs, err := pveshCreateGuestArgs(node, vm, configArgs)
-			if err != nil {
-				logger.Warning("Failed to prepare VM/CT create for %s (vmid=%s kind=%s): %v", target, vm.VMID, vm.Kind, err)
-				failed++
-				continue
-			}
-			if err := runPvesh(ctx, logger, createArgs); err != nil {
-				logger.Warning("Failed to create VM/CT config %s (vmid=%s kind=%s): %v", target, vm.VMID, vm.Kind, err)
-				failed++
-				continue
-			}
+		display := vm.VMID
+		if vm.Name != "" {
+			display = fmt.Sprintf("%s (%s)", vm.VMID, vm.Name)
 		}
 
-		args := append([]string{"set", target}, configArgs...)
-		if err := runPvesh(ctx, logger, args); err != nil {
-			logger.Warning("Failed to apply %s (vmid=%s kind=%s): %v", target, vm.VMID, vm.Kind, err)
-			failed++
-		} else {
-			display := vm.VMID
-			if vm.Name != "" {
-				display = fmt.Sprintf("%s (%s)", vm.VMID, vm.Name)
+		if !exists {
+			// pvesh create is a dead end here: ostemplate is create-time-only and
+			// never persists into a CT conf, so an LXC could NEVER be created this
+			// way (fable-check bug 3), and for qemu the conf itself is the
+			// registration. Writing the staged conf into pmxcfs IS how a guest
+			// comes into existence on PVE; its disks are not part of a config
+			// restore and the log says so.
+			if err := writeGuestConfToPmxcfs(logger, node, vm); err != nil {
+				logger.Warning("Failed to register VM/CT config %s (vmid=%s kind=%s): %v", target, vm.VMID, vm.Kind, err)
+				failed++
+				continue
 			}
-			logger.Info("Applied VM/CT config %s", display)
+			logger.Info("Registered VM/CT config %s via pmxcfs (config only: disks are not part of a config restore)", display)
 			applied++
+			continue
 		}
+
+		// Existing guest: the API first, minus the create-only keys the update
+		// schema refuses (`meta` on qemu, `ostemplate` on lxc - one rejected key
+		// fails the WHOLE set, which is how no modern guest ever got its config
+		// applied, fable-check bug 2). The staged conf file is the fidelity net,
+		// guarded off a RUNNING guest: a config race with a live guest is the one
+		// case where the file must not win (maintainer's call, 2026-09-02).
+		args := append([]string{"set", target}, filterGuestCreateOnlyArgs(configArgs)...)
+		if err := runPvesh(ctx, logger, args); err != nil {
+			if running := pveshGuestRunning(ctx, logger, node, vm); running {
+				logger.Warning("Failed to apply %s (vmid=%s kind=%s) and the guest is running; skipping the file fallback (config race with a live guest): %v", target, vm.VMID, vm.Kind, err)
+				failed++
+				continue
+			}
+			if wErr := writeGuestConfToPmxcfs(logger, node, vm); wErr != nil {
+				logger.Warning("Failed to apply %s (vmid=%s kind=%s): %v (pmxcfs fallback: %v)", target, vm.VMID, vm.Kind, err, wErr)
+				failed++
+				continue
+			}
+			logger.Info("Applied VM/CT config %s via pmxcfs after the API refused: %v", display, err)
+			applied++
+			continue
+		}
+		logger.Info("Applied VM/CT config %s", display)
+		applied++
 	}
 	return applied, failed
+}
+
+// guestConfDir maps a guest kind to its pmxcfs config directory.
+func guestConfDir(kind string) string {
+	if kind == "qemu" {
+		return "qemu-server"
+	}
+	return kind
+}
+
+// writeGuestConfToPmxcfs writes the staged conf byte-for-byte to
+// /etc/pve/nodes/<node>/<kind-dir>/<vmid>.conf.
+func writeGuestConfToPmxcfs(logger *logging.Logger, node string, vm vmEntry) error {
+	data, err := restoreFS.ReadFile(vm.Path)
+	if err != nil {
+		return fmt.Errorf("read staged conf %s: %w", vm.Path, err)
+	}
+	rel := filepath.Join("nodes", node, guestConfDir(vm.Kind), vm.VMID+".conf")
+	return pmxcfsWriteFile(logger, rel, data)
+}
+
+// filterGuestCreateOnlyArgs drops the keys the live update schemas refuse
+// (probed 2026-09-02 on PVE 9.1.9): --meta is absent from the qemu set schema
+// and --ostemplate from the lxc one; either fails the whole set.
+func filterGuestCreateOnlyArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--meta=") || strings.HasPrefix(arg, "--ostemplate=") {
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
+}
+
+// pveshGuestRunning reports whether status/current answers "running". Any
+// error or unparsable answer counts as NOT running: in restore context the
+// guard exists only to avoid racing a demonstrably live guest.
+func pveshGuestRunning(ctx context.Context, logger *logging.Logger, node string, vm vmEntry) bool {
+	statusPath := fmt.Sprintf("/nodes/%s/%s/%s/status/current", node, vm.Kind, vm.VMID)
+	out, err := restoreCmd.Run(ctx, "pvesh", "get", statusPath, "--output-format=json")
+	if err != nil {
+		logger.Debug("guest status probe %s failed (treated as not running): %v", statusPath, err)
+		return false
+	}
+	return strings.Contains(string(out), `"status":"running"`)
 }
 
 func localNodeName() string {
@@ -253,36 +319,6 @@ func pveshGuestExists(ctx context.Context, logger *logging.Logger, target string
 		return false, err
 	}
 	return true, nil
-}
-
-func pveshCreateGuestArgs(node string, vm vmEntry, configArgs []string) ([]string, error) {
-	args := []string{
-		"create",
-		fmt.Sprintf("/nodes/%s/%s", node, vm.Kind),
-		fmt.Sprintf("--vmid=%s", vm.VMID),
-	}
-	switch vm.Kind {
-	case "qemu":
-		return args, nil
-	case "lxc":
-		ostemplate, ok := pveshArgValue(configArgs, "ostemplate")
-		if !ok {
-			return nil, fmt.Errorf("missing ostemplate in LXC config")
-		}
-		return append(args, fmt.Sprintf("--ostemplate=%s", ostemplate)), nil
-	default:
-		return nil, fmt.Errorf("unsupported guest kind %q", vm.Kind)
-	}
-}
-
-func pveshArgValue(args []string, key string) (string, bool) {
-	prefix := "--" + key + "="
-	for _, arg := range args {
-		if strings.HasPrefix(arg, prefix) {
-			return strings.TrimPrefix(arg, prefix), true
-		}
-	}
-	return "", false
 }
 
 func isPveshNotFoundError(err error) bool {

--- a/internal/orchestrator/restore_cluster_apply.go
+++ b/internal/orchestrator/restore_cluster_apply.go
@@ -4,6 +4,7 @@ package orchestrator
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -187,8 +188,15 @@ func readVMName(confPath string) string {
 
 func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logger) (applied, failed int) {
 	node := localNodeName()
+	done := logging.DebugStart(logger, "pve guest configs apply", "entries=%d current_node=%s", len(entries), node)
+	var traceErr error
+	defer func() {
+		logging.DebugStep(logger, "pve guest configs apply", "Result: ok=%d failed=%d", applied, failed)
+		done(traceErr)
+	}()
 	for _, vm := range entries {
 		if err := ctx.Err(); err != nil {
+			traceErr = err
 			logger.Warning("VM apply aborted: %v", err)
 			return applied, failed
 		}
@@ -236,8 +244,14 @@ func applyVMConfigs(ctx context.Context, entries []vmEntry, logger *logging.Logg
 		// case where the file must not win (maintainer's call, 2026-09-02).
 		args := append([]string{"set", target}, filterGuestCreateOnlyArgs(configArgs)...)
 		if err := runPvesh(ctx, logger, args); err != nil {
-			if running := pveshGuestRunning(ctx, logger, node, vm); running {
-				logger.Warning("Failed to apply %s (vmid=%s kind=%s) and the guest is running; skipping the file fallback (config race with a live guest): %v", target, vm.VMID, vm.Kind, err)
+			status, statusErr := pveshGuestStatus(ctx, node, vm)
+			if statusErr != nil {
+				logger.Warning("Failed to apply %s (vmid=%s kind=%s) and could not verify that the guest is stopped; skipping the file fallback: %v (status probe: %v)", target, vm.VMID, vm.Kind, err, statusErr)
+				failed++
+				continue
+			}
+			if status != "stopped" {
+				logger.Warning("Failed to apply %s (vmid=%s kind=%s) and guest status is %q, not explicitly stopped; skipping the file fallback: %v", target, vm.VMID, vm.Kind, status, err)
 				failed++
 				continue
 			}
@@ -289,17 +303,26 @@ func filterGuestCreateOnlyArgs(args []string) []string {
 	return out
 }
 
-// pveshGuestRunning reports whether status/current answers "running". Any
-// error or unparsable answer counts as NOT running: in restore context the
-// guard exists only to avoid racing a demonstrably live guest.
-func pveshGuestRunning(ctx context.Context, logger *logging.Logger, node string, vm vmEntry) bool {
+// pveshGuestStatus returns the explicit status/current state. Callers must
+// positively observe "stopped" before a direct pmxcfs fallback; a command or
+// parse error is never equivalent to a stopped guest.
+func pveshGuestStatus(ctx context.Context, node string, vm vmEntry) (string, error) {
 	statusPath := fmt.Sprintf("/nodes/%s/%s/%s/status/current", node, vm.Kind, vm.VMID)
 	out, err := restoreCmd.Run(ctx, "pvesh", "get", statusPath, "--output-format=json")
 	if err != nil {
-		logger.Debug("guest status probe %s failed (treated as not running): %v", statusPath, err)
-		return false
+		return "", fmt.Errorf("pvesh get %s: %w", statusPath, err)
 	}
-	return strings.Contains(string(out), `"status":"running"`)
+	var payload struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return "", fmt.Errorf("parse guest status %s: %w", statusPath, err)
+	}
+	status := strings.ToLower(strings.TrimSpace(payload.Status))
+	if status == "" {
+		return "", fmt.Errorf("guest status %s is empty", statusPath)
+	}
+	return status, nil
 }
 
 func localNodeName() string {

--- a/internal/orchestrator/restore_coverage_extra_test.go
+++ b/internal/orchestrator/restore_coverage_extra_test.go
@@ -22,11 +22,16 @@ func (runOnlyRunner) Run(ctx context.Context, name string, args ...string) ([]by
 type zfsContextTestKey struct{}
 
 type recordingRunner struct {
-	calls []string
+	calls           []string
+	inventoryOutput []byte
 }
 
 func (r *recordingRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	r.calls = append(r.calls, commandKey(name, args))
+	key := commandKey(name, args)
+	r.calls = append(r.calls, key)
+	if key == pveGuestInventoryCommand && r.inventoryOutput != nil {
+		return r.inventoryOutput, nil
+	}
 	return []byte("ok"), nil
 }
 
@@ -274,7 +279,10 @@ func TestRunSafeClusterApply_AppliesVMStorageAndDatacenterConfigs(t *testing.T) 
 	}
 	t.Setenv("PATH", pathDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	runner := &recordingRunner{}
+	runner := &recordingRunner{inventoryOutput: guestInventoryJSON(t,
+		pveGuestResource{VMID: 100, Node: localNodeName(), Kind: "qemu", Status: "stopped"},
+		pveGuestResource{VMID: 101, Node: localNodeName(), Kind: "lxc", Status: "stopped"},
+	)}
 	restoreCmd = runner
 
 	exportRoot := t.TempDir()
@@ -488,7 +496,9 @@ func TestRunSafeClusterApply_UsesSingleExportedNodeWhenHostnameMismatch(t *testi
 	}
 	t.Setenv("PATH", pathDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	runner := &recordingRunner{}
+	runner := &recordingRunner{inventoryOutput: guestInventoryJSON(t,
+		pveGuestResource{VMID: 100, Node: localNodeName(), Kind: "qemu", Status: "stopped"},
+	)}
 	restoreCmd = runner
 
 	exportRoot := t.TempDir()
@@ -541,7 +551,9 @@ func TestRunSafeClusterApply_PromptsForSourceNodeWhenMultipleExportNodes(t *test
 	}
 	t.Setenv("PATH", pathDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	runner := &recordingRunner{}
+	runner := &recordingRunner{inventoryOutput: guestInventoryJSON(t,
+		pveGuestResource{VMID: 101, Node: localNodeName(), Kind: "qemu", Status: "stopped"},
+	)}
 	restoreCmd = runner
 
 	exportRoot := t.TempDir()

--- a/internal/orchestrator/restore_coverage_extra_test.go
+++ b/internal/orchestrator/restore_coverage_extra_test.go
@@ -318,9 +318,18 @@ func TestRunSafeClusterApply_AppliesVMStorageAndDatacenterConfigs(t *testing.T) 
 		t.Fatalf("write datacenter.cfg: %v", err)
 	}
 
+	// datacenter.cfg is no longer a pvesh call (the live node has no 'set'
+	// handler on /cluster/config): it is a pmxcfs write, asserted on the file.
+	pmxRoot := t.TempDir()
+	seamPmxcfs(t, pmxRoot, true, nil)
+
 	reader := bufio.NewReader(strings.NewReader("yes\nyes\nyes\n"))
 	if err := runSafeClusterApply(context.Background(), reader, exportRoot, newTestLogger()); err != nil {
 		t.Fatalf("runSafeClusterApply error: %v", err)
+	}
+
+	if got, err := os.ReadFile(filepath.Join(pmxRoot, "datacenter.cfg")); err != nil || string(got) != "keyboard: it\n" {
+		t.Fatalf("datacenter.cfg not written into pmxcfs: %q err=%v", got, err)
 	}
 
 	wantPrefixes := []string{
@@ -328,7 +337,6 @@ func TestRunSafeClusterApply_AppliesVMStorageAndDatacenterConfigs(t *testing.T) 
 		"pvesh set /nodes/" + node + "/lxc/101/config --hostname=ct101",
 		"pvesh create /storage --storage=local --type=dir --path=/var/lib/vz",
 		"pvesh create /storage --storage=backup_ext --type=nfs --server=10.0.0.1",
-		"pvesh set /cluster/config -conf ",
 	}
 	for _, prefix := range wantPrefixes {
 		found := false

--- a/internal/orchestrator/restore_errors_test.go
+++ b/internal/orchestrator/restore_errors_test.go
@@ -1645,8 +1645,13 @@ func TestApplyVMConfigs_SuccessfulApply(t *testing.T) {
 	orig := restoreCmd
 	t.Cleanup(func() { restoreCmd = orig })
 
+	node := localNodeName()
 	fake := &FakeCommandRunner{
-		Outputs: map[string][]byte{},
+		Outputs: map[string][]byte{
+			pveGuestInventoryCommand: guestInventoryJSON(t,
+				pveGuestResource{VMID: 100, Node: node, Kind: "qemu", Status: "stopped"},
+			),
+		},
 	}
 	restoreCmd = fake
 
@@ -1684,11 +1689,9 @@ func TestApplyVMConfigs_RegistersMissingGuestViaPmxcfs(t *testing.T) {
 	t.Cleanup(func() { restoreCmd = orig })
 
 	node := localNodeName()
-	getCall := fmt.Sprintf("pvesh get /nodes/%s/qemu/100/config", node)
 	fake := &FakeCommandRunner{
-		Outputs: map[string][]byte{},
-		Errors: map[string]error{
-			getCall: fmt.Errorf("not found"),
+		Outputs: map[string][]byte{
+			pveGuestInventoryCommand: guestInventoryJSON(t),
 		},
 	}
 	restoreCmd = fake

--- a/internal/orchestrator/restore_errors_test.go
+++ b/internal/orchestrator/restore_errors_test.go
@@ -1685,8 +1685,10 @@ func TestApplyVMConfigs_RegistersMissingGuestViaPmxcfs(t *testing.T) {
 	// create was a dead end for LXC (ostemplate) and needless for qemu, so a
 	// missing guest is now registered by writing its staged conf into pmxcfs
 	// (fable-check bugs 2-3; see pve_guest_apply_test.go for the full matrix).
-	orig := restoreCmd
-	t.Cleanup(func() { restoreCmd = orig })
+	orig, origLockedWriter := restoreCmd, pveGuestLockedWriter
+	t.Cleanup(func() {
+		restoreCmd, pveGuestLockedWriter = orig, origLockedWriter
+	})
 
 	node := localNodeName()
 	fake := &FakeCommandRunner{
@@ -1698,6 +1700,10 @@ func TestApplyVMConfigs_RegistersMissingGuestViaPmxcfs(t *testing.T) {
 
 	pmxRoot := t.TempDir()
 	seamPmxcfs(t, pmxRoot, true, nil)
+	pveGuestLockedWriter = func(_ context.Context, logger *logging.Logger, currentNode string, vm vmEntry, _ guestApplyPrecondition, data []byte) error {
+		rel := filepath.Join("nodes", currentNode, guestConfDir(vm.Kind), vm.VMID+".conf")
+		return pmxcfsWriteFile(logger, rel, data)
+	}
 
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "100.conf")

--- a/internal/orchestrator/restore_errors_test.go
+++ b/internal/orchestrator/restore_errors_test.go
@@ -1675,7 +1675,11 @@ func TestApplyVMConfigs_SuccessfulApply(t *testing.T) {
 	}
 }
 
-func TestApplyVMConfigs_CreatesMissingGuestBeforeSet(t *testing.T) {
+func TestApplyVMConfigs_RegistersMissingGuestViaPmxcfs(t *testing.T) {
+	// The old contract created the guest via pvesh and then set its config; the
+	// create was a dead end for LXC (ostemplate) and needless for qemu, so a
+	// missing guest is now registered by writing its staged conf into pmxcfs
+	// (fable-check bugs 2-3; see pve_guest_apply_test.go for the full matrix).
 	orig := restoreCmd
 	t.Cleanup(func() { restoreCmd = orig })
 
@@ -1688,6 +1692,9 @@ func TestApplyVMConfigs_CreatesMissingGuestBeforeSet(t *testing.T) {
 		},
 	}
 	restoreCmd = fake
+
+	pmxRoot := t.TempDir()
+	seamPmxcfs(t, pmxRoot, true, nil)
 
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "100.conf")
@@ -1702,12 +1709,13 @@ func TestApplyVMConfigs_CreatesMissingGuestBeforeSet(t *testing.T) {
 	if applied != 1 || failed != 0 {
 		t.Fatalf("expected (1,0), got (%d,%d)", applied, failed)
 	}
-	calls := strings.Join(fake.CallsList(), "\n")
-	if !strings.Contains(calls, fmt.Sprintf("pvesh create /nodes/%s/qemu --vmid=100", node)) {
-		t.Fatalf("missing create call; calls=%s", calls)
+	got, err := os.ReadFile(filepath.Join(pmxRoot, "nodes", node, "qemu-server", "100.conf"))
+	if err != nil || string(got) != "name: test-vm" {
+		t.Fatalf("conf not registered in pmxcfs: %q err=%v", got, err)
 	}
-	if !strings.Contains(calls, fmt.Sprintf("pvesh set /nodes/%s/qemu/100/config --name=test-vm", node)) {
-		t.Fatalf("missing set call; calls=%s", calls)
+	calls := strings.Join(fake.CallsList(), "\n")
+	if strings.Contains(calls, "pvesh create /nodes/") {
+		t.Fatalf("pvesh create must be gone; calls=%s", calls)
 	}
 }
 

--- a/internal/orchestrator/restore_test.go
+++ b/internal/orchestrator/restore_test.go
@@ -1385,16 +1385,11 @@ func TestPveshArgsFromColonConfigLinesStopsAtSectionHeader(t *testing.T) {
 	}
 }
 
-func TestPveshCreateGuestArgsIncludesLXCOstemplate(t *testing.T) {
-	args, err := pveshCreateGuestArgs("node1", vmEntry{VMID: "101", Kind: "lxc"}, []string{"--hostname=ct101", "--ostemplate=local:vztmpl/debian.tar.zst"})
-	if err != nil {
-		t.Fatalf("pveshCreateGuestArgs error = %v", err)
-	}
-	got := strings.Join(args, " ")
-	if !strings.Contains(got, "create /nodes/node1/lxc --vmid=101") || !strings.Contains(got, "--ostemplate=local:vztmpl/debian.tar.zst") {
-		t.Fatalf("unexpected create args: %v", args)
-	}
-}
+// TestPveshCreateGuestArgsIncludesLXCOstemplate is gone with its subject:
+// pveshCreateGuestArgs demanded an ostemplate no real conf carries (the test
+// hand-fed it, an input no backup produces - fable-check bug 3). A missing
+// guest is now registered by writing its staged conf into pmxcfs; see
+// pve_guest_apply_test.go.
 
 // --------------------------------------------------------------------------
 // detectConfiguredZFSPools tests

--- a/internal/orchestrator/restore_workflow_ui_cluster_apply.go
+++ b/internal/orchestrator/restore_workflow_ui_cluster_apply.go
@@ -331,11 +331,19 @@ func (f *safeClusterApplyUIFlow) confirmAndApplyDatacenterCfg(dcCfg string, size
 		f.logger.Info("Skipping datacenter.cfg apply")
 		return nil
 	}
-	logging.DebugStep(f.logger, "safe cluster apply (ui)", "Apply datacenter.cfg via pvesh")
-	if err := runPvesh(f.ctx, f.logger, []string{"set", "/cluster/config", "-conf", dcCfg}); err != nil {
+	// Not pvesh: the live node has no 'set' handler on /cluster/config (probed
+	// 2026-09-02, PVE 9.1.9), so the old call never applied anything. The file
+	// write IS the cluster-wide apply - /etc/pve is pmxcfs.
+	logging.DebugStep(f.logger, "safe cluster apply (ui)", "Write datacenter.cfg into pmxcfs")
+	data, err := restoreFS.ReadFile(dcCfg)
+	if err != nil {
+		f.logger.Warning("Failed to read exported datacenter.cfg: %v", err)
+		return nil
+	}
+	if err := pmxcfsWriteFile(f.logger, "datacenter.cfg", data); err != nil {
 		f.logger.Warning("Failed to apply datacenter.cfg: %v", err)
 	} else {
-		f.logger.Info("datacenter.cfg applied successfully")
+		f.logger.Info("datacenter.cfg written to pmxcfs (cluster-wide)")
 	}
 	return nil
 }

--- a/internal/orchestrator/restore_workflow_ui_cluster_apply.go
+++ b/internal/orchestrator/restore_workflow_ui_cluster_apply.go
@@ -50,7 +50,7 @@ func (f *safeClusterApplyUIFlow) run() error {
 	}
 	f.detectCurrentNode()
 	f.logger.Info("")
-	f.logger.Info("SAFE cluster restore: applying configs via pvesh (node=%s)", f.currentNode)
+	f.logger.Info("SAFE cluster restore: applying configs (node=%s)", f.currentNode)
 	f.applyResourceMappings()
 	if err := f.preparePools(); err != nil {
 		return err

--- a/internal/orchestrator/storage_adapter.go
+++ b/internal/orchestrator/storage_adapter.go
@@ -193,9 +193,17 @@ func (s *StorageAdapter) Sync(ctx context.Context, stats *BackupStats) error {
 		}
 	}
 
-	if hasWarnings {
+	// The closing line follows the WORST thing the adapter saw, mirroring
+	// finalizeStorageStatus below: a failed store used to close green whenever
+	// retention then ran clean, so the log's last word contradicted the
+	// notification's "error". Still WARNING-level: the store failure itself is
+	// logged as recoverable and the exit contract stays warning-weight.
+	switch {
+	case hasErrors:
+		s.logger.Warning("✗ %s operations completed with errors", s.backend.Name())
+	case hasWarnings:
 		s.logger.Warning("✗ %s operations completed with warnings", s.backend.Name())
-	} else {
+	default:
 		s.logger.Info("✓ %s operations completed", s.backend.Name())
 	}
 	s.finalizeStorageStatus(stats, hasErrors, hasWarnings)

--- a/internal/orchestrator/storage_adapter_close_line_test.go
+++ b/internal/orchestrator/storage_adapter_close_line_test.go
@@ -1,0 +1,93 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/config"
+	"github.com/tis24dev/proxsave/internal/logging"
+	"github.com/tis24dev/proxsave/internal/storage"
+	"github.com/tis24dev/proxsave/internal/types"
+)
+
+// The tier closing line is the log's last word on a storage backend, and until now
+// nothing pinned it: the branch read only hasWarnings, so a run whose Store FAILED
+// (status "error" in the notification, "Backup was not saved" two lines above)
+// still closed green with "✓ ... operations completed" at INFO whenever retention
+// then ran clean - exactly the shape of a secondary/cloud mount that dies mid-copy.
+// The closing line must follow the worst thing the adapter saw, not the best.
+func adapterClosingLine(t *testing.T, storeErr, retentionErr error) string {
+	t.Helper()
+	logger := logging.New(types.LogLevelDebug, false)
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+
+	backend := &fakeStorageBackend{
+		name:     "secondary",
+		location: storage.LocationSecondary,
+		enabled:  true,
+		critical: false,
+		detectFilesystemFn: func(context.Context) (*storage.FilesystemInfo, error) {
+			return &storage.FilesystemInfo{Type: storage.FilesystemExt4}, nil
+		},
+		storeFn: func(context.Context, string, *types.BackupMetadata) error { return storeErr },
+		applyRetentionFn: func(context.Context, storage.RetentionConfig) (int, error) {
+			return 0, retentionErr
+		},
+		getStatsFn: func(context.Context) (*storage.StorageStats, error) {
+			return &storage.StorageStats{TotalBackups: 1}, nil
+		},
+	}
+	adapter := NewStorageAdapter(backend, logger, &config.Config{SecondaryRetentionDays: 2})
+	if err := adapter.Sync(context.Background(), sampleAdapterStats()); err != nil {
+		t.Fatalf("Sync returned error: %v", err)
+	}
+
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if strings.Contains(line, "operations completed") {
+			return line
+		}
+	}
+	t.Fatalf("no closing line rendered:\n%s", buf.String())
+	return ""
+}
+
+func closeLevelOf(t *testing.T, line string) string {
+	t.Helper()
+	_, rest, found := strings.Cut(line, "] ")
+	if !found {
+		t.Fatalf("unparseable line: %q", line)
+	}
+	return strings.Fields(rest)[0]
+}
+
+func TestClosingLineAfterFailedStoreSaysErrorsAtWarning(t *testing.T) {
+	line := adapterClosingLine(t, errors.New("store fail"), nil)
+	if !strings.Contains(line, "✗ secondary operations completed with errors") {
+		t.Fatalf("a failed store still closes green; the log's last word contradicts the notification's \"error\":\n%s", line)
+	}
+	if got := closeLevelOf(t, line); got != "WARNING" {
+		t.Fatalf("closing line level = %s, want WARNING (store failure stays warning-weight, exit contract unchanged):\n%s", got, line)
+	}
+}
+
+func TestClosingLineErrorsOutrankWarnings(t *testing.T) {
+	line := adapterClosingLine(t, errors.New("store fail"), errors.New("retention fail"))
+	if !strings.Contains(line, "completed with errors") {
+		t.Fatalf("with both flags set the closing line must report the worse one:\n%s", line)
+	}
+}
+
+func TestClosingLineArmsStillRender(t *testing.T) {
+	warn := adapterClosingLine(t, nil, errors.New("retention fail"))
+	if !strings.Contains(warn, "✗ secondary operations completed with warnings") || closeLevelOf(t, warn) != "WARNING" {
+		t.Fatalf("warnings arm changed:\n%s", warn)
+	}
+	ok := adapterClosingLine(t, nil, nil)
+	if !strings.Contains(ok, "✓ secondary operations completed") || closeLevelOf(t, ok) != "INFO" {
+		t.Fatalf("clean arm changed:\n%s", ok)
+	}
+}

--- a/internal/orchestrator/temp_registry.go
+++ b/internal/orchestrator/temp_registry.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/tis24dev/proxsave/internal/filelock"
 	"github.com/tis24dev/proxsave/internal/logging"
 )
 
@@ -209,22 +210,13 @@ func (r *TempDirRegistry) withLock(mutator func([]tempDirRecord) ([]tempDirRecor
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	lockFile, err := os.OpenFile(r.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	releaseLock, err := filelock.Acquire(r.lockPath)
 	if err != nil {
-		return fmt.Errorf("open registry lock: %w", err)
+		return fmt.Errorf("lock registry: %w", err)
 	}
 	defer func() {
-		if closeErr := lockFile.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("close registry lock: %w", closeErr)
-		}
-	}()
-
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
-		return fmt.Errorf("flock registry: %w", err)
-	}
-	defer func() {
-		if unlockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); unlockErr != nil && err == nil {
-			err = fmt.Errorf("unlock registry: %w", unlockErr)
+		if releaseErr := releaseLock(); releaseErr != nil && err == nil {
+			err = fmt.Errorf("release registry lock: %w", releaseErr)
 		}
 	}()
 

--- a/internal/orchestrator/workflow_ui_charm_restore.go
+++ b/internal/orchestrator/workflow_ui_charm_restore.go
@@ -314,7 +314,7 @@ func (u *charmWorkflowUI) ConfirmApplyStorageCfg(ctx context.Context, storageCfg
 
 func (u *charmWorkflowUI) ConfirmApplyDatacenterCfg(ctx context.Context, datacenterCfgPath string) (bool, error) {
 	return u.confirmApply(ctx, "Apply datacenter.cfg",
-		fmt.Sprintf("Datacenter configuration found:\n\n%s\n\nApply datacenter.cfg via pvesh now?", strings.TrimSpace(datacenterCfgPath)))
+		fmt.Sprintf("Datacenter configuration found:\n\n%s\n\nApply datacenter.cfg now?", strings.TrimSpace(datacenterCfgPath)))
 }
 
 func (u *charmWorkflowUI) confirmApply(ctx context.Context, title, message string) (bool, error) {

--- a/internal/orchestrator/workflow_ui_charm_restore.go
+++ b/internal/orchestrator/workflow_ui_charm_restore.go
@@ -313,14 +313,18 @@ func (u *charmWorkflowUI) ConfirmApplyStorageCfg(ctx context.Context, storageCfg
 }
 
 func (u *charmWorkflowUI) ConfirmApplyDatacenterCfg(ctx context.Context, datacenterCfgPath string) (bool, error) {
-	return u.confirmApply(ctx, "Apply datacenter.cfg",
+	return u.confirmApplyWithLabel(ctx, "Apply datacenter.cfg", "Write to pmxcfs",
 		fmt.Sprintf("Datacenter configuration found:\n\n%s\n\nApply datacenter.cfg now?", strings.TrimSpace(datacenterCfgPath)))
 }
 
 func (u *charmWorkflowUI) confirmApply(ctx context.Context, title, message string) (bool, error) {
+	return u.confirmApplyWithLabel(ctx, title, "Apply via API", message)
+}
+
+func (u *charmWorkflowUI) confirmApplyWithLabel(ctx context.Context, title, yesLabel, message string) (bool, error) {
 	res, err := shell.Ask(ctx, u.session, components.NewConfirm(
 		title, message,
-		components.WithLabels("Apply via API", "Skip"),
+		components.WithLabels(yesLabel, "Skip"),
 		components.WithDefaultYes(false),
 		components.WithDanger(),
 	))

--- a/internal/orchestrator/workflow_ui_charm_restore_test.go
+++ b/internal/orchestrator/workflow_ui_charm_restore_test.go
@@ -355,6 +355,7 @@ func TestCharmConfirmApplyPrompts(t *testing.T) {
 		resCh <- result{ok, err}
 	}()
 	d.waitScreen("Apply storage.cfg")
+	d.waitOutput("Apply via API")
 	d.keys("left enter") // deliberate apply
 	if res := <-resCh; res.err != nil || !res.ok {
 		t.Fatalf("deliberate apply failed, got %+v", res)
@@ -365,6 +366,7 @@ func TestCharmConfirmApplyPrompts(t *testing.T) {
 		resCh <- result{ok, err}
 	}()
 	d.waitScreen("Apply datacenter.cfg")
+	d.waitOutput("Write to pmxcfs")
 	d.keys("esc")
 	if res := <-resCh; res.err != nil || res.ok {
 		t.Fatalf("esc must decline, got %+v", res)

--- a/internal/orchestrator/workflow_ui_cli.go
+++ b/internal/orchestrator/workflow_ui_cli.go
@@ -387,5 +387,5 @@ func (u *cliWorkflowUI) ConfirmApplyStorageCfg(ctx context.Context, storageCfgPa
 func (u *cliWorkflowUI) ConfirmApplyDatacenterCfg(ctx context.Context, datacenterCfgPath string) (bool, error) {
 	fmt.Fprintln(u.w())
 	fmt.Fprintf(u.w(), "Datacenter configuration found: %s\n", components.SanitizeLine(strings.TrimSpace(datacenterCfgPath)))
-	return promptYesNo(ctx, u.reader, "Apply datacenter.cfg via pvesh? (y/N): ")
+	return promptYesNo(ctx, u.reader, "Apply datacenter.cfg? (y/N): ")
 }

--- a/internal/safefs/safefs.go
+++ b/internal/safefs/safefs.go
@@ -397,11 +397,12 @@ func CreateTemp(ctx context.Context, dir, pattern string, timeout time.Duration)
 // actually-used byte counts. "Available" tracks Bavail (space a non-root user can
 // allocate), while "used" tracks Blocks-Bfree (space already consumed).
 func SpaceUsageFromStatfs(stat syscall.Statfs_t) (totalBytes, availableBytes, usedBytes int64) {
-	totalBytes = statfsBlocksToBytes(stat.Blocks, stat.Bsize)
-	availableBytes = statfsBlocksToBytes(stat.Bavail, stat.Bsize)
+	blockSize := int64(stat.Bsize)
+	totalBytes = statfsBlocksToBytes(stat.Blocks, blockSize)
+	availableBytes = statfsBlocksToBytes(stat.Bavail, blockSize)
 
 	if stat.Blocks > stat.Bfree {
-		usedBytes = statfsBlocksToBytes(stat.Blocks-stat.Bfree, stat.Bsize)
+		usedBytes = statfsBlocksToBytes(stat.Blocks-stat.Bfree, blockSize)
 	}
 	if availableBytes > totalBytes {
 		availableBytes = totalBytes

--- a/internal/safefs/safefs_test.go
+++ b/internal/safefs/safefs_test.go
@@ -223,15 +223,16 @@ func TestSpaceUsageFromStatfsSaturatesOverflowingProducts(t *testing.T) {
 	}
 
 	total, available, used := SpaceUsageFromStatfs(stat)
+	want := int64(math.MaxInt64)
 
-	if total != math.MaxInt64 {
-		t.Fatalf("total = %d; want %d", total, math.MaxInt64)
+	if total != want {
+		t.Fatalf("total = %d; want %d", total, want)
 	}
-	if available != math.MaxInt64 {
-		t.Fatalf("available = %d; want %d", available, math.MaxInt64)
+	if available != want {
+		t.Fatalf("available = %d; want %d", available, want)
 	}
-	if used != math.MaxInt64 {
-		t.Fatalf("used = %d; want %d", used, math.MaxInt64)
+	if used != want {
+		t.Fatalf("used = %d; want %d", used, want)
 	}
 }
 

--- a/internal/storage/backup_files.go
+++ b/internal/storage/backup_files.go
@@ -41,12 +41,15 @@ func isBackupSidecar(path string) bool {
 // written before promotion) rather than a completed backup. Such files must
 // never be counted as backups by any List filter.
 //
-// ".tmp-" is matched anywhere in the name, not only as a leading dot: the bundle
-// build stages "<archive>.bundle.tar.tmp-<rand>" in BACKUP_PATH (fs.CreateTemp with
-// pattern "<base>.tmp-*"), and a crash mid-bundle leaves that file matching the
-// backup glob - counted as a backup forever, warned about every pass, deleted never.
+// The bundle build stages "<archive>.bundle.tar.tmp-<rand>" in BACKUP_PATH
+// (fs.CreateTemp with pattern "<base>.tmp-*"), while secondary copies use a
+// leading ".tmp-". Matching only those concrete forms avoids hiding a completed
+// backup whose hostname happens to contain ".tmp-".
 func isBackupTempArtifact(path string) bool {
-	return strings.Contains(filepath.Base(path), ".tmp-") || strings.HasSuffix(path, ".partial")
+	base := filepath.Base(path)
+	return strings.HasPrefix(base, ".tmp-") ||
+		strings.Contains(base, bundleSuffix+".tmp-") ||
+		strings.HasSuffix(base, ".partial")
 }
 
 // trimBundleSuffix removes the .bundle.tar suffix from a path if present.

--- a/internal/storage/backup_files.go
+++ b/internal/storage/backup_files.go
@@ -40,9 +40,13 @@ func isBackupSidecar(path string) bool {
 // partial artifact (a .tmp-<...> temp copy, or a <name>.partial archive being
 // written before promotion) rather than a completed backup. Such files must
 // never be counted as backups by any List filter.
+//
+// ".tmp-" is matched anywhere in the name, not only as a leading dot: the bundle
+// build stages "<archive>.bundle.tar.tmp-<rand>" in BACKUP_PATH (fs.CreateTemp with
+// pattern "<base>.tmp-*"), and a crash mid-bundle leaves that file matching the
+// backup glob - counted as a backup forever, warned about every pass, deleted never.
 func isBackupTempArtifact(path string) bool {
-	base := filepath.Base(path)
-	return strings.HasPrefix(base, ".tmp-") || strings.HasSuffix(path, ".partial")
+	return strings.Contains(filepath.Base(path), ".tmp-") || strings.HasSuffix(path, ".partial")
 }
 
 // trimBundleSuffix removes the .bundle.tar suffix from a path if present.

--- a/internal/storage/backup_files_test.go
+++ b/internal/storage/backup_files_test.go
@@ -62,7 +62,8 @@ func TestBuildBackupCandidatePathsNormalizesBundleInput(t *testing.T) {
 // A crash during bundling leaves that file behind, it matches the backup glob, and a
 // prefix-only check let every List count it as a backup forever: phantom counts, a
 // missing-.metadata WARNING each pass (pinning exit 1), and nothing ever deleting it.
-// The temp marker must therefore match anywhere in the name.
+// The bundle staging marker must therefore match even though it is not a prefix,
+// without treating an unrelated ".tmp-" in a completed backup name as temporary.
 func TestBackupTempArtifactMatchesBundleTempMidName(t *testing.T) {
 	cases := map[string]bool{
 		"host-backup-20250101-120000.tar.zst.bundle.tar.tmp-12345": true,
@@ -70,6 +71,7 @@ func TestBackupTempArtifactMatchesBundleTempMidName(t *testing.T) {
 		"host-backup-20250101-120000.tar.zst.partial":              true,
 		"host-backup-20250101-120000.tar.zst":                      false,
 		"host-backup-20250101-120000.tar.zst.bundle.tar":           false,
+		"node.tmp-lab-backup-20250101-120000.tar.zst":              false,
 	}
 	for path, want := range cases {
 		if got := isBackupTempArtifact("/backups/" + path); got != want {

--- a/internal/storage/backup_files_test.go
+++ b/internal/storage/backup_files_test.go
@@ -56,3 +56,24 @@ func TestBuildBackupCandidatePathsNormalizesBundleInput(t *testing.T) {
 		})
 	}
 }
+
+// The bundle build stages `<archive>.bundle.tar.tmp-<rand>` IN BACKUP_PATH
+// (fs.CreateTemp with pattern "<base>.tmp-*", orchestrator.go), with NO leading dot.
+// A crash during bundling leaves that file behind, it matches the backup glob, and a
+// prefix-only check let every List count it as a backup forever: phantom counts, a
+// missing-.metadata WARNING each pass (pinning exit 1), and nothing ever deleting it.
+// The temp marker must therefore match anywhere in the name.
+func TestBackupTempArtifactMatchesBundleTempMidName(t *testing.T) {
+	cases := map[string]bool{
+		"host-backup-20250101-120000.tar.zst.bundle.tar.tmp-12345": true,
+		".tmp-host-backup-20250101-120000.tar.zst":                 true,
+		"host-backup-20250101-120000.tar.zst.partial":              true,
+		"host-backup-20250101-120000.tar.zst":                      false,
+		"host-backup-20250101-120000.tar.zst.bundle.tar":           false,
+	}
+	for path, want := range cases {
+		if got := isBackupTempArtifact("/backups/" + path); got != want {
+			t.Errorf("isBackupTempArtifact(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/internal/storage/bundle_pair_counting_test.go
+++ b/internal/storage/bundle_pair_counting_test.go
@@ -1,0 +1,85 @@
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/config"
+)
+
+// Characterization of PARKED bug 6 (diagnostics/fable-check.md, maintainer call
+// 2026-09-02): when the SAME archive exists in both forms - standalone and
+// .bundle.tar - the two gates behave very differently, and only one of them is
+// a design.
+//
+// The both-forms state is not a normal run's product: bundling removes the raw
+// files after building the bundle, and only a removeAssociatedFiles failure
+// right after bundling (backup_run_phases.go, Warning "Failed to remove raw
+// files after bundling") leaves the pair behind. Nobody has ever reported it in
+// the wild, which is why the OFF-side behavior is parked, not fixed.
+//
+// These tests exist so the state stays MEASURED: if either side changes, it
+// must change consciously, and if the pair ever shows up in a real report the
+// fix flips the OFF-side assertions.
+
+func seedBundlePair(t *testing.T) (dir, standalone, bundle string) {
+	t.Helper()
+	dir = t.TempDir()
+	standalone = filepath.Join(dir, "host-backup-20260101-120000.tar.zst")
+	bundle = standalone + ".bundle.tar"
+	for _, p := range []string{standalone, bundle} {
+		if err := os.WriteFile(p, []byte("x"), 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir, standalone, bundle
+}
+
+// The default everyone runs: BUNDLE_ASSOCIATED_FILES=true. The pair collapses
+// to ONE logical backup (the standalone is skipped because its bundle exists),
+// which is exactly why no user has ever seen a double count.
+func TestBundlePairCountsOnceWithBundlingOn(t *testing.T) {
+	dir, _, bundle := seedBundlePair(t)
+	ls, err := NewLocalStorage(&config.Config{BackupPath: dir, BundleAssociatedFiles: true, MaxLocalBackups: 7}, newTestLogger(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := ls.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].BackupFile != bundle {
+		t.Fatalf("with bundling ON the pair must collapse to the bundle alone, got %d entries: %+v", len(list), list)
+	}
+}
+
+// PARKED bug 6, pinned as it stands today: with bundling OFF nothing collapses
+// the pair, so List reports TWO backups where one exists on disk - while Delete
+// of EITHER entry removes both forms (buildBackupCandidatePaths always includes
+// the bundle). Simple retention counting entries therefore keeps fewer real
+// backups than MAX_LOCAL_BACKUPS promises whenever pairs are present. The
+// secondary backend carries the same two gates (secondary.go List/Delete).
+func TestBundlePairDoubleCountWithBundlingOffIsTheParkedState(t *testing.T) {
+	dir, standalone, bundle := seedBundlePair(t)
+	ls, err := NewLocalStorage(&config.Config{BackupPath: dir, BundleAssociatedFiles: false, MaxLocalBackups: 7}, newTestLogger(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := ls.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("the parked state changed: List = %d entries, the pin expects today's double count of 2 - if this is a deliberate fix of bug 6, flip this test", len(list))
+	}
+	if err := ls.Delete(context.Background(), standalone); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	for _, p := range []string{standalone, bundle} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("deleting one entry is expected to remove BOTH forms (that linkage is why the double count understates retention), %s survived", p)
+		}
+	}
+}

--- a/internal/storage/cloud.go
+++ b/internal/storage/cloud.go
@@ -1799,11 +1799,6 @@ func (c *CloudStorage) deleteAssociatedLog(ctx context.Context, backupFile strin
 	if base == "" {
 		return false
 	}
-	baseForWarning := c.cloudLogBase(base)
-	if baseForWarning == "" {
-		baseForWarning = base
-	}
-
 	host, ts, ok := extractLogKeyFromBackup(backupFile)
 	if !ok {
 		return false
@@ -1820,18 +1815,21 @@ func (c *CloudStorage) deleteAssociatedLog(ctx context.Context, backupFile strin
 		return false
 	}
 
-	args := c.buildRcloneArgs("delete")
+	// `deletefile` is the single-object delete. The directory-oriented `delete` used
+	// here before answered a merely-absent log with "directory not found" on
+	// directory-listing backends - misread as the whole CLOUD_LOG_PATH being gone,
+	// poisoning cleanup for every remaining backup - and with exit 0 on prefix
+	// backends, counting a deletion that never happened. The absence of ONE log says
+	// nothing about the base path, so every not-found wording lands in the benign
+	// branch; the real path-missing detection stays with countLogFiles' lsf.
+	args := c.buildRcloneArgs("deletefile")
 	args = append(args, cloudPath)
 	c.logger.Debug("Cloud logs: deleting log %s", cloudPath)
 	output, err := c.exec(ctx, args[0], args[1:]...)
 	if err != nil {
 		msg := strings.TrimSpace(string(output))
 		if isRcloneObjectNotFound(msg) || isRcloneObjectNotFound(err.Error()) {
-			if strings.Contains(strings.ToLower(msg), "directory") {
-				c.markCloudLogPathMissing(baseForWarning, msg)
-			} else {
-				c.logger.Debug("Cloud logs: log already removed %s (%s)", cloudPath, msg)
-			}
+			c.logger.Debug("Cloud logs: log already removed %s (%s)", cloudPath, msg)
 			return false
 		}
 		// Carrying the exec error alone left rclone's reason on a Debug line a

--- a/internal/storage/cloud_log_deletefile_test.go
+++ b/internal/storage/cloud_log_deletefile_test.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tis24dev/proxsave/internal/config"
+)
+
+// deleteAssociatedLog removes ONE file, so it must use rclone's single-object verb.
+// The directory-oriented `delete` it used before answered a merely-absent log with
+// "directory not found" on directory-listing backends, which the error branch read
+// as the whole CLOUD_LOG_PATH being gone: a false WARNING naming the base, plus
+// logPathMissing poisoning log cleanup for every remaining backup of the pass. On
+// prefix backends the same miss exited 0 and falsely counted a deletion. Both
+// behaviors were reproduced live with rclone v1.75.0.
+func TestDeleteAssociatedLogUsesDeletefile(t *testing.T) {
+	cfg := &config.Config{
+		CloudEnabled:  true,
+		CloudRemote:   "remote",
+		CloudLogPath:  "remote:logs",
+		RcloneRetries: 1,
+	}
+	cs := newCloudStorageForTest(cfg)
+
+	var calls [][]string
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		return nil, nil
+	}
+
+	if !cs.deleteAssociatedLog(context.Background(), "host-backup-20250101-010101.tar.xz") {
+		t.Fatal("deleteAssociatedLog() = false on a successful delete, want true")
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one rclone call, got %d: %v", len(calls), calls)
+	}
+	if calls[0][0] != "deletefile" {
+		t.Fatalf("verb = %q, want deletefile (single-object delete): %v", calls[0][0], calls[0])
+	}
+	if last := calls[0][len(calls[0])-1]; !strings.HasSuffix(last, "backup-host-20250101-010101.log") {
+		t.Fatalf("expected the derived log path as the final argument, got %v", calls[0])
+	}
+}
+
+// A missing log is the benign branch whatever wording the backend picks:
+// "directory not found" from a directory-listing backend must NOT mark the whole
+// log path unavailable and must NOT warn - the next backup's log delete still runs.
+func TestDeleteAssociatedLogMissingLogDoesNotPoisonTheLogPath(t *testing.T) {
+	cfg := &config.Config{
+		CloudEnabled:  true,
+		CloudRemote:   "remote",
+		CloudLogPath:  "remote:logs",
+		RcloneRetries: 1,
+	}
+	cs := newCloudStorageForTest(cfg)
+
+	var calls int
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		calls++
+		return []byte("2025/11/16 22:11:47 ERROR : remote:logs/backup-host-20250101-010101.log: directory not found"), errors.New("exit status 3")
+	}
+
+	if cs.deleteAssociatedLog(context.Background(), "host-backup-20250101-010101.tar.xz") {
+		t.Fatal("deleteAssociatedLog() = true for a missing log, want false")
+	}
+	if cs.isCloudLogPathUnavailable() {
+		t.Fatal("a single missing log marked the whole CLOUD_LOG_PATH unavailable, poisoning cleanup for every remaining backup")
+	}
+	if cs.deleteAssociatedLog(context.Background(), "host-backup-20250102-010101.tar.xz"); calls != 2 {
+		t.Fatalf("the second backup's log delete was skipped (calls=%d), want it to still run", calls)
+	}
+}

--- a/internal/storage/cloud_retention_owner.go
+++ b/internal/storage/cloud_retention_owner.go
@@ -39,6 +39,14 @@ func (c *CloudStorage) resolveRetentionOwners(ctx context.Context, backups []*ty
 		return
 	}
 
+	// The run ctx is cancel-only; every archive costs one `rclone cat` and this
+	// function waits on ALL of them, so an unfloored ctx let a single wedged cat
+	// hang the unattended run forever. One shared management budget bounds the whole
+	// attribution phase: archives left unresolved when it expires keep an empty
+	// Hostname and degrade to the filename token, the documented fallback.
+	ctx, cancel := c.boundManagementCtx(ctx)
+	defer cancel()
+
 	// One round trip per archive, so a large remote is worth parallelising. Bounded by
 	// the same CLOUD_PARALLEL_MAX_JOBS the upload path uses, rather than a second knob:
 	// both are round trips to the same remote and the operator already tuned that

--- a/internal/storage/cloud_retention_owner_test.go
+++ b/internal/storage/cloud_retention_owner_test.go
@@ -240,3 +240,33 @@ func TestApplyRetentionLeavesSameShortNameForeignFQDNAlone(t *testing.T) {
 		}
 	}
 }
+
+// TestResolveRetentionOwnersBoundsItsContext pins the timeout floor on retention's
+// manifest attribution. The run ctx is cancel-only (no deadline), each archive costs
+// one `rclone cat`, and resolveRetentionOwners waits on ALL of them: one wedged cat
+// used to block wg.Wait() forever and hang the unattended cron/daemon run, while the
+// file header of cloud.go promises the retention paths are floored. The whole
+// attribution phase must therefore run under boundManagementCtx: every exec must see
+// a deadline when the caller's ctx has none.
+func TestResolveRetentionOwnersBoundsItsContext(t *testing.T) {
+	cfg := &config.Config{CloudEnabled: true, CloudRemote: "gdrive"}
+	cs := newCloudStorageForTest(cfg)
+
+	deadlines := 0
+	cs.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if _, ok := ctx.Deadline(); ok {
+			deadlines++
+		}
+		return []byte(`{"hostname":"server1"}`), nil
+	}
+
+	list := []*types.BackupMetadata{
+		{BackupFile: "a-backup-20250102-100000.tar.zst"},
+		{BackupFile: "b-backup-20250103-100000.tar.zst"},
+	}
+	cs.resolveRetentionOwners(context.Background(), list)
+
+	if deadlines != len(list) {
+		t.Fatalf("%d of %d manifest reads ran with a deadline; a deadline-less run ctx must be floored so a wedged rclone cat cannot hang retention forever", deadlines, len(list))
+	}
+}

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -228,22 +228,30 @@ func (d *FilesystemDetector) getFilesystemType(ctx context.Context, mountPoint s
 		return FilesystemUnknown, "", err
 	}
 
-	lines := strings.Split(string(data), "\n")
+	if fsTypeStr, device, ok := lastMountEntryFor(strings.Split(string(data), "\n"), mountPoint); ok {
+		return parseFilesystemType(fsTypeStr), device, nil
+	}
+
+	return FilesystemUnknown, "", fmt.Errorf("filesystem type not found in /proc/mounts")
+}
+
+// lastMountEntryFor returns the type and device of the LAST /proc/mounts entry for
+// mountPoint. The kernel appends mounts in order, so with stacked entries the last
+// one is the filesystem a path actually resolves to - under a systemd automount the
+// autofs placeholder comes first and the triggered real filesystem after it, and
+// answering with the first entry made the backup path look like an Unknown autofs:
+// no network ownership probe, chown/chmod on stored backups silently skipped.
+func lastMountEntryFor(lines []string, mountPoint string) (fsTypeStr, device string, ok bool) {
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) < 3 {
 			continue
 		}
-
-		mount := unescapeOctal(fields[1])
-		if mount == mountPoint {
-			fsTypeStr := fields[2]
-			device := fields[0]
-			return parseFilesystemType(fsTypeStr), device, nil
+		if unescapeOctal(fields[1]) == mountPoint {
+			fsTypeStr, device, ok = fields[2], fields[0], true
 		}
 	}
-
-	return FilesystemUnknown, "", fmt.Errorf("filesystem type not found in /proc/mounts")
+	return fsTypeStr, device, ok
 }
 
 // testOwnershipSupport tests if a filesystem actually supports Unix ownership

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -176,14 +176,19 @@ func (d *FilesystemDetector) getMountPoint(path string) (string, error) {
 		return "", err
 	}
 
-	lines := strings.Split(string(data), "\n")
-	bestMatch := "/"
-	bestMatchLen := 0
-
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		absPath = path
 	}
+
+	return bestMountPointFor(strings.Split(string(data), "\n"), absPath), nil
+}
+
+// bestMountPointFor picks the deepest mount point owning absPath from /proc/mounts
+// lines, defaulting to "/".
+func bestMountPointFor(lines []string, absPath string) string {
+	bestMatch := "/"
+	bestMatchLen := 0
 
 	for _, line := range lines {
 		fields := strings.Fields(line)
@@ -195,8 +200,10 @@ func (d *FilesystemDetector) getMountPoint(path string) (string, error) {
 		// Unescape octal sequences like \040 (space)
 		mountPoint = unescapeOctal(mountPoint)
 
-		// Check if this path is under this mount point
-		if strings.HasPrefix(absPath, mountPoint) {
+		// Under this mount point by PATH BOUNDARY: a bare prefix check let a
+		// sibling mount whose path is a string prefix win (/mnt/nas vs /mnt/nas2),
+		// and a dead sibling then aborted the backup of a healthy path.
+		if mountPoint == "/" || absPath == mountPoint || strings.HasPrefix(absPath, mountPoint+"/") {
 			if len(mountPoint) > bestMatchLen {
 				bestMatch = mountPoint
 				bestMatchLen = len(mountPoint)
@@ -204,7 +211,7 @@ func (d *FilesystemDetector) getMountPoint(path string) (string, error) {
 		}
 	}
 
-	return bestMatch, nil
+	return bestMatch
 }
 
 // getFilesystemType gets the filesystem type for a mount point using df

--- a/internal/storage/filesystem_test.go
+++ b/internal/storage/filesystem_test.go
@@ -309,3 +309,25 @@ func TestFilesystemDetectorTestOwnershipSupport_FailsWhenDirNotWritable(t *testi
 		t.Fatalf("expected ownership support test to fail when directory is not writable")
 	}
 }
+
+// A mount point must own the path by PATH BOUNDARY, not by string prefix: with
+// mounts "/" and "/mnt/nas", BACKUP_PATH=/mnt/nas2 lives on "/", but a bare
+// HasPrefix picked "/mnt/nas" - and a dead /mnt/nas then turned into a critical
+// StorageError aborting the backup of a perfectly healthy sibling path.
+func TestBestMountPointForRespectsPathBoundaries(t *testing.T) {
+	lines := []string{
+		"rootfs / ext4 rw 0 0",
+		"nas /mnt/nas nfs4 rw 0 0",
+	}
+	cases := map[string]string{
+		"/mnt/nas2":    "/",
+		"/mnt/nas":     "/mnt/nas",
+		"/mnt/nas/sub": "/mnt/nas",
+		"/var/backups": "/",
+	}
+	for path, want := range cases {
+		if got := bestMountPointFor(lines, path); got != want {
+			t.Errorf("bestMountPointFor(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/internal/storage/filesystem_test.go
+++ b/internal/storage/filesystem_test.go
@@ -331,3 +331,35 @@ func TestBestMountPointForRespectsPathBoundaries(t *testing.T) {
 		}
 	}
 }
+
+// getFilesystemType answered with the FIRST /proc/mounts entry for the mount
+// point. Under a systemd automount the autofs placeholder precedes the real
+// filesystem at the same path - both lines below are verbatim from the live PVE
+// test node - so the backup path resolved to autofs, parseFilesystemType said
+// Unknown, the network write-probe never ran (Unknown is not a network FS) and
+// SetPermissions silently skipped chown/chmod 0600 on the stored backups. The
+// kernel appends mounts in order (verified live with stacked mounts), so the
+// LAST matching entry is the filesystem a path actually resolves to.
+func TestLastMountEntryWinsOverAutofsPlaceholder(t *testing.T) {
+	lines := []string{
+		"systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=37,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=12636 0 0",
+		"binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc rw,nosuid,nodev,noexec,relatime 0 0",
+	}
+	fsTypeStr, device, ok := lastMountEntryFor(lines, "/proc/sys/fs/binfmt_misc")
+	if !ok || fsTypeStr != "binfmt_misc" || device != "binfmt_misc" {
+		t.Fatalf("want the real filesystem behind the autofs placeholder, got type=%q device=%q ok=%v", fsTypeStr, device, ok)
+	}
+
+	nas := []string{
+		"systemd-1 /mnt/nas autofs rw,relatime,fd=41,pgrp=1,timeout=120,minproto=5,maxproto=5,direct 0 0",
+		"nas:/export /mnt/nas nfs4 rw,relatime,vers=4.2 0 0",
+	}
+	fsTypeStr, device, ok = lastMountEntryFor(nas, "/mnt/nas")
+	if !ok || fsTypeStr != "nfs4" || device != "nas:/export" {
+		t.Fatalf("the triggered nfs4 mount must win over its autofs trigger, got type=%q device=%q ok=%v", fsTypeStr, device, ok)
+	}
+
+	if _, _, ok := lastMountEntryFor(nas, "/mnt/other"); ok {
+		t.Fatal("an absent mount point must not match")
+	}
+}

--- a/internal/whatsnew/registry.go
+++ b/internal/whatsnew/registry.go
@@ -98,12 +98,12 @@ var notes = []Note{
 		Lines: []string{
 			"Run your own scripts around each backup: PERSONAL_SCRIPT_PRE_RUN and PERSONAL_SCRIPT_POST_RUN in backup.env",
 			"The notification issue list names the failed operation (upload, retention, listing), one entry per fault",
-			"Secondary storage reports unreadable archives and a location that stopped answering instead of skipping them silently",
-			"A backup that hits those secondary faults ends with exit 1 instead of reporting success",
+			"Secondary storage reports unreadable archives and a stopped location, and those faults end the run with exit 1",
 			"Log messages no longer repeat the level word the level column already prints",
 			"A cloud delete killed mid-transfer reports the kill, not rclone's last progress line",
 			"Personal scripts must live on a root-owned, non-writable path chain; unsafe paths are refused at daemon start",
 			"A daemon shutdown no longer waits for a running personal script; the script keeps its own 10-minute budget",
+			"Staged PVE restore really applies datacenter.cfg, vzdump.cron, storage definitions and guest configs",
 		},
 		Actions: []string{
 			"If runs start ending with exit 1 naming unreadable secondary archives, repair or remove those files",

--- a/internal/whatsnew/registry.go
+++ b/internal/whatsnew/registry.go
@@ -114,12 +114,18 @@ var notes = []Note{
 	{
 		Version: "0.34.0",
 		Lines: []string{
-			"Staged PVE restore really applies datacenter.cfg, vzdump.cron and existing storage definitions",
-			"Guest configs survive restore on modern PVE: rejected keys are stripped and the conf file is the fallback",
-			"A guest missing from the node is registered by restoring its config file (disks are not part of it)",
+			"Staged PVE restore really applies datacenter.cfg, vzdump.cron, storage definitions and guest configs",
+			"A guest missing from the node is registered from its restored config file; rejected keys no longer fail it",
+			"Copy failures of critical files and interrupted collections now warn in the log instead of hiding at debug",
+			"Text cleanup in backups only touches CRLF line endings in plain text; UTF-16 and binary files stay untouched",
+			"The PVE cluster database is captured as a consistent snapshot, including changes not yet checkpointed",
+			"Cloud retention no longer stalls the run when rclone hangs; a missing cloud log no longer skips log cleanup",
+			"A failed notification now always exits 1, and --log-level only quiets the console, never the exit code",
+			"Starting --daemon twice is refused, so the running daemon stays discoverable by backup handoffs",
 		},
 		Actions: []string{
 			"After a staged PVE restore, check the restore log: applied items say pmxcfs or pvesh, failures stay warnings",
+			"If a monitoring script gates on the exit code, note a failed notification now exits 1 on every install",
 		},
 	},
 }

--- a/internal/whatsnew/registry.go
+++ b/internal/whatsnew/registry.go
@@ -120,12 +120,12 @@ var notes = []Note{
 			"Text cleanup in backups only touches CRLF line endings in plain text; UTF-16 and binary files stay untouched",
 			"The PVE cluster database is captured as a consistent snapshot, including changes not yet checkpointed",
 			"Cloud retention no longer stalls the run when rclone hangs; a missing cloud log no longer skips log cleanup",
-			"A failed notification now always exits 1, and --log-level only quiets the console, never the exit code",
+			"A failed notification promotes an otherwise clean non-dry-run run to exit 1; --log-level only quiets the console",
 			"Starting --daemon twice is refused, so the running daemon stays discoverable by backup handoffs",
 		},
 		Actions: []string{
 			"After a staged PVE restore, check the restore log: applied items say pmxcfs or pvesh, failures stay warnings",
-			"If a monitoring script gates on the exit code, note a failed notification now exits 1 on every install",
+			"If a monitoring script gates on exit codes, account for failed notifications promoting clean non-dry runs to exit 1",
 		},
 	},
 }

--- a/internal/whatsnew/registry.go
+++ b/internal/whatsnew/registry.go
@@ -98,17 +98,28 @@ var notes = []Note{
 		Lines: []string{
 			"Run your own scripts around each backup: PERSONAL_SCRIPT_PRE_RUN and PERSONAL_SCRIPT_POST_RUN in backup.env",
 			"The notification issue list names the failed operation (upload, retention, listing), one entry per fault",
-			"Secondary storage reports unreadable archives and a stopped location, and those faults end the run with exit 1",
+			"Secondary storage reports unreadable archives and a location that stopped answering instead of skipping them silently",
+			"A backup that hits those secondary faults ends with exit 1 instead of reporting success",
 			"Log messages no longer repeat the level word the level column already prints",
 			"A cloud delete killed mid-transfer reports the kill, not rclone's last progress line",
 			"Personal scripts must live on a root-owned, non-writable path chain; unsafe paths are refused at daemon start",
 			"A daemon shutdown no longer waits for a running personal script; the script keeps its own 10-minute budget",
-			"Staged PVE restore really applies datacenter.cfg, vzdump.cron, storage definitions and guest configs",
 		},
 		Actions: []string{
 			"If runs start ending with exit 1 naming unreadable secondary archives, repair or remove those files",
 			"Update any log-parsing script of yours that matches WARNING: or ERROR: inside the message text",
 			"If the daemon warns a personal script was disabled, move it to a root-owned directory and chmod it 0755 or stricter",
+		},
+	},
+	{
+		Version: "0.34.0",
+		Lines: []string{
+			"Staged PVE restore really applies datacenter.cfg, vzdump.cron and existing storage definitions",
+			"Guest configs survive restore on modern PVE: rejected keys are stripped and the conf file is the fallback",
+			"A guest missing from the node is registered by restoring its config file (disks are not part of it)",
+		},
+		Actions: []string{
+			"After a staged PVE restore, check the restore log: applied items say pmxcfs or pvesh, failures stay warnings",
 		},
 	},
 }


### PR DESCRIPTION
Automated release PR for `v0.34.0`.

<!-- release-tag: v0.34.0 -->

## Summary by Sourcery

Harden daemon operation, backup collection, logging, cloud retention, and staged Proxmox restores for the v0.34.0 release.

New Features:
- Improve staged Proxmox restore coverage for datacenter settings, backup jobs, storage definitions, and VM/CT configurations.
- Capture live PVE cluster databases through consistent SQLite snapshots and add safer backup text normalization.
- Add daemon single-instance protection and improve cloud retention and log cleanup behavior.

Bug Fixes:
- Prevent duplicate daemons from overwriting the incumbent's discovery files and double-scheduling backups.
- Ensure restore operations handle existing and missing guests, create-only configuration keys, existing storage definitions, and pmxcfs mount safety correctly.
- Make real collection failures, skipped collection work, notification failures, and storage errors visible through warnings and accurate exit statuses.
- Prevent stale or mid-name temporary backup artifacts from being counted as completed backups.
- Avoid false cloud log-path failures and bound retention ownership resolution when remote commands hang.
- Correct filesystem mount detection for path boundaries and stacked automount entries.

Enhancements:
- Restrict text normalization to CRLF sequences in plain single-byte text while preserving UTF-16, binary, and lone-carriage-return files.
- Treat warning and error thresholds as console-only filters while retaining issue counts and file-log evidence.
- Reduce duplicate lock-in-progress error logging and align restore messaging with pmxcfs-based operations.

Documentation:
- Update CLI, notification, cluster recovery, and restore documentation to describe the revised logging, restore, and exit-code behavior.

Tests:
- Add coverage for daemon instance protection, collection failure visibility, SQLite snapshots, text safety, logging semantics, pmxcfs restore paths, Proxmox staged-apply behavior, cloud cleanup, retention timeouts, and filesystem detection.

Chores:
- Add v0.34.0 release notes and operator actions to the What's New registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevented multiple backup daemon instances from running simultaneously.
  * Improved Proxmox VE cluster restore handling for guests, storage, datacenter settings, and scheduled jobs.
  * Added more reliable Proxmox configuration database snapshots.
  * Dashboard upgrades now relaunch the updated application automatically.
  * Daemon status now reports personal script readiness and diagnostic details without executing scripts.
  * Notification failures now produce a warning exit status for monitoring.
* **Bug Fixes**
  * Corrected temporary-file detection, cloud log deletion, mount resolution, and storage completion reporting.
  * Protected binary and non-plain-text files during text cleanup.
  * Improved backup failure and skipped-operation logging.
  * Added safer validation for cluster restore writes.
  * Console log-level filtering now preserves warnings and errors in logs and counters.
* **Documentation**
  * Updated CLI logging, notification, restore, daemon, and troubleshooting documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The release hardens daemon ownership, backup and storage handling, diagnostics, and staged Proxmox restore behavior. The current guest-restore implementation addresses the previously reported overwrite races by repeating existence and runtime-state checks within PVE’s native locking and registration paths.

- Adds single-instance daemon ownership and expanded daemon/script diagnostics.
- Improves collection, archive normalization, retention, logging, and storage error handling.
- Extends staged Proxmox recovery for guest, storage, datacenter, and backup-job configuration.
- Serializes guest configuration application and revalidates safety preconditions immediately before mutation.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/restore_cluster_apply.go | Existing and absent guest paths now fail closed on uncertain state and delegate final pmxcfs writes to a locked, precondition-aware helper. |
| internal/orchestrator/pve_guest_locked_apply.go | Adds native PVE guest locking, refreshed cluster-state validation, stopped-state checks, and atomic placeholder registration before staged configuration writes. |
| internal/orchestrator/pve_guest_apply_race_test.go | Covers concurrent guest creation after inventory and guest startup after the preliminary status probe. |
| cmd/proxsave/daemon.go | Acquires authoritative per-base-directory ownership before publishing daemon identity or starting scheduled work. |
| internal/storage/cloud_retention_owner.go | Bounds remote ownership resolution used during cloud retention cleanup. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Load cluster guest inventory] --> B{Guest exists?}
    B -->|No| C[Acquire native QEMU and LXC locks]
    C --> D[Refresh cluster state and require VMID absent]
    D --> E[Atomically register create-locked placeholder]
    E --> F[Install staged configuration]
    B -->|Yes, local and same kind| G[Attempt API configuration update]
    G -->|Success| H[Complete]
    G -->|Failure| I[Require status/current = stopped]
    I --> J[Acquire native QEMU and LXC locks]
    J --> K[Reload config and require guest still stopped]
    K --> F
    B -->|Remote or type mismatch| L[Refuse apply]
    D -->|Precondition failed| L
    I -->|Unknown or running| L
    K -->|Precondition failed| L
```
</details>

<sub>Reviews (10): Last reviewed commit: ["fix: execute inspected personal script p..."](https://github.com/tis24dev/proxsave/commit/647d33914bb142e1db5cad1e3c6a4ce7bf9f9571) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59612624)</sub>

**Context used:**

- Knowledge Base — [Restore and recovery](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/proxsave/-/docs/restore-and-recovery.md)

<!-- /greptile_comment -->